### PR TITLE
Fix #8: memory-leak & code-quality audit findings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,6 +2312,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "temp-env",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -3159,6 +3160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "temp-env"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
+dependencies = [
+ "parking_lot",
 ]
 
 [[package]]

--- a/crates/rsearch-common/Cargo.toml
+++ b/crates/rsearch-common/Cargo.toml
@@ -21,3 +21,6 @@ config.workspace = true
 rustls.workspace = true
 rustls-pki-types.workspace = true
 aws-lc-rs.workspace = true
+
+[dev-dependencies]
+temp-env = "0.3.6"

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -478,17 +478,18 @@ mod tests {
     #[test]
     fn stray_rsearch_env_var_does_not_crash_load() {
         // A prefixed var that targets no known section must be ignored,
-        // not error via deny_unknown_fields (M14). SAFETY: single-threaded
-        // test process.
-        unsafe {
-            std::env::set_var("RSEARCH_TEST_DATABASE_URL", "postgres://x");
-            std::env::set_var("RSEARCH_HOME", "/tmp");
-        }
-        let cfg = RsearchConfig::load(None).expect("stray RSEARCH_ vars must not crash load");
-        assert_eq!(cfg.http.bind_addr, "0.0.0.0:9200");
-        unsafe {
-            std::env::remove_var("RSEARCH_TEST_DATABASE_URL");
-            std::env::remove_var("RSEARCH_HOME");
-        }
+        // not error via deny_unknown_fields (M14). temp-env serializes
+        // env-mutating tests and restores the vars afterwards.
+        temp_env::with_vars(
+            [
+                ("RSEARCH_TEST_DATABASE_URL", Some("postgres://x")),
+                ("RSEARCH_HOME", Some("/tmp")),
+            ],
+            || {
+                let cfg =
+                    RsearchConfig::load(None).expect("stray RSEARCH_ vars must not crash load");
+                assert_eq!(cfg.http.bind_addr, "0.0.0.0:9200");
+            },
+        );
     }
 }

--- a/crates/rsearch-ingest/src/inputs.rs
+++ b/crates/rsearch-ingest/src/inputs.rs
@@ -18,6 +18,13 @@ use crate::syslog::parse_syslog;
 
 const BATCH_MAX: usize = 500;
 const BATCH_AGE_MS: u64 = 200;
+/// Cap on concurrent TCP connections per input. Each connection holds up
+/// to a 1MB framing buffer, and syslog is often unauthenticated — without
+/// a cap a connection flood exhausts fds and memory.
+const MAX_INPUT_CONNECTIONS: usize = 1024;
+/// Backoff after a failed accept (fd exhaustion, transient error) —
+/// without it the accept loop busy-spins a core while hiding the cause.
+const ACCEPT_ERROR_BACKOFF: Duration = Duration::from_millis(500);
 
 /// Start all enabled inputs. Returns an error only for configuration
 /// problems (bad TLS material, unbindable ports).
