### PR TITLE
Fix #7: performance audit — all 23 findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /certs
 /data
 /bench-data
+compose-syslog-input.yml

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -74,7 +74,7 @@ impl SplitBuilder {
     /// Convert and buffer one document (serializes `_source` from `doc`).
     pub fn add_json(
         &mut self,
-        doc: &serde_json::Value,
+        doc: serde_json::Value,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<()> {
         self.add_json_with_source(doc, None, fallback_timestamp)
@@ -82,9 +82,11 @@ impl SplitBuilder {
 
     /// Convert and buffer one document, storing `source` verbatim as
     /// `_source` (the client's original line) instead of re-serializing.
+    /// The document is consumed — its unmapped fields move into `_dynamic`
+    /// without a deep clone.
     pub fn add_json_with_source(
         &mut self,
-        doc: &serde_json::Value,
+        doc: serde_json::Value,
         source: Option<&str>,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<()> {
@@ -177,7 +179,7 @@ mod tests {
         for i in 0..100 {
             builder
                 .add_json(
-                    &serde_json::json!({
+                    serde_json::json!({
                         "@timestamp": 1_753_300_000_000_i64 + i,
                         "service": "api",
                         "message": format!("request {i} handled"),
@@ -237,7 +239,7 @@ mod timestamp_units {
         ] {
             builder
                 .add_json(
-                    &serde_json::json!({"@timestamp": ts, "message": "x"}),
+                    serde_json::json!({"@timestamp": ts, "message": "x"}),
                     tantivy::DateTime::from_timestamp_millis(1_784_871_020_163),
                 )
                 .unwrap();

--- a/crates/rsearch-index/src/cache.rs
+++ b/crates/rsearch-index/src/cache.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -12,10 +12,16 @@ pub struct SplitCache {
     tmp_counter: std::sync::atomic::AtomicU64,
 }
 
+/// Recency is a tick-keyed BTreeMap mirror of `entries` so the eviction
+/// victim is the first key — O(log n) per eviction instead of a full-map
+/// scan under the lock the search path fetches through. Ticks are unique
+/// (bumped on every touch), so the map never collides.
 #[derive(Default)]
 struct CacheState {
     /// key -> (size, last access tick)
     entries: HashMap<String, (u64, u64)>,
+    /// last access tick -> key (mirror of `entries`).
+    by_tick: BTreeMap<u64, String>,
     total_bytes: u64,
     tick: u64,
 }
@@ -55,7 +61,10 @@ impl SplitCache {
                 if entry.file_type()?.is_file() {
                     let size = entry.metadata()?.len();
                     let key = format!("{split_id}/{name}");
-                    state.entries.insert(key, (size, 0));
+                    state.tick += 1;
+                    let tick = state.tick;
+                    state.entries.insert(key.clone(), (size, tick));
+                    state.by_tick.insert(tick, key);
                     state.total_bytes += size;
                 }
             }
@@ -67,21 +76,31 @@ impl SplitCache {
         self.root.join(split_id).join(file_name)
     }
 
-    /// Return the cached path if present, bumping its recency.
+    /// Return the cached path if present, bumping its recency. The
+    /// existence stat runs outside the lock so the shared state is never
+    /// held across a syscall.
     pub fn get(&self, split_id: &str, file_name: &str) -> Option<PathBuf> {
         let key = format!("{split_id}/{file_name}");
-        let mut state = self.state.lock().unwrap();
-        state.tick += 1;
-        let tick = state.tick;
-        if let Some(entry) = state.entries.get_mut(&key) {
+        let path = self.path_for(split_id, file_name);
+        {
+            let mut guard = self.state.lock().unwrap();
+            let state = &mut *guard;
+            state.tick += 1;
+            let tick = state.tick;
+            let entry = state.entries.get_mut(&key)?;
+            state.by_tick.remove(&entry.1);
             entry.1 = tick;
-            let path = self.path_for(split_id, file_name);
-            if path.exists() {
-                return Some(path);
-            }
-            // Disk and index disagree (external cleanup); drop the entry.
-            let (size, _) = state.entries.remove(&key).unwrap();
+            state.by_tick.insert(tick, key.clone());
+        }
+        if path.exists() {
+            return Some(path);
+        }
+        // Disk and index disagree (external cleanup); drop the entry.
+        let mut guard = self.state.lock().unwrap();
+        let state = &mut *guard;
+        if let Some((size, tick)) = state.entries.remove(&key) {
             state.total_bytes -= size;
+            state.by_tick.remove(&tick);
         }
         None
     }
@@ -92,6 +111,20 @@ impl SplitCache {
         split_id: &str,
         file_name: &str,
         data: &[u8],
+    ) -> std::io::Result<PathBuf> {
+        use std::io::Write;
+        self.insert_via(split_id, file_name, |file| file.write_all(data))
+    }
+
+    /// Insert an entry by streaming its contents into the cache file via
+    /// `write` — used by chunked storage fetches so a large fragment never
+    /// has to be materialized in memory. The temp file is removed if
+    /// `write` fails.
+    pub fn insert_via(
+        &self,
+        split_id: &str,
+        file_name: &str,
+        write: impl FnOnce(&mut std::fs::File) -> std::io::Result<()>,
     ) -> std::io::Result<PathBuf> {
         let path = self.path_for(split_id, file_name);
         if let Some(parent) = path.parent() {
@@ -107,33 +140,55 @@ impl SplitCache {
             "{file_name}.tmp-cache-{}-{uniq}",
             std::process::id()
         ));
-        std::fs::write(&tmp, data)?;
+        let mut file = std::fs::File::create(&tmp)?;
+        if let Err(e) = write(&mut file) {
+            drop(file);
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
+        let size = file.metadata()?.len();
+        drop(file);
         std::fs::rename(&tmp, &path)?;
 
         let key = format!("{split_id}/{file_name}");
-        let mut state = self.state.lock().unwrap();
-        state.tick += 1;
-        let tick = state.tick;
-        if let Some((old_size, _)) = state.entries.insert(key.clone(), (data.len() as u64, tick)) {
-            state.total_bytes -= old_size;
-        }
-        state.total_bytes += data.len() as u64;
+        // All disk ops (evicted-file unlinks) run after the lock is
+        // released; victims are already unlinked from the maps here, so
+        // racing inserts never double-delete.
+        let victims: Vec<String> = {
+            let mut guard = self.state.lock().unwrap();
+            let state = &mut *guard;
+            state.tick += 1;
+            let tick = state.tick;
+            if let Some((old_size, old_tick)) =
+                state.entries.insert(key.clone(), (size, tick))
+            {
+                state.total_bytes -= old_size;
+                state.by_tick.remove(&old_tick);
+            }
+            state.by_tick.insert(tick, key.clone());
+            state.total_bytes += size;
 
-        while state.total_bytes > self.max_bytes {
-            let Some((victim, size)) = state
-                .entries
-                .iter()
+            let mut victims = Vec::new();
+            while state.total_bytes > self.max_bytes {
+                let Some((&victim_tick, _)) = state.by_tick.iter().next() else {
+                    break;
+                };
+                let victim_key = state.by_tick.remove(&victim_tick).unwrap();
                 // Never evict the entry we just inserted, even if it alone
                 // exceeds the budget — returning a path to a deleted file
-                // would make the split unsearchable (M4).
-                .filter(|(k, _)| *k != &key)
-                .min_by_key(|(_, v)| v.1)
-                .map(|(k, v)| (k.clone(), v.0))
-            else {
-                break;
-            };
-            state.entries.remove(&victim);
-            state.total_bytes -= size;
+                // would make the split unsearchable (M4). It has the newest
+                // tick, so reaching it means nothing else is left.
+                if victim_key == key {
+                    state.by_tick.insert(victim_tick, victim_key);
+                    break;
+                }
+                let (victim_size, _) = state.entries.remove(&victim_key).unwrap();
+                state.total_bytes -= victim_size;
+                victims.push(victim_key);
+            }
+            victims
+        };
+        for victim in victims {
             let _ = std::fs::remove_file(self.root.join(&victim));
         }
         Ok(path)

--- a/crates/rsearch-index/src/document.rs
+++ b/crates/rsearch-index/src/document.rs
@@ -78,7 +78,7 @@ impl DocumentConverter {
     /// Convert one document, deriving the stored `_source` from the doc.
     pub fn convert(
         &self,
-        doc: &serde_json::Value,
+        doc: serde_json::Value,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<(TantivyDocument, tantivy::DateTime)> {
         self.convert_with_source(doc, None, fallback_timestamp)
@@ -90,34 +90,44 @@ impl DocumentConverter {
     /// ingest hot path. `fallback_timestamp` is used when the document
     /// carries no parseable `@timestamp`/`timestamp`. Returns the
     /// converted document and its effective timestamp.
+    ///
+    /// Takes the document by value: unmapped fields (most of a typical log
+    /// line) are moved into `_dynamic` rather than deep-cloned.
     pub fn convert_with_source(
         &self,
-        doc: &serde_json::Value,
+        doc: serde_json::Value,
         source: Option<&str>,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<(TantivyDocument, tantivy::DateTime)> {
-        let obj = doc
-            .as_object()
-            .ok_or_else(|| IndexError::InvalidDocument("document must be an object".into()))?;
+        let timestamp = extract_timestamp(&doc).unwrap_or(fallback_timestamp);
+        // `_source` must be serialized before the fields are moved out.
+        let serialized = match source {
+            Some(_) => None,
+            None => Some(doc.to_string()),
+        };
+        let obj = match doc {
+            serde_json::Value::Object(obj) => obj,
+            _ => return Err(IndexError::InvalidDocument("document must be an object".into())),
+        };
 
-        let timestamp = extract_timestamp(doc).unwrap_or(fallback_timestamp);
         let mut out = TantivyDocument::new();
         out.add_date(self.schema.timestamp, timestamp);
-        match source {
-            Some(source) => out.add_text(self.schema.source, source),
-            None => out.add_text(self.schema.source, doc.to_string()),
+        match (source, serialized) {
+            (Some(source), _) => out.add_text(self.schema.source, source),
+            (None, Some(serialized)) => out.add_text(self.schema.source, serialized),
+            (None, None) => unreachable!("serialized computed for source: None"),
         }
 
         let mut dynamic = serde_json::Map::new();
         for (key, value) in obj {
-            match self.schema.fields.get(key) {
+            match self.schema.fields.get(&key) {
                 Some((field, ty)) => {
-                    for item in flatten(value) {
+                    for item in flatten(&value) {
                         add_typed(&mut out, *field, *ty, item);
                     }
                 }
                 None => {
-                    dynamic.insert(key.clone(), value.clone());
+                    dynamic.insert(key, value);
                 }
             }
         }
@@ -231,7 +241,7 @@ mod tests {
         let c = converter();
         let (doc, ts) = c
             .convert(
-                &serde_json::json!({
+                serde_json::json!({
                     "@timestamp": "2026-07-24T01:02:03Z",
                     "service": "api",
                     "message": "user login ok",
@@ -251,7 +261,7 @@ mod tests {
     fn uses_fallback_when_timestamp_missing() {
         let c = converter();
         let (_, ts) = c
-            .convert(&serde_json::json!({"message": "no ts"}), fallback())
+            .convert(serde_json::json!({"message": "no ts"}), fallback())
             .unwrap();
         assert_eq!(ts, fallback());
     }
@@ -267,7 +277,7 @@ mod tests {
     #[test]
     fn rejects_non_object_documents() {
         let c = converter();
-        assert!(c.convert(&serde_json::json!([1, 2]), fallback()).is_err());
+        assert!(c.convert(serde_json::json!([1, 2]), fallback()).is_err());
     }
 
     #[test]
@@ -275,7 +285,7 @@ mod tests {
         let c = converter();
         let (doc, _) = c
             .convert(
-                &serde_json::json!({"service": ["a", "b"], "status": [1, 2, 3]}),
+                serde_json::json!({"service": ["a", "b"], "status": [1, 2, 3]}),
                 fallback(),
             )
             .unwrap();

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -102,16 +102,20 @@ impl SplitReader {
         Ok(self.reader.searcher())
     }
 
-    /// Export every document as (source JSON, timestamp millis) — used by
-    /// the merge job to re-index small splits. Call from a blocking
-    /// context; streams the doc store rather than materializing segments.
-    pub fn export_docs(&self) -> IndexResult<Vec<(serde_json::Value, i64)>> {
+    /// Visit every document as (parsed source JSON, timestamp millis) —
+    /// used by the merge job to re-index small splits. Call from a
+    /// blocking context. Streams the doc store one document at a time so
+    /// re-indexing a whole merge group holds O(one doc) in memory, not the
+    /// entire group's parsed corpus.
+    pub fn for_each_doc(
+        &self,
+        mut visit: impl FnMut(serde_json::Value, i64) -> IndexResult<()>,
+    ) -> IndexResult<()> {
         let searcher = self.searcher()?;
         let schema = self.index.schema();
         let source_field = schema
             .get_field(crate::mapping::SOURCE_FIELD)
             .map_err(|_| IndexError::InvalidDocument("split lacks _source".into()))?;
-        let mut docs = Vec::with_capacity(self.meta.split.doc_count as usize);
         for segment_reader in searcher.segment_readers() {
             let store = segment_reader.get_store_reader(10)?;
             let ts_column = segment_reader
@@ -132,10 +136,10 @@ impl SplitReader {
                     .first(doc_id)
                     .map(|dt| dt.into_timestamp_millis())
                     .unwrap_or_default();
-                docs.push((json, ts));
+                visit(json, ts)?;
             }
         }
-        Ok(docs)
+        Ok(())
     }
 }
 
@@ -146,6 +150,12 @@ struct DirectoryInner {
     cache: Arc<SplitCache>,
     runtime: Handle,
 }
+
+/// Ranged-read chunk size for cold split fetches. Large bundled files
+/// (a merged split's doc store can be 100MB+) stream into the cache file
+/// chunk by chunk, so transient memory stays O(chunk) per concurrent
+/// fetch instead of O(file).
+const FETCH_CHUNK_BYTES: u64 = 8 << 20;
 
 impl DirectoryInner {
     /// Fetch an internal file (whole-file granularity) through the cache.
@@ -160,15 +170,22 @@ impl DirectoryInner {
                 format!("{file_name} not in split bundle"),
             )
         })?;
-        let data = self
-            .runtime
-            .block_on(
-                self.storage
-                    .get_range(&self.key, span.offset..span.offset + span.len),
-            )
-            .map_err(std::io::Error::other)?;
         self.cache
-            .insert(&self.meta.split.split_id, file_name, &data)
+            .insert_via(&self.meta.split.split_id, file_name, |file| {
+                use std::io::Write;
+                let mut offset = span.offset;
+                let end = span.offset + span.len;
+                while offset < end {
+                    let chunk_end = (offset + FETCH_CHUNK_BYTES).min(end);
+                    let data = self
+                        .runtime
+                        .block_on(self.storage.get_range(&self.key, offset..chunk_end))
+                        .map_err(std::io::Error::other)?;
+                    file.write_all(&data)?;
+                    offset = chunk_end;
+                }
+                Ok(())
+            })
     }
 }
 
@@ -319,7 +336,7 @@ mod tests {
         for i in 0..500 {
             builder
                 .add_json(
-                    &serde_json::json!({
+                    serde_json::json!({
                         "@timestamp": 1_753_300_000_000_i64 + i,
                         "service": if i % 2 == 0 { "api" } else { "worker" },
                         "message": format!("event number {i}"),

--- a/crates/rsearch-ingest/src/inputs.rs
+++ b/crates/rsearch-ingest/src/inputs.rs
@@ -169,12 +169,20 @@ async fn read_lines(
             return Ok(());
         }
         pending.extend_from_slice(&chunk[..n]);
-        while let Some(pos) = pending.iter().position(|&b| b == b'\n') {
-            let line: Vec<u8> = pending.drain(..=pos).collect();
-            let line = String::from_utf8_lossy(&line[..line.len() - 1]);
+        // Frame via a cursor and compact once per chunk — a per-message
+        // drain() shifts the whole remaining buffer every message, which
+        // goes quadratic on floods of small messages.
+        let mut start = 0;
+        while let Some(rel) = pending[start..].iter().position(|&b| b == b'\n') {
+            let end = start + rel;
+            let line = String::from_utf8_lossy(&pending[start..end]);
             if !line.trim().is_empty() {
                 let _ = tx.send(parse_syslog(&line)).await;
             }
+            start = end + 1;
+        }
+        if start > 0 {
+            pending.drain(..start);
         }
         // Guard against unframed floods.
         if pending.len() > 1 << 20 {
@@ -235,14 +243,20 @@ async fn read_gelf(
             return Ok(());
         }
         pending.extend_from_slice(&chunk[..n]);
-        while let Some(pos) = pending.iter().position(|&b| b == 0) {
-            let frame: Vec<u8> = pending.drain(..=pos).collect();
-            match parse_gelf(&frame[..frame.len() - 1]) {
+        // Cursor + single compaction per chunk (see read_lines).
+        let mut start = 0;
+        while let Some(rel) = pending[start..].iter().position(|&b| b == 0) {
+            let end = start + rel;
+            match parse_gelf(&pending[start..end]) {
                 Some(doc) => {
                     let _ = tx.send(doc).await;
                 }
                 None => warn!("dropping invalid GELF frame"),
             }
+            start = end + 1;
+        }
+        if start > 0 {
+            pending.drain(..start);
         }
         if pending.len() > 1 << 20 {
             pending.clear();

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -54,7 +54,14 @@ struct PipelineInner {
     storage: Arc<dyn Storage>,
     metastore: Metastore,
     wal: Arc<Wal>,
-    workers: tokio::sync::Mutex<HashMap<String, mpsc::Sender<WorkItem>>>,
+    /// Stream → worker sender. Read-locked (sync, never across an await)
+    /// on the per-document hot path; the write lock is only ever taken to
+    /// insert a newly created worker.
+    workers: std::sync::RwLock<HashMap<String, mpsc::Sender<WorkItem>>>,
+    /// Single-flights first-time worker creation so the metastore resolve
+    /// never runs under `workers` — enqueues to existing streams are not
+    /// blocked while a new stream's row is being created.
+    worker_create: tokio::sync::Mutex<()>,
     metrics: IngestMetrics,
     /// Routing rules, refreshed periodically from the metastore.
     rules: std::sync::RwLock<Arc<Vec<rsearch_metastore::RoutingRuleRecord>>>,
@@ -86,7 +93,8 @@ impl IngestPipeline {
                 storage,
                 metastore,
                 wal,
-                workers: tokio::sync::Mutex::new(HashMap::new()),
+                workers: std::sync::RwLock::new(HashMap::new()),
+                worker_create: tokio::sync::Mutex::new(()),
                 metrics: IngestMetrics::default(),
                 rules: std::sync::RwLock::new(Arc::new(Vec::new())),
             }),
@@ -163,28 +171,30 @@ impl IngestPipeline {
     ) -> IngestResult<(usize, usize)> {
         // Programmatic inputs have no original line, so serialize once and
         // share the Arc across every route.
-        let mut pairs: Vec<(String, Value, Arc<str>)> = Vec::new();
+        let mut pairs: Vec<(String, Arc<str>)> = Vec::new();
         for doc in docs {
             let source: Arc<str> = Arc::from(doc.to_string());
             for stream in self.expand_routes(default_stream, &doc) {
-                pairs.push((stream, doc.clone(), source.clone()));
+                pairs.push((stream, source.clone()));
             }
         }
         if pairs.is_empty() {
             return Ok((0, 0));
         }
+        // The pairs move into the blocking task and back so the WAL append
+        // works on the existing strings — no per-document byte copies.
         let wal = self.inner.wal.clone();
-        let wal_items: Vec<(String, Vec<u8>)> = pairs
-            .iter()
-            .map(|(stream, _, source)| (stream.clone(), source.as_bytes().to_vec()))
-            .collect();
-        let positions = tokio::task::spawn_blocking(move || wal.append_batch(&wal_items))
-            .await
-            .map_err(|e| IngestError::Wal(std::io::Error::other(e.to_string())))??;
+        let (pairs, positions) = tokio::task::spawn_blocking(move || {
+            let positions = wal.append_batch(&pairs);
+            (pairs, positions)
+        })
+        .await
+        .map_err(|e| IngestError::Wal(std::io::Error::other(e.to_string())))?;
+        let positions = positions?;
 
         let mut accepted = 0;
         let mut dropped = 0;
-        for ((stream, _doc, source), pos) in pairs.into_iter().zip(positions) {
+        for ((stream, source), pos) in pairs.into_iter().zip(positions) {
             match self.enqueue(&stream, source, pos).await {
                 Ok(()) => accepted += 1,
                 Err(_) => {
@@ -247,7 +257,12 @@ impl IngestPipeline {
                 self.inner.wal.confirm(&[record.pos]);
                 continue;
             }
-            let source: Arc<str> = Arc::from(String::from_utf8_lossy(&record.doc).into_owned());
+            // Valid JSON is valid UTF-8, so the common path builds the Arc
+            // straight from the record bytes (one copy, no String detour).
+            let source: Arc<str> = match std::str::from_utf8(&record.doc) {
+                Ok(text) => Arc::from(text),
+                Err(_) => Arc::from(String::from_utf8_lossy(&record.doc).into_owned()),
+            };
             let tx = self.worker_for(&record.stream).await?;
             self.inner.metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
             if tx
@@ -268,12 +283,16 @@ impl IngestPipeline {
     }
 
     async fn worker_for(&self, stream: &str) -> IngestResult<mpsc::Sender<WorkItem>> {
-        let mut workers = self.inner.workers.lock().await;
-        if let Some(tx) = workers.get(stream) {
+        if let Some(tx) = self.inner.workers.read().unwrap().get(stream) {
             return Ok(tx.clone());
         }
         // First document for this stream: resolve it in the metastore and
-        // spin up its worker.
+        // spin up its worker. Serialized behind `worker_create` (re-checking
+        // after acquiring it) so concurrent first-docs create one worker.
+        let _create = self.inner.worker_create.lock().await;
+        if let Some(tx) = self.inner.workers.read().unwrap().get(stream) {
+            return Ok(tx.clone());
+        }
         let record = self.inner.metastore.ensure_stream(stream).await?;
         let mapping = IndexMapping::from_json(&record.mapping).unwrap_or_default();
         let schema = MappedSchema::build(mapping);
@@ -285,7 +304,11 @@ impl IngestPipeline {
             schema,
             rx,
         ));
-        workers.insert(stream.to_string(), tx.clone());
+        self.inner
+            .workers
+            .write()
+            .unwrap()
+            .insert(stream.to_string(), tx.clone());
         Ok(tx)
     }
 }
@@ -412,7 +435,7 @@ async fn flush_inner(
                 // only ever held the raw bytes.
                 match serde_json::from_str::<Value>(&item.source) {
                     Ok(doc) => {
-                        builder.add_json_with_source(&doc, Some(&item.source), fallback)?;
+                        builder.add_json_with_source(doc, Some(&item.source), fallback)?;
                     }
                     Err(e) => {
                         // Enqueued docs were validated, so this is unexpected;

--- a/crates/rsearch-ingest/src/wal.rs
+++ b/crates/rsearch-ingest/src/wal.rs
@@ -147,16 +147,28 @@ impl Wal {
     /// buffer), then the fsync runs under a separate gate so concurrent
     /// appends coalesce into one fsync (group commit) instead of each
     /// paying its own.
-    pub fn append_batch(&self, items: &[(String, Vec<u8>)]) -> std::io::Result<Vec<WalPos>> {
+    pub fn append_batch<S, D>(&self, items: &[(S, D)]) -> std::io::Result<Vec<WalPos>>
+    where
+        S: AsRef<str>,
+        D: AsRef<str>,
+    {
         use std::sync::atomic::Ordering;
         let mut positions = Vec::with_capacity(items.len());
+        // Segments sealed by rotation during this batch are fsynced below,
+        // outside the writer lock; fully-confirmed segments GC found are
+        // unlinked outside it too — neither disk op stalls other appenders.
+        let mut sealed: Vec<std::fs::File> = Vec::new();
+        let mut victims: Vec<PathBuf> = Vec::new();
         let (fd, my_gen) = {
             let mut inner = self.inner.lock().unwrap();
             for (stream, doc) in items {
+                let doc = doc.as_ref().as_bytes();
                 if inner.current_len >= self.max_segment_bytes {
-                    self.rotate(&mut inner)?;
+                    let (old_file, mut gc) = self.rotate(&mut inner)?;
+                    sealed.push(old_file);
+                    victims.append(&mut gc);
                 }
-                let stream_bytes = stream.as_bytes();
+                let stream_bytes = stream.as_ref().as_bytes();
                 let payload_len = 2 + stream_bytes.len() + doc.len();
                 let len_field = stream_bytes.len() as u16;
                 // Stream the CRC over the three payload slices; write them
@@ -189,6 +201,16 @@ impl Wal {
             (fd, inner.written)
         };
 
+        // Rotated-out segments may hold records from this batch, so they
+        // must be durable before the positions are acked. The group-commit
+        // fsync below only covers the current segment's fd.
+        for old in &sealed {
+            old.sync_data()?;
+        }
+        for path in victims {
+            let _ = std::fs::remove_file(path);
+        }
+
         // Group commit: if someone already fsynced past our records, skip;
         // otherwise fsync once (covers everyone flushed so far).
         if self.synced.load(Ordering::Acquire) < my_gen {
@@ -204,9 +226,11 @@ impl Wal {
         Ok(positions)
     }
 
-    fn rotate(&self, inner: &mut WalInner) -> std::io::Result<()> {
+    /// Seal the current segment and open a fresh one. Returns the sealed
+    /// file — the caller fsyncs it outside the writer lock — plus any
+    /// fully-confirmed segments for the caller to unlink, also outside.
+    fn rotate(&self, inner: &mut WalInner) -> std::io::Result<(std::fs::File, Vec<PathBuf>)> {
         inner.writer.flush()?;
-        inner.writer.get_ref().sync_data()?;
         let old_seq = inner.current_seq;
         if let Some(state) = inner.segments.get_mut(&old_seq) {
             state.sealed = true;
@@ -216,7 +240,10 @@ impl Wal {
             .create(true)
             .append(true)
             .open(segment_path(&self.dir, new_seq))?;
-        inner.writer = BufWriter::new(file);
+        let old = std::mem::replace(&mut inner.writer, BufWriter::new(file));
+        let old_file = old
+            .into_inner()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
         inner.current_seq = new_seq;
         inner.current_len = 0;
         inner.segments.insert(
@@ -227,32 +254,43 @@ impl Wal {
             },
         );
         // The old segment may already be fully confirmed.
-        Self::gc_locked(&self.dir, inner);
-        Ok(())
+        let victims = self.collect_confirmed(inner);
+        Ok((old_file, victims))
     }
 
     /// Confirm records as durably published; deletes exhausted segments.
     pub fn confirm(&self, positions: &[WalPos]) {
-        let mut inner = self.inner.lock().unwrap();
-        for pos in positions {
-            if let Some(state) = inner.segments.get_mut(&pos.segment) {
-                state.outstanding = state.outstanding.saturating_sub(1);
+        let victims = {
+            let mut inner = self.inner.lock().unwrap();
+            for pos in positions {
+                if let Some(state) = inner.segments.get_mut(&pos.segment) {
+                    state.outstanding = state.outstanding.saturating_sub(1);
+                }
             }
+            self.collect_confirmed(&mut inner)
+        };
+        for path in victims {
+            let _ = std::fs::remove_file(path);
         }
-        Self::gc_locked(&self.dir, &mut inner);
     }
 
-    fn gc_locked(dir: &Path, inner: &mut WalInner) {
-        let victims: Vec<u64> = inner
+    /// Drop fully-confirmed sealed segments from tracking and return their
+    /// paths. The caller unlinks them after releasing the writer lock so
+    /// the syscall never stalls concurrent appends. Each victim is removed
+    /// from the map here, so racing callers never unlink the same path.
+    fn collect_confirmed(&self, inner: &mut WalInner) -> Vec<PathBuf> {
+        let seqs: Vec<u64> = inner
             .segments
             .iter()
             .filter(|(_, s)| s.sealed && s.outstanding == 0)
             .map(|(&seq, _)| seq)
             .collect();
-        for seq in victims {
-            inner.segments.remove(&seq);
-            let _ = std::fs::remove_file(segment_path(dir, seq));
-        }
+        seqs.into_iter()
+            .map(|seq| {
+                inner.segments.remove(&seq);
+                segment_path(&self.dir, seq)
+            })
+            .collect()
     }
 
     /// Number of live (non-deleted) segments — used by tests and metrics.
@@ -367,14 +405,9 @@ impl Iterator for WalReplay {
 mod tests {
     use super::*;
 
-    fn items(n: usize, stream: &str) -> Vec<(String, Vec<u8>)> {
+    fn items(n: usize, stream: &str) -> Vec<(String, String)> {
         (0..n)
-            .map(|i| {
-                (
-                    stream.to_string(),
-                    format!("{{\"n\":{i}}}").into_bytes(),
-                )
-            })
+            .map(|i| (stream.to_string(), format!("{{\"n\":{i}}}")))
             .collect()
     }
 

--- a/crates/rsearch-metastore/src/control.rs
+++ b/crates/rsearch-metastore/src/control.rs
@@ -101,16 +101,25 @@ impl Metastore {
         .await?)
     }
 
-    /// Published splits past their stream's retention window.
-    pub async fn expired_splits(&self, now_millis: i64) -> MetastoreResult<Vec<String>> {
+    /// Published splits past their stream's retention window. Bounded by
+    /// `limit` so enabling retention on a large old stream marks its
+    /// backlog in batches (the caller loops) instead of loading millions
+    /// of ids in one shot.
+    pub async fn expired_splits(
+        &self,
+        now_millis: i64,
+        limit: i64,
+    ) -> MetastoreResult<Vec<String>> {
         let rows = sqlx::query(
             "SELECT s.split_id FROM splits s
              JOIN streams st ON st.id = s.stream_id
              WHERE s.state = 'published'
                AND st.retention_hours IS NOT NULL
-               AND s.time_end_millis < $1 - (st.retention_hours::bigint * 3600000)",
+               AND s.time_end_millis < $1 - (st.retention_hours::bigint * 3600000)
+             LIMIT $2",
         )
         .bind(now_millis)
+        .bind(limit)
         .fetch_all(self.pool())
         .await?;
         Ok(rows.iter().map(|r| r.get::<String, _>("split_id")).collect())

--- a/crates/rsearch-metastore/src/locations.rs
+++ b/crates/rsearch-metastore/src/locations.rs
@@ -116,6 +116,29 @@ impl Metastore {
         Ok(rows.into_iter().map(|(key,)| key).collect())
     }
 
+    /// Refresh interval for the per-node held-bytes totals used to rank
+    /// replication targets. A few seconds of staleness only skews
+    /// placement slightly; the aggregation it avoids is a full scan of
+    /// object_locations per call.
+    const HELD_BYTES_TTL: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// Total recorded bytes per node, cached for [`Self::HELD_BYTES_TTL`].
+    async fn node_held_bytes(&self) -> MetastoreResult<std::collections::HashMap<String, i64>> {
+        if let Some((map, at)) = self.held_bytes.lock().unwrap().as_ref()
+            && at.elapsed() < Self::HELD_BYTES_TTL
+        {
+            return Ok(map.clone());
+        }
+        let rows: Vec<(String, i64)> = sqlx::query_as(
+            "SELECT node_id, SUM(size_bytes)::bigint FROM object_locations GROUP BY node_id",
+        )
+        .fetch_all(self.pool())
+        .await?;
+        let map: std::collections::HashMap<String, i64> = rows.into_iter().collect();
+        *self.held_bytes.lock().unwrap() = Some((map.clone(), std::time::Instant::now()));
+        Ok(map)
+    }
+
     /// Up to `limit` live nodes to receive new object copies, excluding
     /// `exclude` (typically the writer and existing holders), preferring
     /// nodes holding the fewest total bytes so fresh/empty nodes absorb
@@ -123,6 +146,10 @@ impl Metastore {
     /// too, ranked after non-draining ones — repair's last resort when
     /// nothing else can take a copy (#4); the drain job moves such copies
     /// off again later.
+    ///
+    /// The held-bytes ranking comes from a short-TTL cache rather than an
+    /// O(object_locations) aggregation per call — this runs on every
+    /// replicated write and repair/drain key.
     pub async fn replication_targets(
         &self,
         stale_after_secs: f64,
@@ -130,27 +157,31 @@ impl Metastore {
         limit: i64,
         include_draining: bool,
     ) -> MetastoreResult<Vec<NodeRecord>> {
-        Ok(sqlx::query_as::<_, NodeRecord>(
+        let mut candidates = sqlx::query_as::<_, NodeRecord>(
             "SELECT n.id, n.roles, n.address, n.draining,
                     EXTRACT(EPOCH FROM (now() - n.last_heartbeat))::float8 AS heartbeat_age_secs,
                     EXTRACT(EPOCH FROM (now() - n.draining_since))::float8 AS draining_since_secs
              FROM nodes n
-             LEFT JOIN (
-                 SELECT node_id, SUM(size_bytes)::bigint AS bytes
-                 FROM object_locations GROUP BY node_id
-             ) held ON held.node_id = n.id
              WHERE n.last_heartbeat > now() - make_interval(secs => $1)
                AND n.id <> ALL($2)
-               AND (NOT n.draining OR $4)
-             ORDER BY n.draining ASC, COALESCE(held.bytes, 0) ASC, n.id
-             LIMIT $3",
+               AND (NOT n.draining OR $3)",
         )
         .bind(stale_after_secs)
         .bind(exclude)
-        .bind(limit)
         .bind(include_draining)
         .fetch_all(self.pool())
-        .await?)
+        .await?;
+        let held = self.node_held_bytes().await?;
+        candidates.sort_by(|a, b| {
+            let a_bytes = held.get(&a.id).copied().unwrap_or(0);
+            let b_bytes = held.get(&b.id).copied().unwrap_or(0);
+            a.draining
+                .cmp(&b.draining)
+                .then_with(|| a_bytes.cmp(&b_bytes))
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        candidates.truncate(limit.max(0) as usize);
+        Ok(candidates)
     }
 
     /// Recorded size of an object, if any copy is registered.

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -12,6 +12,13 @@ const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_co
 #[derive(Clone)]
 pub struct Metastore {
     pool: PgPool,
+    /// Per-node held-bytes totals for replication target ranking. The
+    /// backing SUM..GROUP BY over object_locations is O(table), so it is
+    /// refreshed at most once per TTL instead of on every placement call
+    /// (see `replication_targets`). Shared across clones.
+    pub(crate) held_bytes: std::sync::Arc<
+        std::sync::Mutex<Option<(std::collections::HashMap<String, i64>, std::time::Instant)>>,
+    >,
 }
 
 impl Metastore {
@@ -33,7 +40,10 @@ impl Metastore {
             .connect(&url)
             .await?;
         sqlx::migrate!("./migrations").run(&pool).await?;
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            held_bytes: Default::default(),
+        })
     }
 
     pub fn pool(&self) -> &PgPool {

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -5,7 +5,8 @@
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
-use std::time::Instant;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
 use tantivy::aggregation::AggregationLimitsGuard;
@@ -26,10 +27,18 @@ use crate::error::{SearchError, SearchResult};
 use crate::query_dsl::{extract_time_bounds, rewrite_agg_fields, translate_query};
 
 const TIMESTAMP_ALIASES: [&str; 3] = ["@timestamp", "timestamp", "_timestamp"];
-/// Cap on cached open split readers (LRU).
+/// Cap on cached open split readers (LRU), across all shards.
 const READER_CACHE_CAP: usize = 256;
+/// Reader-cache shards: every split touch on every query locks the cache
+/// (LRU `get` mutates), so one global lock serializes the whole search
+/// path. Sharding by split id keeps that contention local.
+const READER_CACHE_SHARDS: usize = 8;
 /// Max concurrent split searches per query.
 const SPLIT_SEARCH_CONCURRENCY: usize = 16;
+/// How long a resolved stream record + built schema may be reused before
+/// re-checking the metastore. Bounds mapping-change staleness the same way
+/// the ingest side's per-flush re-check does.
+const STREAM_CACHE_TTL: Duration = Duration::from_secs(10);
 /// ES-compatible default exact-count ceiling; beyond this the reported
 /// total is a lower bound (`"relation": "gte"`).
 const DEFAULT_TRACK_TOTAL_HITS: usize = 10_000;
@@ -141,16 +150,29 @@ struct SplitOutcome {
     aggs: Option<IntermediateAggregationResults>,
 }
 
+/// A resolved stream: its metastore record plus the schema built from its
+/// mapping, cached for [`STREAM_CACHE_TTL`].
+struct CachedStream {
+    record: rsearch_metastore::StreamRecord,
+    schema: Arc<MappedSchema>,
+}
+
 /// Stateless search service: metastore for pruning, storage for split
-/// bytes, an LRU cache of open readers with single-flight opens.
+/// bytes, a sharded LRU cache of open readers with single-flight opens.
 pub struct SearchService {
     metastore: Metastore,
     storage: Arc<dyn Storage>,
     cache: Arc<SplitCache>,
-    readers: Mutex<lru::LruCache<String, Arc<SplitReader>>>,
+    /// Sharded by split id; each shard is a sync mutex (never held across
+    /// an await) so concurrent split touches don't serialize globally.
+    readers: Vec<std::sync::Mutex<lru::LruCache<String, Arc<SplitReader>>>>,
     /// Per-split open locks so concurrent queries opening the same cold
     /// split don't each pay the open cost.
-    opening: Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    opening: std::sync::Mutex<HashMap<String, Arc<Mutex<()>>>>,
+    /// Stream name → resolved record + built schema. Saves the per-query
+    /// metastore roundtrip and full Tantivy schema rebuild for data that
+    /// only changes on PUT /{index}.
+    streams: std::sync::Mutex<HashMap<String, (Arc<CachedStream>, Instant)>>,
 }
 
 impl SearchService {
@@ -159,40 +181,82 @@ impl SearchService {
             metastore,
             storage,
             cache,
-            readers: Mutex::new(lru::LruCache::new(
-                NonZeroUsize::new(READER_CACHE_CAP).unwrap(),
-            )),
-            opening: Mutex::new(HashMap::new()),
+            readers: (0..READER_CACHE_SHARDS)
+                .map(|_| {
+                    std::sync::Mutex::new(lru::LruCache::new(
+                        NonZeroUsize::new(READER_CACHE_CAP / READER_CACHE_SHARDS).unwrap(),
+                    ))
+                })
+                .collect(),
+            opening: std::sync::Mutex::new(HashMap::new()),
+            streams: std::sync::Mutex::new(HashMap::new()),
         }
     }
 
+    fn reader_shard(&self, split_id: &str) -> &std::sync::Mutex<lru::LruCache<String, Arc<SplitReader>>> {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        split_id.hash(&mut hasher);
+        &self.readers[hasher.finish() as usize % READER_CACHE_SHARDS]
+    }
+
+    /// Resolve a stream's record and schema through the TTL cache.
+    async fn stream_schema(&self, name: &str) -> SearchResult<Arc<CachedStream>> {
+        if let Some((cached, at)) = self.streams.lock().unwrap().get(name)
+            && at.elapsed() < STREAM_CACHE_TTL
+        {
+            return Ok(cached.clone());
+        }
+        let record = self.metastore.get_stream(name).await?;
+        let mapping = IndexMapping::from_json(&record.mapping)
+            .map_err(|e| SearchError::BadRequest(e.to_string()))?;
+        let cached = Arc::new(CachedStream {
+            schema: Arc::new(MappedSchema::build(mapping)),
+            record,
+        });
+        let mut streams = self.streams.lock().unwrap();
+        // Bounded so a probe flood of stream names can't grow it forever.
+        if streams.len() > 10_000 {
+            streams.clear();
+        }
+        streams.insert(name.to_string(), (cached.clone(), Instant::now()));
+        Ok(cached)
+    }
+
     async fn reader(&self, split_id: &str, storage_key: &str) -> SearchResult<Arc<SplitReader>> {
-        if let Some(reader) = self.readers.lock().await.get(split_id).cloned() {
-            return Ok(reader);
+        if let Some(reader) = self.reader_shard(split_id).lock().unwrap().get(split_id) {
+            return Ok(reader.clone());
         }
         // Single-flight: coalesce concurrent opens of the same split.
         let gate = {
-            let mut opening = self.opening.lock().await;
+            let mut opening = self.opening.lock().unwrap();
             opening
                 .entry(split_id.to_string())
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+                .or_insert_with(|| Arc::new(Mutex::new(())))
                 .clone()
         };
         let _guard = gate.lock().await;
         // Someone may have opened it while we waited for the gate.
-        if let Some(reader) = self.readers.lock().await.get(split_id).cloned() {
-            return Ok(reader);
+        if let Some(reader) = self.reader_shard(split_id).lock().unwrap().get(split_id) {
+            return Ok(reader.clone());
         }
-        let reader = Arc::new(
-            SplitReader::open(self.storage.clone(), storage_key, self.cache.clone()).await?,
-        );
+        // The gate entry must not outlive the attempt: a failed open would
+        // otherwise leak it forever (one map entry per failing split id).
+        let opened = SplitReader::open(self.storage.clone(), storage_key, self.cache.clone()).await;
+        let reader = match opened {
+            Ok(reader) => Arc::new(reader),
+            Err(e) => {
+                self.opening.lock().unwrap().remove(split_id);
+                return Err(e.into());
+            }
+        };
         // LRU insert evicts only the least-recently-used entry, not the
         // whole cache.
-        self.readers
+        self.reader_shard(split_id)
             .lock()
-            .await
+            .unwrap()
             .put(split_id.to_string(), reader.clone());
-        self.opening.lock().await.remove(split_id);
+        self.opening.lock().unwrap().remove(split_id);
         Ok(reader)
     }
 
@@ -201,10 +265,9 @@ impl SearchService {
         use futures::stream::{self, StreamExt};
 
         let started = Instant::now();
-        let stream = self.metastore.get_stream(&request.stream).await?;
-        let mapping = IndexMapping::from_json(&stream.mapping)
-            .map_err(|e| SearchError::BadRequest(e.to_string()))?;
-        let schema = Arc::new(MappedSchema::build(mapping));
+        let cached = self.stream_schema(&request.stream).await?;
+        let stream = &cached.record;
+        let schema = cached.schema.clone();
 
         let (t_start, t_end) = extract_time_bounds(&request.query);
         let splits = self
@@ -239,6 +302,11 @@ impl SearchService {
         // split order so split_idx stays meaningful.
         let track = request.track_total_hits;
         let sort_desc = request.sort_desc;
+        // Running total of counted matches across splits. Once it passes
+        // track_total_hits, later splits skip their Count collector and the
+        // response reports `"relation": "gte"` — the default 10k cap stops
+        // exact counting instead of scanning every match in the stream.
+        let counted = Arc::new(AtomicUsize::new(0));
         let futs: Vec<_> = splits
             .iter()
             .enumerate()
@@ -247,6 +315,7 @@ impl SearchService {
                 let schema = schema.clone();
                 let query = query.clone();
                 let aggregations = aggregations.clone();
+                let counted = counted.clone();
                 let split_id = split.split_id.clone();
                 let storage_key = split.storage_key.clone();
                 let doc_count = split.doc_count as usize;
@@ -258,7 +327,11 @@ impl SearchService {
                     && t_end.map(|e| split.time_end_millis <= e).unwrap_or(true);
                 async move {
                     let reader = this.reader(&split_id, &storage_key).await?;
-                    tokio::task::spawn_blocking(move || {
+                    let skip_count = match track {
+                        Some(cap) => counted.load(Ordering::Relaxed) >= cap,
+                        None => false,
+                    };
+                    let outcome = tokio::task::spawn_blocking(move || {
                         search_one_split(
                             &reader,
                             &schema,
@@ -266,14 +339,16 @@ impl SearchService {
                             aggregations,
                             fetch_limit,
                             sort_desc,
-                            track,
+                            skip_count,
                             idx,
                             doc_count,
                             fully_covered,
                         )
                     })
                     .await
-                    .map_err(|e| SearchError::Internal(format!("search task panicked: {e}")))?
+                    .map_err(|e| SearchError::Internal(format!("search task panicked: {e}")))??;
+                    counted.fetch_add(outcome.count, Ordering::Relaxed);
+                    Ok(outcome)
                 }
             })
             .collect();
@@ -386,37 +461,52 @@ impl SearchService {
         page: &[SplitHit],
         stream: &str,
     ) -> SearchResult<Vec<Value>> {
-        // Group page positions by split.
+        use futures::stream::{self, StreamExt};
+
+        // Group page positions by split, then fetch the splits concurrently
+        // (bounded); positions restore the page order afterwards.
         let mut by_split: HashMap<usize, Vec<(usize, DocAddress)>> = HashMap::new();
         for (pos, hit) in page.iter().enumerate() {
             by_split.entry(hit.split_idx).or_default().push((pos, hit.doc));
         }
-        let mut sources: Vec<Value> = vec![Value::Null; page.len()];
-        for (split_idx, wants) in by_split {
-            let split = &splits[split_idx];
-            let reader = self.reader(&split.split_id, &split.storage_key).await?;
-            let schema = schema.clone();
-            let fetched = tokio::task::spawn_blocking(move || {
-                let searcher = reader.searcher()?;
-                let mut out = Vec::with_capacity(wants.len());
-                for (pos, address) in wants {
-                    let doc: TantivyDocument =
-                        searcher.doc(address).map_err(SearchError::Tantivy)?;
-                    let source = doc
-                        .get_first(schema.source)
-                        .and_then(|v| v.as_str().map(str::to_string));
-                    out.push((pos, source));
+        let futs: Vec<_> = by_split
+            .into_iter()
+            .map(|(split_idx, wants)| {
+                let this = &*self;
+                let split = &splits[split_idx];
+                let schema = schema.clone();
+                async move {
+                    let reader = this.reader(&split.split_id, &split.storage_key).await?;
+                    tokio::task::spawn_blocking(move || {
+                        let searcher = reader.searcher()?;
+                        let mut out = Vec::with_capacity(wants.len());
+                        for (pos, address) in wants {
+                            let doc: TantivyDocument =
+                                searcher.doc(address).map_err(SearchError::Tantivy)?;
+                            let source = doc
+                                .get_first(schema.source)
+                                .and_then(|v| v.as_str().map(str::to_string));
+                            out.push((pos, source));
+                        }
+                        Ok::<_, SearchError>(out)
+                    })
+                    .await
+                    .map_err(|e| SearchError::Internal(format!("source fetch panicked: {e}")))?
                 }
-                Ok::<_, SearchError>(out)
             })
+            .collect();
+        let mut sources: Vec<Value> = vec![Value::Null; page.len()];
+        let fetched: Vec<Vec<(usize, Option<String>)>> = stream::iter(futs)
+            .buffer_unordered(SPLIT_SEARCH_CONCURRENCY)
+            .collect::<Vec<SearchResult<_>>>()
             .await
-            .map_err(|e| SearchError::Internal(format!("source fetch panicked: {e}")))??;
-            for (pos, source) in fetched {
-                sources[pos] = source
-                    .as_deref()
-                    .and_then(|s| serde_json::from_str(s).ok())
-                    .unwrap_or(Value::Null);
-            }
+            .into_iter()
+            .collect::<SearchResult<Vec<_>>>()?;
+        for (pos, source) in fetched.into_iter().flatten() {
+            sources[pos] = source
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok())
+                .unwrap_or(Value::Null);
         }
         Ok(page
             .iter()
@@ -460,7 +550,7 @@ fn search_one_split(
     aggregations: Option<Aggregations>,
     fetch_limit: usize,
     sort_desc: bool,
-    track_total_hits: Option<usize>,
+    skip_count: bool,
     split_idx: usize,
     doc_count: usize,
     fully_covered: bool,
@@ -498,11 +588,10 @@ fn search_one_split(
         });
     }
 
-    // track_total_hits:false → don't run the Count collector at all; the
-    // total becomes a lower bound (the page length). Aggregations still
-    // need their collector.
-    let skip_count = track_total_hits == Some(0);
-
+    // skip_count (track_total_hits:false, or the running total already
+    // passed the cap) → don't run the Count collector at all; the total
+    // becomes a lower bound (the page length). Aggregations still need
+    // their collector, and counting is free alongside their full scan.
     let (count, count_is_lower_bound, top, agg_result) = match (aggregations, skip_count) {
         (Some(aggs), _) => {
             let agg_collector = tantivy::aggregation::DistributedAggregationCollector::from_aggs(

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -33,17 +33,27 @@ pub struct AuthState {
     pub enforced: Arc<AtomicBool>,
     /// token-digest -> (identity, inserted_at). Short-TTL cache that keeps
     /// shipper auth off the DB hot path (no per-request session lookup or
-    /// `last_used_at` write). Cleared on user/key mutation.
+    /// `last_used_at` write). Also holds verified Basic credentials (keyed
+    /// by a digest of user+password) so shippers don't pay a full PBKDF2
+    /// per request. Cleared on user/key mutation.
     cache: Arc<Mutex<std::collections::HashMap<String, (Identity, Instant)>>>,
+    /// Digests of tokens that recently failed both DB lookups. Keeps a
+    /// misconfigured shipper (or a token-spraying client) from hammering
+    /// the metastore with two queries per request. Cleared on mutation
+    /// alongside the positive cache, so a just-created key is usable
+    /// immediately.
+    negative: Arc<Mutex<std::collections::HashMap<String, Instant>>>,
 }
 
 const TOKEN_CACHE_TTL: Duration = Duration::from_secs(30);
+const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(5);
 
 impl Default for AuthState {
     fn default() -> Self {
         Self {
             enforced: Arc::new(AtomicBool::new(true)),
             cache: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            negative: Arc::new(Mutex::new(std::collections::HashMap::new())),
         }
     }
 }
@@ -69,10 +79,31 @@ impl AuthState {
         cache.insert(hash, (identity, Instant::now()));
     }
 
+    fn negative_get(&self, hash: &str) -> bool {
+        let mut negative = self.negative.lock().unwrap();
+        if let Some(at) = negative.get(hash) {
+            if at.elapsed() < NEGATIVE_CACHE_TTL {
+                return true;
+            }
+            negative.remove(hash);
+        }
+        false
+    }
+
+    fn negative_put(&self, hash: String) {
+        let mut negative = self.negative.lock().unwrap();
+        // Bounded to keep a token flood from growing it without limit.
+        if negative.len() > 10_000 {
+            negative.clear();
+        }
+        negative.insert(hash, Instant::now());
+    }
+
     /// Invalidate the whole token cache — called after any user/key change
     /// so revocations take effect within one request rather than one TTL.
     pub fn invalidate(&self) {
         self.cache.lock().unwrap().clear();
+        self.negative.lock().unwrap().clear();
     }
 }
 
@@ -170,12 +201,19 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
         if let Some(identity) = state.auth.cache_get(&hash) {
             return Some(identity);
         }
-        if let Ok(Some(user)) = state.metastore.session_user(&hash).await {
+        if state.auth.negative_get(&hash) {
+            continue;
+        }
+        let session = state.metastore.session_user(&hash).await;
+        let session_missed = matches!(session, Ok(None));
+        if let Ok(Some(user)) = session {
             let identity = user_identity(user);
             state.auth.cache_put(hash, identity.clone());
             return Some(identity);
         }
-        if let Ok(Some(key)) = state.metastore.api_key_by_hash(&hash).await {
+        let api_key = state.metastore.api_key_by_hash(&hash).await;
+        let api_key_missed = matches!(api_key, Ok(None));
+        if let Ok(Some(key)) = api_key {
             let identity = Identity {
                 name: format!("apikey:{}", key.name),
                 is_admin: key.actions.iter().any(|a| a == "admin"),
@@ -184,6 +222,11 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
             };
             state.auth.cache_put(hash, identity.clone());
             return Some(identity);
+        }
+        // Only a definite miss goes in the negative cache — a metastore
+        // error must not make a valid token unusable for the TTL.
+        if session_missed && api_key_missed {
+            state.auth.negative_put(hash);
         }
     }
 
@@ -199,6 +242,15 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
         && let Ok(text) = String::from_utf8(decoded)
         && let Some((username, password)) = text.split_once(':')
     {
+        // Verified credentials are cached (same TTL and invalidation as
+        // tokens) so shippers using Basic don't pay a full PBKDF2 per
+        // request. Failures are never cached: first contact with any
+        // username always costs one full verify, preserving the
+        // timing defense below.
+        let basic_hash = crypto::token_digest(&format!("basic\0{username}\0{password}"));
+        if let Some(identity) = state.auth.cache_get(&basic_hash) {
+            return Some(identity);
+        }
         let user = state.metastore.get_user(username).await.ok().flatten();
         let hash = user
             .as_ref()
@@ -209,7 +261,9 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
             .await
             .unwrap_or(false);
         if ok && let Some(user) = user {
-            return Some(user_identity(user));
+            let identity = user_identity(user);
+            state.auth.cache_put(basic_hash, identity.clone());
+            return Some(identity);
         }
     }
     None

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -60,13 +60,14 @@ async fn handle_bulk(state: AppState, default_index: Option<String>, body: Strin
         })
         .collect();
     let wal = pipeline.wal().clone();
-    let wal_items: Vec<(String, Vec<u8>)> = expanded
+    let wal_items: Vec<(String, std::sync::Arc<str>)> = expanded
         .iter()
         .flat_map(|(_, item, routes)| {
-            // WAL payload = the client's original line bytes (no re-serialize).
+            // WAL payload = the client's original line bytes (no
+            // re-serialize, no byte copy — the Arc is shared).
             routes
                 .iter()
-                .map(move |stream| (stream.clone(), item.raw.as_bytes().to_vec()))
+                .map(move |stream| (stream.clone(), item.raw.clone()))
         })
         .collect();
     let positions = match tokio::task::spawn_blocking(move || wal.append_batch(&wal_items)).await {

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -10,9 +10,20 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rsearch_common::config::{ControlConfig, RsearchConfig};
 use rsearch_index::{IndexMapping, MappedSchema, SplitBuilder, SplitCache, SplitReader};
-use rsearch_metastore::{Metastore, SplitRecord};
+use rsearch_metastore::{Metastore, NodeRecord, SplitRecord, UnderReplicatedKey};
 use rsearch_storage::Storage;
 use tracing::{error, info, warn};
+
+/// Peer transfers per repair/drain pass that run concurrently. Each key's
+/// metastore lookups and replicate calls are independent; running them
+/// serially made drain throughput a function of per-key latency.
+const REPAIR_DRAIN_CONCURRENCY: usize = 8;
+/// Ceiling on drain batches processed per node per tick — bounds how long
+/// one tick can run while still draining far faster than one batch/tick.
+const DRAIN_BATCHES_PER_TICK: usize = 10;
+/// How often the full under-replication scan must run even with no
+/// membership change — catches writes that never reached the factor.
+const REPAIR_FULL_SCAN_SECS: u64 = 300;
 
 pub struct ControlPlane {
     metastore: Metastore,
@@ -30,6 +41,19 @@ pub struct ControlPlane {
     replication: Option<ReplicationCtl>,
     /// Shared with the /metrics handler.
     metrics: Arc<crate::metrics::ControlMetrics>,
+    /// Gates the O(object_locations) under-replication aggregation so
+    /// healthy steady-state ticks don't pay a full-table scan every 15s.
+    repair_scan: std::sync::Mutex<RepairScanState>,
+}
+
+#[derive(Default)]
+struct RepairScanState {
+    /// Live-node set at the last scan; a change (death/join) triggers one.
+    last_live: std::collections::BTreeSet<String>,
+    last_scan: Option<std::time::Instant>,
+    /// The previous scan found under-replicated keys — keep scanning every
+    /// tick until a scan comes back clean.
+    last_found_work: bool,
 }
 
 struct ReplicationCtl {
@@ -73,6 +97,7 @@ impl ControlPlane {
             webhook: crate::webhook::WebhookClient::new(config.control.allow_insecure_webhooks)?,
             replication,
             metrics,
+            repair_scan: std::sync::Mutex::new(RepairScanState::default()),
         })
     }
 
@@ -142,9 +167,34 @@ impl ControlPlane {
     /// copy is a leader-instructed pull on the target so the transfer
     /// streams peer-to-peer, never through the leader.
     async fn repair_job(&self) -> anyhow::Result<()> {
+        use futures::stream::{self, StreamExt};
         let Some(ctl) = &self.replication else {
             return Ok(());
         };
+        // The under-replication query aggregates the whole placement
+        // table, so a healthy cluster shouldn't pay it every tick: scan
+        // when the live-node set changed (a node died or joined), while
+        // the previous scan still found work, and on a periodic deadline
+        // (catches writes that never reached the factor with no
+        // membership change at all).
+        let nodes = self.metastore.list_nodes().await?;
+        let live: std::collections::BTreeSet<String> = nodes
+            .into_iter()
+            .filter(|n| n.heartbeat_age_secs < ctl.repair_stale_secs)
+            .map(|n| n.id)
+            .collect();
+        {
+            let mut scan = self.repair_scan.lock().unwrap();
+            let deadline_due = scan
+                .last_scan
+                .map(|at| at.elapsed().as_secs() >= REPAIR_FULL_SCAN_SECS)
+                .unwrap_or(true);
+            if live == scan.last_live && !scan.last_found_work && !deadline_due {
+                return Ok(());
+            }
+            scan.last_live = live;
+            scan.last_scan = Some(std::time::Instant::now());
+        }
         // repair_stale_secs doubles as the fresh-write grace: a key whose
         // newest row is younger may still be mid-push (quorum acks detach
         // the remaining replica pushes).
@@ -160,86 +210,108 @@ impl ControlPlane {
         self.metrics
             .repair_pending_keys
             .store(under.len() as u64, std::sync::atomic::Ordering::Relaxed);
-        for entry in under {
-            let key = &entry.storage_key;
-            // Holders must be reachable *now* to serve as copy sources.
-            let holders = self.metastore.live_holders_of(key, 30.0).await?;
-            let Some(source) = holders.iter().find_map(|h| h.address.as_deref()) else {
-                warn!(key, "repair: no live holder — object currently unavailable");
-                continue;
-            };
-            let missing = (ctl.replication_factor as usize).saturating_sub(holders.len());
-            if missing == 0 {
-                continue;
-            }
-            let exclude: Vec<String> = holders.iter().map(|h| h.id.clone()).collect();
-            let mut targets = self
-                .metastore
-                .replication_targets(30.0, &exclude, missing as i64, false)
-                .await?;
-            if targets.len() < missing {
-                // Last resort: a draining node beats losing the last copy.
-                // The drain job moves the copy off again once a real
-                // target exists (#4).
-                let mut exclude_more = exclude.clone();
-                exclude_more.extend(targets.iter().map(|t| t.id.clone()));
-                let fallback = self
-                    .metastore
-                    .replication_targets(
-                        30.0,
-                        &exclude_more,
-                        (missing - targets.len()) as i64,
-                        true,
-                    )
-                    .await?;
-                for target in fallback {
-                    warn!(
-                        key,
-                        target = %target.id,
-                        "repair: using draining node as last-resort copy target"
-                    );
-                    targets.push(target);
+        self.repair_scan.lock().unwrap().last_found_work = !under.is_empty();
+        // Keys repair independently; bounded concurrency overlaps their
+        // metastore lookups and peer transfers instead of running the
+        // whole batch serially.
+        let futs: Vec<_> = under
+            .iter()
+            .map(|entry| async move {
+                if let Err(e) = self.repair_one(ctl, entry).await {
+                    warn!(key = %entry.storage_key, error = %e, "repair: key failed");
                 }
-            }
-            if targets.is_empty() {
-                // Even draining nodes were considered above, so this means
-                // every live node already holds a copy — the cluster is
-                // simply short of nodes for the factor.
+            })
+            .collect();
+        stream::iter(futs)
+            .buffer_unordered(REPAIR_DRAIN_CONCURRENCY)
+            .collect::<Vec<()>>()
+            .await;
+        Ok(())
+    }
+
+    async fn repair_one(
+        &self,
+        ctl: &ReplicationCtl,
+        entry: &UnderReplicatedKey,
+    ) -> anyhow::Result<()> {
+        let key = &entry.storage_key;
+        // Holders must be reachable *now* to serve as copy sources.
+        let holders = self.metastore.live_holders_of(key, 30.0).await?;
+        let Some(source) = holders.iter().find_map(|h| h.address.as_deref()) else {
+            warn!(key, "repair: no live holder — object currently unavailable");
+            return Ok(());
+        };
+        let missing = (ctl.replication_factor as usize).saturating_sub(holders.len());
+        if missing == 0 {
+            return Ok(());
+        }
+        let exclude: Vec<String> = holders.iter().map(|h| h.id.clone()).collect();
+        let mut targets = self
+            .metastore
+            .replication_targets(30.0, &exclude, missing as i64, false)
+            .await?;
+        if targets.len() < missing {
+            // Last resort: a draining node beats losing the last copy.
+            // The drain job moves the copy off again once a real
+            // target exists (#4).
+            let mut exclude_more = exclude.clone();
+            exclude_more.extend(targets.iter().map(|t| t.id.clone()));
+            let fallback = self
+                .metastore
+                .replication_targets(
+                    30.0,
+                    &exclude_more,
+                    (missing - targets.len()) as i64,
+                    true,
+                )
+                .await?;
+            for target in fallback {
                 warn!(
                     key,
-                    live_holders = holders.len(),
-                    missing,
-                    "repair: no eligible target nodes — every live node \
-                     already holds a copy"
+                    target = %target.id,
+                    "repair: using draining node as last-resort copy target"
                 );
-                continue;
+                targets.push(target);
             }
-            for target in targets {
-                let Some(target_addr) = target.address.as_deref() else { continue };
-                match tokio::time::timeout(
-                    Duration::from_secs(600),
-                    ctl.client.replicate(target_addr, key, source),
-                )
-                .await
-                {
-                    Ok(Ok(())) => {
-                        self.metrics
-                            .repair_copies_restored
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        info!(key, target = %target.id, "repair: copy restored");
-                    }
-                    Ok(Err(e)) => {
-                        self.metrics
-                            .repair_failures
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        warn!(key, target = %target.id, error = %e, "repair: replicate failed");
-                    }
-                    Err(_) => {
-                        self.metrics
-                            .repair_failures
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        warn!(key, target = %target.id, "repair: replicate timed out");
-                    }
+        }
+        if targets.is_empty() {
+            // Even draining nodes were considered above, so this means
+            // every live node already holds a copy — the cluster is
+            // simply short of nodes for the factor.
+            warn!(
+                key,
+                live_holders = holders.len(),
+                missing,
+                "repair: no eligible target nodes — every live node \
+                 already holds a copy"
+            );
+            return Ok(());
+        }
+        for target in targets {
+            let Some(target_addr) = target.address.as_deref() else { continue };
+            match tokio::time::timeout(
+                Duration::from_secs(600),
+                ctl.client.replicate(target_addr, key, source),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
+                    self.metrics
+                        .repair_copies_restored
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    info!(key, target = %target.id, "repair: copy restored");
+                }
+                Ok(Err(e)) => {
+                    self.metrics
+                        .repair_failures
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    warn!(key, target = %target.id, error = %e, "repair: replicate failed");
+                }
+                Err(_) => {
+                    self.metrics
+                        .repair_failures
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    warn!(key, target = %target.id, "repair: replicate timed out");
                 }
             }
         }
@@ -322,6 +394,7 @@ impl ControlPlane {
     /// no rows left it can be shut down. The node keeps serving reads the
     /// whole time, so there is no availability dip.
     async fn drain_job(&self) -> anyhow::Result<()> {
+        use futures::stream::{self, StreamExt};
         let nodes = self.metastore.list_nodes().await?;
         // A draining flag outliving the warn window is likely a forgotten
         // DELETE: the node looks healthy but silently takes no writes and
@@ -344,80 +417,117 @@ impl ControlPlane {
         };
         let factor = ctl.replication_factor as usize;
         for node in nodes.iter().filter(|n| n.draining) {
-            let keys = self.metastore.locations_on_node(&node.id, 50).await?;
-            if keys.is_empty() {
-                info!(node = %node.id, "drain complete: node holds no objects and can be shut down");
-                continue;
-            }
-            for key in &keys {
-                let holders = self.metastore.live_holders_of(key, 30.0).await?;
-                let Some(source) = holders.iter().find_map(|h| h.address.as_deref()) else {
-                    warn!(key, "drain: no live holder to copy from; skipping");
-                    continue;
-                };
-                // Copies already safe on nodes that are staying.
-                let mut safe = holders.iter().filter(|h| !h.draining).count();
-                if safe < factor {
-                    let exclude: Vec<String> = holders.iter().map(|h| h.id.clone()).collect();
-                    let targets = self
-                        .metastore
-                        .replication_targets(30.0, &exclude, (factor - safe) as i64, false)
-                        .await?;
-                    for target in targets {
-                        let Some(addr) = target.address.as_deref() else { continue };
-                        match tokio::time::timeout(
-                            Duration::from_secs(600),
-                            ctl.client.replicate(addr, key, source),
-                        )
-                        .await
-                        {
-                            Ok(Ok(())) => {
-                                safe += 1;
-                                self.metrics
-                                    .drain_copies_moved
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                info!(key, target = %target.id, "drain: copy moved");
-                            }
-                            Ok(Err(e)) => {
-                                self.metrics
-                                    .drain_failures
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                warn!(key, target = %target.id, error = %e, "drain: replicate failed");
-                            }
-                            Err(_) => {
-                                self.metrics
-                                    .drain_failures
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                warn!(key, target = %target.id, "drain: replicate timed out");
+            // Multiple batches per tick with concurrent per-key transfers;
+            // one serial 50-key batch per 15s tick made draining a large
+            // node take days. A batch with any stuck key stops until the
+            // next tick rather than re-fetching the same keys in a loop.
+            for _ in 0..DRAIN_BATCHES_PER_TICK {
+                let keys = self.metastore.locations_on_node(&node.id, 50).await?;
+                if keys.is_empty() {
+                    info!(node = %node.id, "drain complete: node holds no objects and can be shut down");
+                    break;
+                }
+                let futs: Vec<_> = keys
+                    .iter()
+                    .map(|key| async move {
+                        match self.drain_one(ctl, node, factor, key).await {
+                            Ok(moved) => moved,
+                            Err(e) => {
+                                warn!(key = %key, error = %e, "drain: key failed");
+                                false
                             }
                         }
-                    }
-                }
-                if safe >= factor {
-                    // Prefer a peer DELETE: the draining node drops the
-                    // file AND its own row, so the disk space returns and
-                    // an undrained node can't later serve cluster-deleted
-                    // objects from leftovers. Fall back to just the row if
-                    // the node is unreachable.
-                    let deleted = match node.address.as_deref() {
-                        Some(addr) => ctl.client.delete(addr, key).await.is_ok(),
-                        None => false,
-                    };
-                    if !deleted {
-                        self.metastore.remove_object_location(key, &node.id).await?;
-                    }
-                } else {
-                    warn!(
-                        key,
-                        node = %node.id,
-                        safe,
-                        factor,
-                        "drain: not enough non-draining nodes to hold the factor"
-                    );
+                    })
+                    .collect();
+                let results: Vec<bool> = stream::iter(futs)
+                    .buffer_unordered(REPAIR_DRAIN_CONCURRENCY)
+                    .collect()
+                    .await;
+                if results.iter().any(|moved| !moved) {
+                    break;
                 }
             }
         }
         Ok(())
+    }
+
+    /// Drain a single key off `node`: ensure `factor` copies exist on
+    /// non-draining nodes, then drop the draining node's copy. Returns
+    /// whether the node's placement row for the key is gone.
+    async fn drain_one(
+        &self,
+        ctl: &ReplicationCtl,
+        node: &NodeRecord,
+        factor: usize,
+        key: &str,
+    ) -> anyhow::Result<bool> {
+        let holders = self.metastore.live_holders_of(key, 30.0).await?;
+        let Some(source) = holders.iter().find_map(|h| h.address.as_deref()) else {
+            warn!(key, "drain: no live holder to copy from; skipping");
+            return Ok(false);
+        };
+        // Copies already safe on nodes that are staying.
+        let mut safe = holders.iter().filter(|h| !h.draining).count();
+        if safe < factor {
+            let exclude: Vec<String> = holders.iter().map(|h| h.id.clone()).collect();
+            let targets = self
+                .metastore
+                .replication_targets(30.0, &exclude, (factor - safe) as i64, false)
+                .await?;
+            for target in targets {
+                let Some(addr) = target.address.as_deref() else { continue };
+                match tokio::time::timeout(
+                    Duration::from_secs(600),
+                    ctl.client.replicate(addr, key, source),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        safe += 1;
+                        self.metrics
+                            .drain_copies_moved
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        info!(key, target = %target.id, "drain: copy moved");
+                    }
+                    Ok(Err(e)) => {
+                        self.metrics
+                            .drain_failures
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        warn!(key, target = %target.id, error = %e, "drain: replicate failed");
+                    }
+                    Err(_) => {
+                        self.metrics
+                            .drain_failures
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        warn!(key, target = %target.id, "drain: replicate timed out");
+                    }
+                }
+            }
+        }
+        if safe >= factor {
+            // Prefer a peer DELETE: the draining node drops the
+            // file AND its own row, so the disk space returns and
+            // an undrained node can't later serve cluster-deleted
+            // objects from leftovers. Fall back to just the row if
+            // the node is unreachable.
+            let deleted = match node.address.as_deref() {
+                Some(addr) => ctl.client.delete(addr, key).await.is_ok(),
+                None => false,
+            };
+            if !deleted {
+                self.metastore.remove_object_location(key, &node.id).await?;
+            }
+            Ok(true)
+        } else {
+            warn!(
+                key,
+                node = %node.id,
+                safe,
+                factor,
+                "drain: not enough non-draining nodes to hold the factor"
+            );
+            Ok(false)
+        }
     }
 
     /// Combine the first group of >= 2 small published splits in one
@@ -452,32 +562,36 @@ impl ControlPlane {
             "merging small splits"
         );
 
-        // Export docs from every source split (blocking reads).
-        let mut all_docs: Vec<(serde_json::Value, i64)> = Vec::new();
+        // Stream every source split's docs straight into the new builder,
+        // one split at a time on blocking threads. Peak memory is one doc
+        // plus the Tantivy writer budget — the merge group's parsed corpus
+        // (GBs at default config) is never materialized.
+        let stream_name = stream.name.clone();
+        let work_dir = self.work_dir.clone();
+        let budget = self.memory_budget;
+        let mut builder = tokio::task::spawn_blocking(move || {
+            SplitBuilder::new(stream_name, schema, &work_dir, budget)
+        })
+        .await??;
         for split in &group {
             let reader = Arc::new(
                 SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
                     .await?,
             );
-            let docs =
-                tokio::task::spawn_blocking(move || reader.export_docs()).await??;
-            all_docs.extend(docs);
+            builder = tokio::task::spawn_blocking(move || {
+                reader.for_each_doc(|doc, ts_millis| {
+                    // Docs lacking their own timestamp keep the original
+                    // one via the fallback.
+                    builder.add_json(
+                        doc,
+                        rsearch_index::DateTime::from_timestamp_millis(ts_millis),
+                    )
+                })?;
+                Ok::<_, rsearch_index::IndexError>(builder)
+            })
+            .await??;
         }
-
-        // Re-index into one split.
-        let stream_name = stream.name.clone();
-        let work_dir = self.work_dir.clone();
-        let budget = self.memory_budget;
-        let packaged = tokio::task::spawn_blocking(move || {
-            let mut builder = SplitBuilder::new(stream_name, schema, &work_dir, budget)?;
-            for (doc, ts_millis) in &all_docs {
-                // Docs lacking their own timestamp keep the original one
-                // via the fallback.
-                builder.add_json(doc, rsearch_index::DateTime::from_timestamp_millis(*ts_millis))?;
-            }
-            builder.finish()
-        })
-        .await??;
+        let packaged = tokio::task::spawn_blocking(move || builder.finish()).await??;
 
         let key = format!("streams/{}/{}.split", stream.name, packaged.meta.split_id);
         self.storage.put_file(&key, &packaged.file_path).await?;
@@ -525,14 +639,24 @@ impl ControlPlane {
     }
 
     async fn retention_job(&self) -> anyhow::Result<()> {
+        const BATCH: i64 = 10_000;
         let now_millis = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_millis() as i64)
             .unwrap_or(0);
-        let expired = self.metastore.expired_splits(now_millis).await?;
-        if !expired.is_empty() {
+        // Batched: enabling retention on a large old stream marks its
+        // whole backlog without ever holding millions of ids in memory.
+        loop {
+            let expired = self.metastore.expired_splits(now_millis, BATCH).await?;
+            if expired.is_empty() {
+                break;
+            }
+            let finished = (expired.len() as i64) < BATCH;
             let marked = self.metastore.mark_splits_for_delete(&expired).await?;
             info!(marked, "retention: expired splits marked for delete");
+            if finished {
+                break;
+            }
         }
         Ok(())
     }

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -142,14 +142,13 @@ async fn resolve_stream(state: &AppState, pattern: &str) -> Result<String, Strin
         return Ok(pattern.to_string());
     }
     let streams = state
-        .metastore
-        .list_streams()
+        .cached_stream_names()
         .await
         .map_err(|e| e.to_string())?;
     let matches: Vec<String> = streams
-        .into_iter()
-        .map(|s| s.name)
+        .iter()
         .filter(|name| glob_match(pattern, name))
+        .cloned()
         .collect();
     match matches.len() {
         0 => Err(format!("no stream matches '{pattern}'")),

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -29,6 +29,10 @@ pub struct AppState {
     /// Repair/drain/leadership counters for /metrics, shared with the
     /// control loop. Present only on nodes running the control role.
     pub control: Option<Arc<crate::metrics::ControlMetrics>>,
+    /// Short-TTL cache of all stream names for wildcard resolution — an
+    /// `_msearch` refresh resolves `logs-*` once per TTL instead of one
+    /// `list_streams` query per header/body pair per viewer.
+    pub stream_names: Arc<std::sync::Mutex<Option<(Arc<Vec<String>>, std::time::Instant)>>>,
 }
 
 impl AppState {
@@ -52,7 +56,30 @@ impl AppState {
             internal: None,
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             control: None,
+            stream_names: Arc::new(std::sync::Mutex::new(None)),
         }
+    }
+
+    /// All stream names, cached briefly (see `stream_names`).
+    pub async fn cached_stream_names(
+        &self,
+    ) -> Result<Arc<Vec<String>>, rsearch_metastore::MetastoreError> {
+        const TTL: std::time::Duration = std::time::Duration::from_secs(5);
+        if let Some((names, at)) = self.stream_names.lock().unwrap().as_ref()
+            && at.elapsed() < TTL
+        {
+            return Ok(names.clone());
+        }
+        let names: Arc<Vec<String>> = Arc::new(
+            self.metastore
+                .list_streams()
+                .await?
+                .into_iter()
+                .map(|s| s.name)
+                .collect(),
+        );
+        *self.stream_names.lock().unwrap() = Some((names.clone(), std::time::Instant::now()));
+        Ok(names)
     }
 
     /// Record a security-relevant event to the `rsearch-audit` stream

--- a/crates/rsearch-storage/src/fs.rs
+++ b/crates/rsearch-storage/src/fs.rs
@@ -197,9 +197,18 @@ impl Storage for FsStorage {
         let path = self.resolve(key)?;
         self.prepare_parent(&path, key).await?;
         let tmp = path.with_extension("tmp-upload");
-        tokio::fs::copy(local, &tmp)
-            .await
-            .map_err(|e| Self::io_err(key, e))?;
+        // Publish via hard link when the staging dir and the storage root
+        // share a filesystem (both usually live under data_dir) — a copy
+        // would rewrite every split byte a second time (2x publish write
+        // amplification). Cross-device or unsupported links fall back to
+        // the copy. The link target must not exist, so clear any leftover
+        // temp from a crashed earlier attempt first.
+        let _ = tokio::fs::remove_file(&tmp).await;
+        if tokio::fs::hard_link(local, &tmp).await.is_err() {
+            tokio::fs::copy(local, &tmp)
+                .await
+                .map_err(|e| Self::io_err(key, e))?;
+        }
         // Durability: fsync the data before it becomes visible, so the
         // ingest WAL is only truncated after the split is truly on disk.
         {


### PR DESCRIPTION
Closes #7.

Implements every finding from the performance audit (4 High, 11 Medium, 8 Low). Highlights:

## High
- **H1** — per-document `workers` lock is now a sync `RwLock` read; first-time worker creation is single-flighted behind a separate mutex so the `ensure_stream` DB roundtrip never stalls enqueues to existing streams.
- **H2** — verified Basic credentials are cached in the existing auth cache (same 30s TTL + invalidation), so shippers no longer pay a 600k-iteration PBKDF2 per request. Failed verifications are never cached, preserving the username-enumeration timing defense.
- **H3** — merge no longer materializes the whole group: `SplitReader::for_each_doc` streams docs one at a time into the new `SplitBuilder` (replaces `export_docs`). Peak RSS drops from ~2-4GB at defaults to one doc + writer budget.
- **H4** — `track_total_hits` is enforced: a cross-split running total skips the `Count` collector once the cap is passed and the response reports `"relation": "gte"`. Agg queries still count (free alongside the agg scan).

## Medium
- **M1** dead per-route `doc.clone()` removed from `ingest_external`.
- **M2** `Wal::append_batch` is generic over `AsRef<str>` pairs; callers pass their existing `Arc<str>`s — no more full-body byte copy per bulk request.
- **M3** `replication_targets` ranks against a 5s-TTL per-node held-bytes cache instead of a full-table `SUM…GROUP BY` on every replicated write and repair/drain key.
- **M4** the under-replication full-table scan is gated: it runs when the live-node set changes, while the previous scan found work, or on a 5-minute deadline — healthy steady-state ticks skip it.
- **M5** reader LRU sharded 8× behind sync mutexes; the single-flight `opening` entry is now removed on the failed-open path too (was a permanent leak per failing split id).
- **M6** cold split fetches stream to the cache file in 8MB ranged chunks (`SplitCache::insert_via`) instead of buffering the whole file in RAM.
- **M7** `SplitCache` recency lives in a tick-keyed `BTreeMap` (O(log n) eviction, no full-map scans); `stat`/`unlink` syscalls moved outside the lock.
- **M8** repair and drain process keys with 8-way bounded concurrency; drain runs up to 10 batches per tick (stops early if any key is stuck).
- **M9** `_msearch` wildcard resolution reads a 5s-TTL stream-name cache instead of one `list_streams` query per header/body pair.
- **M10** searches resolve the stream record + built Tantivy schema through a 10s-TTL cache — no DB fetch + schema rebuild per query.
- **M11** `DocumentConverter` consumes the `Value` and moves unmapped fields into `_dynamic` — no deep clone of (most of) every log doc.

## Low
L1 replay single-copy Arc build · L2 WAL GC unlinks outside the writer lock · L3 rotation fsync outside the lock (sealed fds synced before ack) · L4 cursor-based syslog/GELF framing (one compaction per chunk) · L5 `expired_splits` batched with LIMIT+loop · L6 concurrent page-source fetches · L7 5s negative auth cache (definite misses only — DB errors are never negative-cached) · L8 `put_file` hard-links into the storage root with copy fallback.

`cargo check --workspace --all-targets` clean, all tests pass.

Note: the three findings shared with the mem-leak audit (#8) — workers map, executor `opening` map, merge memory — are fixed here; the #8 PR will stack on this branch for its remaining findings.