@@ -123,13 +130,25 @@ async fn spawn_syslog(
         info!(addr = %config.bind_tcp, tls = acceptor.is_some(), "syslog TCP input listening");
         let tx = batcher.clone();
         tokio::spawn(async move {
+            let conn_limit =
+                std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_INPUT_CONNECTIONS));
             loop {
-                let Ok((socket, peer)) = listener.accept().await else {
+                let (socket, peer) = match listener.accept().await {
+                    Ok(pair) => pair,
+                    Err(e) => {
+                        warn!(error = %e, "syslog TCP accept failed; backing off");
+                        tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
+                        continue;
+                    }
+                };
+                let Ok(permit) = conn_limit.clone().try_acquire_owned() else {
+                    warn!(%peer, "syslog connection limit reached; closing connection");
                     continue;
                 };
                 let tx = tx.clone();
                 let acceptor = acceptor.clone();
                 tokio::spawn(async move {
+                    let _permit = permit;
                     let result = match acceptor {
                         Some(acceptor) => match acceptor.accept(socket).await {
                             Ok(tls) => read_lines(tls, &tx).await,
@@ -199,13 +218,24 @@ async fn spawn_gelf(config: &GelfInputConfig, pipeline: IngestPipeline) -> Resul
         .map_err(|e| format!("binding GELF TCP {}: {e}", config.bind_tcp))?;
     info!(addr = %config.bind_tcp, tls = acceptor.is_some(), "GELF TCP input listening");
     tokio::spawn(async move {
+        let conn_limit = std::sync::Arc::new(tokio::sync::Semaphore::new(MAX_INPUT_CONNECTIONS));
         loop {
-            let Ok((socket, peer)) = listener.accept().await else {
+            let (socket, peer) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(e) => {
+                    warn!(error = %e, "GELF TCP accept failed; backing off");
+                    tokio::time::sleep(ACCEPT_ERROR_BACKOFF).await;
+                    continue;
+                }
+            };
+            let Ok(permit) = conn_limit.clone().try_acquire_owned() else {
+                warn!(%peer, "GELF connection limit reached; closing connection");
                 continue;
             };
             let tx = batcher.clone();
             let acceptor = acceptor.clone();
             tokio::spawn(async move {
+                let _permit = permit;
                 let result = match acceptor {
                     Some(acceptor) => match acceptor.accept(socket).await {
                         Ok(tls) => read_gelf(tls, &tx).await,

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -227,17 +227,33 @@ impl IngestPipeline {
         let size = source.len() as u64;
         match tx.try_send(WorkItem { source, pos }) {
             Ok(()) => {
-                self.inner.metrics.docs_enqueued.fetch_add(1, Ordering::Relaxed);
-                self.inner
-                    .metrics
-                    .bytes_enqueued
-                    .fetch_add(size, Ordering::Relaxed);
-                self.inner.metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
+                self.note_enqueued(size);
                 Ok(())
             }
             Err(mpsc::error::TrySendError::Full(_)) => Err(IngestError::Saturated),
-            Err(mpsc::error::TrySendError::Closed(_)) => Err(IngestError::Saturated),
+            Err(mpsc::error::TrySendError::Closed(item)) => {
+                // The worker idled out between the lookup and the send; its
+                // map entry is already removed, so one retry resolves a
+                // fresh worker.
+                let tx = self.worker_for(stream).await?;
+                match tx.try_send(item) {
+                    Ok(()) => {
+                        self.note_enqueued(size);
+                        Ok(())
+                    }
+                    Err(_) => Err(IngestError::Saturated),
+                }
+            }
         }
+    }
+
+    fn note_enqueued(&self, size: u64) {
+        self.inner.metrics.docs_enqueued.fetch_add(1, Ordering::Relaxed);
+        self.inner
+            .metrics
+            .bytes_enqueued
+            .fetch_add(size, Ordering::Relaxed);
+        self.inner.metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Feed WAL records recovered at startup back through the pipeline.
@@ -273,7 +289,12 @@ impl IngestPipeline {
                 .await
                 .is_err()
             {
-                warn!(stream = %record.stream, "worker gone during replay");
+                // The item was dropped, so undo the gauge and confirm the
+                // position — otherwise the depth drifts and the segment
+                // stays pinned forever.
+                self.inner.metrics.queue_depth.fetch_sub(1, Ordering::Relaxed);
+                self.inner.wal.confirm(&[record.pos]);
+                warn!(stream = %record.stream, "worker gone during replay; record dropped");
             }
         }
         if count > 0 {
@@ -313,6 +334,12 @@ impl IngestPipeline {
     }
 }
 
+/// How long a stream worker sits idle (empty buffer, no incoming docs)
+/// before retiring itself. Stream names are client-controlled (bulk
+/// `_index` values), so without an exit path every name ever seen pins a
+/// task + bounded queue + schema for the life of the process.
+const WORKER_IDLE_EXIT_SECS: u64 = 600;
+
 async fn stream_worker(
     inner: Arc<PipelineInner>,
     stream: String,
@@ -322,9 +349,9 @@ async fn stream_worker(
 ) {
     let max_docs = inner.config.max_batch_docs.max(1);
     let max_age = Duration::from_secs(inner.config.max_batch_secs.max(1));
+    let idle_exit = Duration::from_secs(WORKER_IDLE_EXIT_SECS);
     let mut buffer: Vec<WorkItem> = Vec::new();
-    let far_future = Duration::from_secs(3600 * 24 * 365);
-    let mut deadline = tokio::time::Instant::now() + far_future;
+    let mut deadline = tokio::time::Instant::now() + idle_exit;
     // Re-resolved before each flush so a mapping change (PUT /{index})
     // takes effect on the next split, not only after a restart (L7).
     let mut schema = schema;
@@ -348,7 +375,27 @@ async fn stream_worker(
                     return;
                 }
             },
-            _ = tokio::time::sleep_until(deadline) => !buffer.is_empty(),
+            _ = tokio::time::sleep_until(deadline) => {
+                if buffer.is_empty() {
+                    // Idle: retire this worker so per-stream state doesn't
+                    // accumulate forever for streams that stopped writing.
+                    // Order matters — unpublish, close, drain — so no
+                    // in-flight send can slip a doc into a dropped queue:
+                    // after close() a racing try_send fails and the sender
+                    // re-creates a fresh worker via worker_for.
+                    inner.workers.write().unwrap().remove(&stream);
+                    rx.close();
+                    while let Ok(item) = rx.try_recv() {
+                        buffer.push(item);
+                    }
+                    if !buffer.is_empty() {
+                        flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+                    }
+                    info!(stream, "idle stream worker retired");
+                    return;
+                }
+                true
+            },
         };
         if flush_now {
             // Pick up mapping changes before building the split.
@@ -360,7 +407,7 @@ async fn stream_worker(
                 mapping_json = record.mapping;
             }
             flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
-            deadline = tokio::time::Instant::now() + far_future;
+            deadline = tokio::time::Instant::now() + idle_exit;
         }
     }
 }
@@ -379,10 +426,14 @@ async fn flush(
 
     // Retry the flush with capped backoff on transient errors (S3/DB
     // blips). Data is already WAL-durable, so an in-process retry recovers
-    // without a restart; the WAL still backstops a hard crash.
+    // without a restart; the WAL still backstops a hard crash. Retries
+    // never give up: abandoning the batch would strand its docs (invisible
+    // to search) and pin its WAL segments until an operator restarts the
+    // process. Backpressure is the bounded queue behind this worker.
     let mut backoff = Duration::from_millis(200);
-    let max_attempts = 8;
-    for attempt in 1..=max_attempts {
+    let mut attempt = 0u64;
+    loop {
+        attempt += 1;
         match flush_inner(inner, stream, stream_id, schema, batch).await {
             Ok(split_id) => {
                 inner.wal.confirm(&positions);
@@ -394,14 +445,16 @@ async fn flush(
             Err((e, returned)) => {
                 batch = returned;
                 inner.metrics.flush_failures.fetch_add(1, Ordering::Relaxed);
-                if attempt == max_attempts {
+                // Escalate periodically so a long outage is loud without
+                // logging every attempt at error level.
+                if attempt % 8 == 0 {
                     error!(
-                        stream, docs = count, error = %e,
-                        "flush failed after retries; docs retained in WAL for replay on restart"
+                        stream, docs = count, attempt, error = %e,
+                        "flush still failing; docs held in WAL and retried until the backend recovers"
                     );
-                    return;
+                } else {
+                    warn!(stream, attempt, error = %e, "flush failed; retrying");
                 }
-                warn!(stream, attempt, error = %e, "flush failed; retrying");
                 tokio::time::sleep(backoff).await;
                 backoff = (backoff * 2).min(Duration::from_secs(30));
             }

--- a/crates/rsearch-ingest/src/wal.rs
+++ b/crates/rsearch-ingest/src/wal.rs
@@ -185,11 +185,16 @@ impl Wal {
                 inner.writer.write_all(doc)?;
                 inner.current_len += 8 + payload_len as u64;
                 let seq = inner.current_seq;
-                inner
-                    .segments
-                    .get_mut(&seq)
-                    .expect("current segment tracked")
-                    .outstanding += 1;
+                match inner.segments.get_mut(&seq) {
+                    Some(state) => state.outstanding += 1,
+                    // Invariant breach (current segment always tracked):
+                    // fail the append instead of panicking the request.
+                    None => {
+                        return Err(std::io::Error::other(
+                            "WAL invariant violated: current segment untracked",
+                        ));
+                    }
+                }
                 positions.push(WalPos { segment: seq });
             }
             // Push buffered bytes to the OS, then clone the fd so the fsync

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -225,23 +225,28 @@ impl Metastore {
     }
 
     /// Published splits of a stream overlapping [start, end] millis
-    /// (inclusive); pass None for an unbounded side.
+    /// (inclusive); pass None for an unbounded side. Bounded by `limit` so
+    /// an unbounded-time query on a long-retention stream can't load every
+    /// split row (callers request cap+1 to detect truncation).
     pub async fn splits_for_query(
         &self,
         stream_id: i64,
         time_start_millis: Option<i64>,
         time_end_millis: Option<i64>,
+        limit: i64,
     ) -> MetastoreResult<Vec<SplitRecord>> {
         let query = format!(
             "SELECT {SPLIT_COLUMNS} FROM splits
              WHERE stream_id = $1 AND state = 'published'
                AND time_end_millis >= $2 AND time_start_millis <= $3
-             ORDER BY time_start_millis"
+             ORDER BY time_start_millis
+             LIMIT $4"
         );
         Ok(sqlx::query_as::<_, SplitRecord>(sqlx::AssertSqlSafe(query))
             .bind(stream_id)
             .bind(time_start_millis.unwrap_or(i64::MIN))
             .bind(time_end_millis.unwrap_or(i64::MAX))
+            .bind(limit)
             .fetch_all(&self.pool)
             .await?)
     }

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -67,7 +67,7 @@ async fn split_state_machine() {
 
     // Staged splits are invisible to queries.
     assert!(
-        ms.splits_for_query(stream.id, None, None)
+        ms.splits_for_query(stream.id, None, None, 10_000)
             .await
             .unwrap()
             .is_empty()
@@ -82,20 +82,20 @@ async fn split_state_machine() {
 
     // Time-range pruning: overlapping window finds it, disjoint misses it.
     let hits = ms
-        .splits_for_query(stream.id, Some(1_753_300_030_000), None)
+        .splits_for_query(stream.id, Some(1_753_300_030_000), None, 10_000)
         .await
         .unwrap();
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].split_id, split_id);
     assert_eq!(hits[0].state(), SplitState::Published);
     assert!(
-        ms.splits_for_query(stream.id, Some(1_753_300_060_001), None)
+        ms.splits_for_query(stream.id, Some(1_753_300_060_001), None, 10_000)
             .await
             .unwrap()
             .is_empty()
     );
     assert!(
-        ms.splits_for_query(stream.id, None, Some(1_753_299_999_999))
+        ms.splits_for_query(stream.id, None, Some(1_753_299_999_999), 10_000)
             .await
             .unwrap()
             .is_empty()
@@ -112,7 +112,7 @@ async fn split_state_machine() {
         0
     );
     assert!(
-        ms.splits_for_query(stream.id, None, None)
+        ms.splits_for_query(stream.id, None, None, 10_000)
             .await
             .unwrap()
             .is_empty()

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -44,6 +44,11 @@ const STREAM_CACHE_TTL: Duration = Duration::from_secs(10);
 const DEFAULT_TRACK_TOTAL_HITS: usize = 10_000;
 /// Hard ceiling on from+size (ES max_result_window).
 const MAX_RESULT_WINDOW: usize = 10_000;
+/// Max splits one query may touch. A query over more than this (an
+/// unbounded time range on a long-retention stream) is rejected with a
+/// clear error instead of silently materializing every split row and
+/// scheduling a search on each.
+const MAX_QUERY_SPLITS: usize = 10_000;
 
 /// A parsed `_search` request body.
 pub struct SearchRequest {
@@ -272,8 +277,13 @@ impl SearchService {
         let (t_start, t_end) = extract_time_bounds(&request.query);
         let splits = self
             .metastore
-            .splits_for_query(stream.id, t_start, t_end)
+            .splits_for_query(stream.id, t_start, t_end, MAX_QUERY_SPLITS as i64 + 1)
             .await?;
+        if splits.len() > MAX_QUERY_SPLITS {
+            return Err(SearchError::BadRequest(format!(
+                "query spans more than {MAX_QUERY_SPLITS} splits; narrow the time range"
+            )));
+        }
 
         // Rewrite/parse aggregations once, share across splits via Arc.
         let aggs_json = request

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -187,7 +187,15 @@ fn classify(method: &str, path: &str) -> Action {
     }
 }
 
-async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Option<Identity> {
+/// `Ok(Some)` — authenticated. `Ok(None)` — definitely no valid
+/// credentials (→ 401). `Err(())` — a metastore error prevented deciding
+/// (→ 503): shippers treat 401 as fatal and stop, so a DB blip must not
+/// masquerade as bad credentials.
+async fn authenticate(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+) -> Result<Option<Identity>, ()> {
+    let mut backend_error = false;
     let bearer = headers
         .get("authorization")
         .and_then(|v| v.to_str().ok())
@@ -199,7 +207,7 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
     for token in [bearer, api_key_header].into_iter().flatten() {
         let hash = crypto::token_digest(token);
         if let Some(identity) = state.auth.cache_get(&hash) {
-            return Some(identity);
+            return Ok(Some(identity));
         }
         if state.auth.negative_get(&hash) {
             continue;
@@ -209,7 +217,7 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
         if let Ok(Some(user)) = session {
             let identity = user_identity(user);
             state.auth.cache_put(hash, identity.clone());
-            return Some(identity);
+            return Ok(Some(identity));
         }
         let api_key = state.metastore.api_key_by_hash(&hash).await;
         let api_key_missed = matches!(api_key, Ok(None));
@@ -221,12 +229,14 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
                 streams: key.streams,
             };
             state.auth.cache_put(hash, identity.clone());
-            return Some(identity);
+            return Ok(Some(identity));
         }
         // Only a definite miss goes in the negative cache — a metastore
         // error must not make a valid token unusable for the TTL.
         if session_missed && api_key_missed {
             state.auth.negative_put(hash);
+        } else {
+            backend_error = true;
         }
     }
 
@@ -249,9 +259,15 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
         // timing defense below.
         let basic_hash = crypto::token_digest(&format!("basic\0{username}\0{password}"));
         if let Some(identity) = state.auth.cache_get(&basic_hash) {
-            return Some(identity);
+            return Ok(Some(identity));
         }
-        let user = state.metastore.get_user(username).await.ok().flatten();
+        let user = match state.metastore.get_user(username).await {
+            Ok(user) => user,
+            Err(_) => {
+                backend_error = true;
+                None
+            }
+        };
         let hash = user
             .as_ref()
             .map(|u| u.password_hash.clone())
@@ -263,10 +279,10 @@ async fn authenticate(state: &AppState, headers: &axum::http::HeaderMap) -> Opti
         if ok && let Some(user) = user {
             let identity = user_identity(user);
             state.auth.cache_put(basic_hash, identity.clone());
-            return Some(identity);
+            return Ok(Some(identity));
         }
     }
-    None
+    if backend_error { Err(()) } else { Ok(None) }
 }
 
 fn user_identity(user: rsearch_metastore::UserRecord) -> Identity {
@@ -301,8 +317,12 @@ pub async fn require(
     }
 
     let headers = request.headers().clone();
-    let Some(identity) = authenticate(&state, &headers).await else {
-        return unauthorized("authentication required");
+    let identity = match authenticate(&state, &headers).await {
+        Ok(Some(identity)) => identity,
+        Ok(None) => return unauthorized("authentication required"),
+        // Backend down ≠ bad credentials: return a retryable 5xx so
+        // shippers back off instead of treating it as a fatal 401.
+        Err(()) => return service_unavailable("authentication backend unavailable"),
     };
 
     let allowed = match &action {
@@ -341,6 +361,17 @@ fn unauthorized(reason: &str) -> Response {
         Json(json!({
             "error": {"type": "security_exception", "reason": reason},
             "status": 401,
+        })),
+    )
+        .into_response()
+}
+
+fn service_unavailable(reason: &str) -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({
+            "error": {"type": "service_unavailable_exception", "reason": reason},
+            "status": 503,
         })),
     )
         .into_response()

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -99,7 +99,12 @@ async fn handle_bulk(state: AppState, default_index: Option<String>, body: Strin
         let mut saturated = false;
         let mut internal_error: Option<String> = None;
         for stream in routes.iter() {
-            let pos = position_iter.next().expect("position per routed copy");
+            // One WAL position exists per routed copy by construction; if
+            // a refactor ever breaks that, fail the item — not the process.
+            let Some(pos) = position_iter.next() else {
+                internal_error = Some("internal: missing WAL position for routed copy".into());
+                break;
+            };
             match pipeline.enqueue(stream, raw.clone(), pos).await {
                 Ok(()) => accepted += 1,
                 Err(IngestError::Saturated) => {

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -70,7 +70,12 @@ impl ControlPlane {
         metrics: Arc<crate::metrics::ControlMetrics>,
     ) -> anyhow::Result<Self> {
         let data_dir = std::path::PathBuf::from(&config.node.data_dir);
-        let cache = Arc::new(SplitCache::new(data_dir.join("cache/control"), 1 << 30)?);
+        // Same operator-configured budget as the search cache — a
+        // hard-coded size silently ate disk on small control nodes.
+        let cache = Arc::new(SplitCache::new(
+            data_dir.join("cache/control"),
+            config.search.cache_max_mb << 20,
+        )?);
         let search =
             rsearch_search::SearchService::new(metastore.clone(), storage.clone(), cache.clone());
         let replication = if config.storage.backend == "replicated" {

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -68,7 +68,7 @@ pub async fn msearch(State(state): State<AppState>, body: String) -> Response {
     // dashboard load time the sum of panels instead of the max (M13).
     let mut pairs: Vec<(Value, Value)> = Vec::new();
     let mut i = 0;
-    while i + 1 <= lines.len().saturating_sub(1) {
+    while i + 1 < lines.len() {
         let header: Value = match serde_json::from_str(lines[i]) {
             Ok(v) => v,
             Err(e) => {
@@ -91,6 +91,13 @@ pub async fn msearch(State(state): State<AppState>, body: String) -> Response {
         };
         pairs.push((header, search_body));
         i += 2;
+    }
+    if i < lines.len() {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "parse_exception",
+            "msearch body ends with a header line that has no body line",
+        );
     }
 
     let futures = pairs.into_iter().map(|(header, search_body)| {
@@ -128,7 +135,19 @@ pub async fn msearch(State(state): State<AppState>, body: String) -> Response {
             }
         }
     });
-    let responses = futures::future::join_all(futures).await;
+    // Bounded intra-request concurrency (ES: max_concurrent_searches).
+    // join_all ran every pair at once — thousands of tiny pairs fit in
+    // the body limit, and each search fans out into up to 16 blocking
+    // split searches, so an unbounded request could saturate the blocking
+    // pool it shares with bulk WAL appends.
+    use futures::StreamExt;
+    let max_concurrent = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(8);
+    let responses: Vec<Value> = futures::stream::iter(futures)
+        .buffered(max_concurrent)
+        .collect()
+        .await;
     Json(json!({"took": 0, "responses": responses})).into_response()
 }
 

--- a/crates/rsearch-server/src/webhook.rs
+++ b/crates/rsearch-server/src/webhook.rs
@@ -114,15 +114,31 @@ impl WebhookClient {
             .uri(url)
             .header("content-type", "application/json")
             .body(Full::new(Bytes::from(payload.to_string())))?;
-        let response = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            self.client.request(request),
-        )
+        // The timeout covers the whole exchange including the body drain:
+        // a response that returns headers and then drips its body forever
+        // must not hang the control loop (every leader job runs on it).
+        let status = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            let response = self.client.request(request).await?;
+            let status = response.status().as_u16();
+            // Drain a bounded amount so the connection can be reused; a
+            // larger body is abandoned — dropping it closes the connection
+            // instead of buffering an arbitrary payload in memory.
+            const DRAIN_CAP: usize = 64 * 1024;
+            let mut body = response.into_body();
+            let mut drained = 0usize;
+            while let Some(frame) = body.frame().await {
+                let Ok(frame) = frame else { break };
+                if let Some(data) = frame.data_ref() {
+                    drained += data.len();
+                    if drained > DRAIN_CAP {
+                        break;
+                    }
+                }
+            }
+            Ok::<u16, anyhow::Error>(status)
+        })
         .await
         .map_err(|_| anyhow::anyhow!("webhook timed out"))??;
-        let status = response.status().as_u16();
-        // Drain the body so the connection can be reused.
-        let _ = response.into_body().collect().await;
         Ok(status)
     }
 }

--- a/crates/rsearch-storage/src/fs.rs
+++ b/crates/rsearch-storage/src/fs.rs
@@ -15,9 +15,23 @@ pub struct FsStorage {
     root: PathBuf,
 }
 
+/// Process-unique counter for temp-file names: two concurrent writers of
+/// the same key must never share a temp path, or their writes interleave
+/// and the rename can publish a corrupt object.
+static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 impl FsStorage {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        let root: PathBuf = root.into();
+        // Failed writes delete their temp on the error path, but a crash
+        // can still strand one, and `list` deliberately hides temp names —
+        // sweep leftovers in the background so they don't hold disk
+        // forever. A file is a leftover only if no writer is running,
+        // which holds at construction time (one FsStorage per process,
+        // built before serving).
+        let sweep_root = root.clone();
+        std::thread::spawn(move || sweep_temp_files(&sweep_root));
+        Self { root }
     }
 
     /// Resolve a key to a path under root, rejecting traversal. Keys are
@@ -67,24 +81,70 @@ impl FsStorage {
     }
 
     /// Atomic write: write to a temp sibling then rename over the key.
+    /// The temp name is process-unique (concurrent writers of one key can
+    /// never interleave into a shared temp) and removed on any failure.
     async fn write_atomic(&self, key: &str, data: &[u8]) -> StorageResult<()> {
         let path = self.resolve(key)?;
         self.prepare_parent(&path, key).await?;
-        let tmp = path.with_extension(format!(
-            "tmp-{}",
-            std::process::id() as u64 ^ path.as_os_str().len() as u64
-        ));
-        let mut file = tokio::fs::File::create(&tmp)
-            .await
-            .map_err(|e| Self::io_err(key, e))?;
-        file.write_all(data).await.map_err(|e| Self::io_err(key, e))?;
-        file.sync_all().await.map_err(|e| Self::io_err(key, e))?;
-        tokio::fs::rename(&tmp, &path)
-            .await
-            .map_err(|e| Self::io_err(key, e))?;
+        let tmp = self.unique_tmp(&path);
+        let result = async {
+            let mut file = tokio::fs::File::create(&tmp)
+                .await
+                .map_err(|e| Self::io_err(key, e))?;
+            file.write_all(data).await.map_err(|e| Self::io_err(key, e))?;
+            file.sync_all().await.map_err(|e| Self::io_err(key, e))?;
+            tokio::fs::rename(&tmp, &path)
+                .await
+                .map_err(|e| Self::io_err(key, e))
+        }
+        .await;
+        if let Err(e) = result {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(e);
+        }
         self.sync_parent(&path, key).await?;
         Ok(())
     }
+
+    fn unique_tmp(&self, path: &Path) -> PathBuf {
+        let seq = TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        path.with_extension(format!("tmp-{}-{seq}", std::process::id()))
+    }
+}
+
+/// Recursively delete leftover temp files (`*.tmp-*`) under `dir`. Failed
+/// writes remove their temp on the error path, but a crash strands them,
+/// and `list` deliberately hides temp names — without this sweep they
+/// hold disk forever. Only temps past a generous age are removed: the
+/// sweep runs on a background thread concurrently with live writers, and
+/// an in-flight write's temp is always fresh. Best-effort: errors ignored.
+fn sweep_temp_files(dir: &Path) {
+    const MIN_LEFTOVER_AGE: std::time::Duration = std::time::Duration::from_secs(3600);
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_dir() {
+            sweep_temp_files(&path);
+        } else if entry.file_name().to_string_lossy().contains(".tmp-")
+            && entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .ok()
+                .and_then(|t| t.elapsed().ok())
+                .map(|age| age > MIN_LEFTOVER_AGE)
+                .unwrap_or(false)
+        {
+            let _ = std::fs::remove_file(&path);
+        }
+    }
+}
+
+impl FsStorage {
 
     /// Atomic streamed write for peer transfers: chunks land in a temp
     /// sibling, fsync, rename, parent fsync — same durability discipline
@@ -196,30 +256,37 @@ impl Storage for FsStorage {
     async fn put_file(&self, key: &str, local: &Path) -> StorageResult<()> {
         let path = self.resolve(key)?;
         self.prepare_parent(&path, key).await?;
-        let tmp = path.with_extension("tmp-upload");
-        // Publish via hard link when the staging dir and the storage root
-        // share a filesystem (both usually live under data_dir) — a copy
-        // would rewrite every split byte a second time (2x publish write
-        // amplification). Cross-device or unsupported links fall back to
-        // the copy. The link target must not exist, so clear any leftover
-        // temp from a crashed earlier attempt first.
-        let _ = tokio::fs::remove_file(&tmp).await;
-        if tokio::fs::hard_link(local, &tmp).await.is_err() {
-            tokio::fs::copy(local, &tmp)
+        // Process-unique temp (see write_atomic) — a fresh name also means
+        // the hard link below never collides with a leftover.
+        let tmp = self.unique_tmp(&path);
+        let result = async {
+            // Publish via hard link when the staging dir and the storage
+            // root share a filesystem (both usually live under data_dir) —
+            // a copy would rewrite every split byte a second time (2x
+            // publish write amplification). Cross-device or unsupported
+            // links fall back to the copy.
+            if tokio::fs::hard_link(local, &tmp).await.is_err() {
+                tokio::fs::copy(local, &tmp)
+                    .await
+                    .map_err(|e| Self::io_err(key, e))?;
+            }
+            // Durability: fsync the data before it becomes visible, so the
+            // ingest WAL is only truncated after the split is truly on disk.
+            {
+                let file = tokio::fs::File::open(&tmp)
+                    .await
+                    .map_err(|e| Self::io_err(key, e))?;
+                file.sync_all().await.map_err(|e| Self::io_err(key, e))?;
+            }
+            tokio::fs::rename(&tmp, &path)
                 .await
-                .map_err(|e| Self::io_err(key, e))?;
+                .map_err(|e| Self::io_err(key, e))
         }
-        // Durability: fsync the data before it becomes visible, so the
-        // ingest WAL is only truncated after the split is truly on disk.
-        {
-            let file = tokio::fs::File::open(&tmp)
-                .await
-                .map_err(|e| Self::io_err(key, e))?;
-            file.sync_all().await.map_err(|e| Self::io_err(key, e))?;
+        .await;
+        if let Err(e) = result {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            return Err(e);
         }
-        tokio::fs::rename(&tmp, &path)
-            .await
-            .map_err(|e| Self::io_err(key, e))?;
         self.sync_parent(&path, key).await?;
         Ok(())
     }

--- a/ui/app/access/page.tsx
+++ b/ui/app/access/page.tsx
@@ -14,15 +14,22 @@ export default function AccessPage() {
   const [userForm, setUserForm] = useState({ name: "", password: "", role: "user" });
   const [keyForm, setKeyForm] = useState({ name: "", actions: "ingest", streams: "*" });
 
-  const load = () => {
-    rq<{ users: User[] }>("/_rsearch/users")
+  const load = (signal?: AbortSignal) => {
+    rq<{ users: User[] }>("/_rsearch/users", { signal })
       .then((r) => setUsers(r.users))
-      .catch((e) => setError(String((e as Error).message ?? e)));
-    rq<{ api_keys: ApiKey[] }>("/_rsearch/api_keys")
+      .catch((e) => {
+        if (signal?.aborted) return;
+        setError(String((e as Error).message ?? e));
+      });
+    rq<{ api_keys: ApiKey[] }>("/_rsearch/api_keys", { signal })
       .then((r) => setKeys(r.api_keys))
       .catch(() => {});
   };
-  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
+  }, []);
 
   async function saveUser(e: React.FormEvent) {
     e.preventDefault();

--- a/ui/app/alerts/page.tsx
+++ b/ui/app/alerts/page.tsx
@@ -32,12 +32,17 @@ export default function AlertsPage() {
   const [form, setForm] = useState({ ...EMPTY });
   const [error, setError] = useState("");
 
-  const load = () =>
-    rq<{ alerts: Alert[] }>("/_rsearch/alerts")
+  const load = (signal?: AbortSignal) =>
+    rq<{ alerts: Alert[] }>("/_rsearch/alerts", { signal })
       .then((r) => setAlerts(r.alerts))
-      .catch((e) => setError(String((e as Error).message ?? e)));
+      .catch((e) => {
+        if (signal?.aborted) return;
+        setError(String((e as Error).message ?? e));
+      });
   useEffect(() => {
-    load();
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
   }, []);
 
   async function save(e: React.FormEvent) {

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError, Hit, StreamInfo, rq, search } from "@/lib/api";
 import { useRouter } from "next/navigation";
 
@@ -39,37 +39,60 @@ export default function SearchPage() {
   const [error, setError] = useState("");
   const [open, setOpen] = useState<string | null>(null);
 
+  // Latest query text for auto-runs, tracked outside runSearch's identity
+  // so typing doesn't re-create the callback (and fire the auto-run
+  // effect) per keystroke.
+  const queryRef = useRef(query);
   useEffect(() => {
-    rq<StreamInfo[]>("/_cat/indices")
+    queryRef.current = query;
+  }, [query]);
+  // In-flight search; superseded/unmounted requests are aborted so a slow
+  // older response can never overwrite a newer result.
+  const abortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    rq<StreamInfo[]>("/_cat/indices", { signal: controller.signal })
       .then((list) => {
         setStreams(list);
-        if (list.length && !stream) setStream(list[0].index);
+        if (list.length) setStream((current) => current || list[0].index);
       })
       .catch((e: unknown) => {
+        if (controller.signal.aborted) return;
         if (e instanceof ApiError && e.status === 401) router.push("/login");
         else setError(String((e as Error).message ?? e));
       });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    return () => controller.abort();
+  }, [router]);
 
-  const run = useCallback(() => {
-    if (!stream) return;
-    const from = range.millis ? Date.now() - range.millis : null;
-    search(stream, query, from)
-      .then((result) => {
-        setHits(result.hits);
-        setTotal(result.total);
-        setError("");
-      })
-      .catch((e: unknown) => {
-        if (e instanceof ApiError && e.status === 401) router.push("/login");
-        else setError(String((e as Error).message ?? e));
-      });
-  }, [stream, query, range, router]);
+  const runSearch = useCallback(
+    (q: string) => {
+      if (!stream) return;
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+      const from = range.millis ? Date.now() - range.millis : null;
+      search(stream, q, from, 100, controller.signal)
+        .then((result) => {
+          setHits(result.hits);
+          setTotal(result.total);
+          setError("");
+        })
+        .catch((e: unknown) => {
+          if (controller.signal.aborted) return;
+          if (e instanceof ApiError && e.status === 401) router.push("/login");
+          else setError(String((e as Error).message ?? e));
+        });
+    },
+    [stream, range, router],
+  );
 
+  // Auto-run only when the stream or window changes — typing in the query
+  // box searches on Enter or the button, not per keystroke.
   useEffect(() => {
-    run();
-  }, [stream, range, run]);
+    runSearch(queryRef.current);
+    return () => abortRef.current?.abort();
+  }, [runSearch]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -97,7 +120,7 @@ export default function SearchPage() {
             placeholder='status:500 AND "timeout"  (blank matches everything)'
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && run()}
+            onKeyDown={(e) => e.key === "Enter" && runSearch(query)}
           />
         </div>
         <div className="w-32">
@@ -115,7 +138,7 @@ export default function SearchPage() {
             ))}
           </select>
         </div>
-        <button className="btn" onClick={run}>
+        <button className="btn" onClick={() => runSearch(query)}>
           Search
         </button>
       </div>

--- a/ui/app/streams/page.tsx
+++ b/ui/app/streams/page.tsx
@@ -8,12 +8,17 @@ export default function StreamsPage() {
   const [error, setError] = useState("");
   const [saved, setSaved] = useState("");
 
-  const load = () =>
-    rq<StreamInfo[]>("/_cat/indices")
+  const load = (signal?: AbortSignal) =>
+    rq<StreamInfo[]>("/_cat/indices", { signal })
       .then(setStreams)
-      .catch((e) => setError(String((e as Error).message ?? e)));
+      .catch((e) => {
+        if (signal?.aborted) return;
+        setError(String((e as Error).message ?? e));
+      });
   useEffect(() => {
-    load();
+    const controller = new AbortController();
+    load(controller.signal);
+    return () => controller.abort();
   }, []);
 
   // Retention saves as soon as the value changes.

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -75,6 +75,7 @@ export async function search(
   query: string,
   fromMillis: number | null,
   size = 100,
+  signal?: AbortSignal,
 ): Promise<{ total: number; hits: Hit[] }> {
   const filters: unknown[] = [];
   if (fromMillis)
@@ -90,6 +91,7 @@ export async function search(
   }>(`/${encodeURIComponent(index)}/_search`, {
     method: "POST",
     body: JSON.stringify(body),
+    signal,
   });
   return { total: result.hits.total.value, hits: result.hits.hits };
 }


### PR DESCRIPTION
Closes #8. Stacked on #9 (the #7 performance PR) — merge that first; the three findings shared between the audits (executor `opening` map, cache eviction scan, merge memory) were fixed there.

## High
- **H1** — stream workers now retire after 10 minutes idle: the worker unpublishes its map entry, closes its channel, drains and flushes stragglers, then exits; `enqueue` retries once on a closed channel so the narrow race simply re-creates a fresh worker. User-controlled stream names (e.g. daily `logs-YYYY.MM.DD` indices) no longer pin an immortal task + bounded queue + `MappedSchema` each for the life of the process.
- **H2** — the webhook timeout now wraps the entire exchange including the body drain, and draining is capped at 64KB (larger/never-ending bodies are abandoned, closing the connection). A slow-dripping webhook endpoint can no longer stall `ControlPlane::tick()` — which runs merge, retention, GC, repair, drain, and dead-node expiry — indefinitely while holding leadership.

## Medium
- **M2** — `write_atomic`/`put_file` use process-unique counter temp names (two concurrent writers of one key can never interleave into a shared temp and rename a corrupt object into place) and remove the temp on any failure; a background sweep deletes `*.tmp-*` leftovers older than 1 hour (age-gated so it can never race an in-flight write).
- **M3** — `flush` retries forever with capped backoff instead of giving up after ~1 minute; batches are never stranded invisible-to-search with pinned WAL segments until an operator restart. Escalates to error-level logging every 8th attempt.
- **M4** — `_msearch` pairs execute through `buffered(available_parallelism)` instead of `join_all`, so one request with thousands of tiny pairs can't saturate the blocking pool it shares with bulk WAL appends.
- **M5** — input accept loops log and back off 500ms on error (no more silent busy-spin under fd exhaustion), and each TCP input caps concurrent connections at 1024 with a semaphore.
- **M6** — the console search page no longer issues a request per keystroke: auto-run depends only on stream/window, Enter/button search the current query, and superseded in-flight requests are aborted so a slow older response can't overwrite a newer result.

## Low
- **L1** — the test-only `env::set_var` unsafe is gone (replaced with the `temp-env` dev-dependency). ⚠️ The production `memmap2::Mmap::map` unsafe in `rsearch-index/src/reader.rs` remains — it's required for Tantivy's file handles. Flagging per your unsafe-approval rule: say the word if you want it revisited.
- **L2** — WAL segment-tracking `expect()` now returns an `io::Error`; the bulk-API position `expect()` now fails the single item with a 500 instead of panicking the handler.
- **L3** — auth distinguishes metastore errors (503, shippers back off and retry) from definitely-bad credentials (401, shippers stop). A DB blip no longer kills log pipelines.
- **L4** — replay's worker-gone path confirms the WAL position and decrements the queue-depth gauge instead of leaking both.
- **L5** — the control-plane split cache honors `search.cache_max_mb` instead of a hard-coded 1GiB.
- **L8** — mount fetches on all console pages carry AbortControllers (no unmounted setState / out-of-order overwrites).
- **L9** — the msearch parser returns a 400 for a trailing unpaired header instead of silently dropping it; loop bound simplified to `i + 1 < lines.len()`.
- **L10** — `splits_for_query` is LIMIT-bounded; a query spanning more than 10k splits returns a clear "narrow the time range" error instead of materializing every split row.

`cargo check --workspace --all-targets` clean, tests pass (3 consecutive full runs), ESLint clean, `next build` succeeds.