### PR TITLE
Fix #11: Loki-compatible query API subset (Grafana Loki datasource + Logs Drilldown)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "serde_json",
+ "time",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3292,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "num-conv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,7 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "tracing",
 ]
@@ -554,6 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -572,8 +573,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -787,7 +790,7 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1067,6 +1070,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "datasketches"
@@ -1395,14 +1404,26 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2160,6 +2181,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,9 +2219,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -2201,7 +2247,26 @@ checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2402,6 +2467,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
+ "regex",
  "rsearch-common",
  "rsearch-index",
  "rsearch-ingest",
@@ -2662,6 +2728,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -2880,7 +2957,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "sqlx-core",
  "thiserror",
@@ -2910,7 +2987,7 @@ dependencies = [
  "log",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3318,6 +3395,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,6 +3546,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror",
+]
 
 [[package]]
 name = "typeid"
@@ -3619,6 +3724,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3809,6 +3923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,6 +3961,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.1.0" }
 rsearch-search = { path = "crates/rsearch-search", version = "0.1.0" }
 
 tokio = { version = "1", features = ["full"] }
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -203,6 +203,35 @@ percentiles, cardinality, …).
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.
 
+### Loki-compatible API (Grafana Logs Drilldown)
+
+rSearch also speaks a subset of Loki's HTTP query API, so Grafana's
+built-in **Loki datasource** — and with it **Logs Drilldown** — works
+with no plugins: point a Loki datasource at the rSearch URL (Basic auth
+or an API key as a bearer credential) and browse.
+
+| Endpoint | Notes |
+|----------|-------|
+| `GET/POST /loki/api/v1/query_range` | log selectors → `streams`, metric queries → `matrix` |
+| `GET/POST /loki/api/v1/query` | instant queries |
+| `GET /loki/api/v1/labels`, `/label/{name}/values` | label discovery |
+| `GET/POST /loki/api/v1/series` | series matching |
+| `GET/POST /loki/api/v1/index/volume`, `/index/volume_range` | Drilldown's volume breakdowns |
+| `GET /loki/api/v1/tail` | WebSocket live tail (poll-backed) |
+| `GET /ready` | Loki readiness probe (open, like `/health`) |
+
+Model mapping: the `service_name` label is the stream name (every stream
+appears as a browsable service); other labels are the stream's
+keyword-mapped fields, with values served from terms aggregations
+(capped at 1000). A log line is the doc's `message` field, or the raw
+`_source` JSON when there is none.
+
+LogQL coverage is the subset Grafana sends: selectors with
+`=`, `!=`, `=~`, `!~`; line filters `|=` and `!=` (regex line filters
+return a clear error); `count_over_time` and `rate`, optionally wrapped
+in `sum` / `sum by (label)`. Like `/_msearch`, the Loki surface requires
+search-level auth with global stream access.
+
 `GET /metrics` serves Prometheus text format: ingest throughput and
 queue depth, WAL backlog (`rsearch_wal_outstanding_records` — watch this
 for restart-replay memory pressure), cluster node liveness/draining

--- a/README.md
+++ b/README.md
@@ -227,10 +227,21 @@ keyword-mapped fields, with values served from terms aggregations
 `_source` JSON when there is none.
 
 LogQL coverage is the subset Grafana sends: selectors with
-`=`, `!=`, `=~`, `!~`; line filters `|=` and `!=` (regex line filters
-return a clear error); `count_over_time` and `rate`, optionally wrapped
-in `sum` / `sum by (label)`. Like `/_msearch`, the Loki surface requires
-search-level auth with global stream access.
+`=`, `!=`, `=~`, `!~`; line filters `|=`, `!=`, `|~`, `!~`;
+`count_over_time` and `rate` (correct sliding-window math for any
+step/range combination), optionally wrapped in `sum` / `sum by (label)`
+— one grouping label. Like `/_msearch`, the Loki surface requires
+search-level auth with global stream access, and selectors must contain
+at least one matcher that doesn't match the empty string.
+
+Line filters are true substring/regex tests against the rendered line —
+never a tokenized index match that could miss "error" when searching
+"err". The trade-off: a filtered query (or filtered metric) examines up
+to 5000 selector-matching docs per stream, newest first, and sets a
+response warning when that scan window saturates. Per-stream failures in
+multi-stream queries degrade to `warnings` with partial results instead
+of failing the whole query. Tails are capped at 16 concurrent sessions
+and 1 hour per session, with WebSocket pings reaping dead peers.
 
 `GET /metrics` serves Prometheus text format: ingest throughput and
 queue depth, WAL backlog (`rsearch_wal_outstanding_records` — watch this

--- a/crates/rsearch-search/src/lib.rs
+++ b/crates/rsearch-search/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod error;
 mod executor;
+pub mod logql;
 mod query_dsl;
 
 pub use error::{SearchError, SearchResult};

--- a/crates/rsearch-search/src/logql.rs
+++ b/crates/rsearch-search/src/logql.rs
@@ -156,13 +156,44 @@ impl<'a> Parser<'a> {
                         Some(b'\\') => {
                             self.pos += 1;
                             match self.peek() {
-                                Some(b'n') => out.push('\n'),
-                                Some(b't') => out.push('\t'),
-                                Some(b'r') => out.push('\r'),
-                                Some(other) => out.push(other as char),
+                                Some(b'n') => {
+                                    out.push('\n');
+                                    self.pos += 1;
+                                }
+                                Some(b't') => {
+                                    out.push('\t');
+                                    self.pos += 1;
+                                }
+                                Some(b'r') => {
+                                    out.push('\r');
+                                    self.pos += 1;
+                                }
+                                // Go-style hex/unicode escapes (LogQL strings
+                                // follow Go string literal syntax).
+                                Some(b'x') => {
+                                    self.pos += 1;
+                                    out.push(self.hex_escape(2)?);
+                                }
+                                Some(b'u') => {
+                                    self.pos += 1;
+                                    out.push(self.hex_escape(4)?);
+                                }
+                                Some(b'U') => {
+                                    self.pos += 1;
+                                    out.push(self.hex_escape(8)?);
+                                }
+                                Some(_) => {
+                                    // Any other escaped char passes through
+                                    // verbatim — decoded as a full UTF-8
+                                    // scalar, not a single byte.
+                                    let rest = std::str::from_utf8(&self.input[self.pos..])
+                                        .map_err(|_| "invalid UTF-8 in string".to_string())?;
+                                    let ch = rest.chars().next().unwrap();
+                                    out.push(ch);
+                                    self.pos += ch.len_utf8();
+                                }
                                 None => return Err("unterminated escape".into()),
                             }
-                            self.pos += 1;
                         }
                         Some(_) => {
                             // Consume one UTF-8 scalar, not one byte.
@@ -190,6 +221,18 @@ impl<'a> Parser<'a> {
             }
             _ => Err(format!("expected string at byte {}", self.pos)),
         }
+    }
+
+    /// `\xNN` / `\uNNNN` / `\UNNNNNNNN` escape body: `digits` hex chars.
+    fn hex_escape(&mut self, digits: usize) -> Result<char, String> {
+        if self.pos + digits > self.input.len() {
+            return Err("truncated hex escape".into());
+        }
+        let text = std::str::from_utf8(&self.input[self.pos..self.pos + digits])
+            .map_err(|_| "invalid hex escape".to_string())?;
+        let code = u32::from_str_radix(text, 16).map_err(|_| "invalid hex escape".to_string())?;
+        self.pos += digits;
+        char::from_u32(code).ok_or_else(|| "escape is not a valid scalar".to_string())
     }
 
     /// `[5m]`-style range: sequence of number+unit components.
@@ -391,6 +434,18 @@ mod tests {
         let q = parse("{}").unwrap();
         let LogQlQuery::Log(sel) = q else { panic!() };
         assert!(sel.matchers.is_empty());
+    }
+
+    #[test]
+    fn string_escapes() {
+        let q = parse(r#"{a="\u0041\x42-\"q\"-é"}"#).unwrap();
+        let LogQlQuery::Log(sel) = q else { panic!() };
+        assert_eq!(sel.matchers[0].value, "AB-\"q\"-é");
+        // Escaped multibyte char passes through without desyncing.
+        let q = parse("{a=\"\\é\"}").unwrap();
+        let LogQlQuery::Log(sel) = q else { panic!() };
+        assert_eq!(sel.matchers[0].value, "é");
+        assert!(parse(r#"{a="\uD800"}"#).is_err()); // surrogate: not a scalar
     }
 
     #[test]

--- a/crates/rsearch-search/src/logql.rs
+++ b/crates/rsearch-search/src/logql.rs
@@ -1,0 +1,403 @@
+//! LogQL parser subset for the Loki-compatible API (#11): stream
+//! selectors with label matchers, line filters, and the metric wrappers
+//! Grafana's Loki datasource and Logs Drilldown actually send —
+//! `count_over_time`, `rate`, optionally wrapped in `sum` / `sum by (…)`.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchOp {
+    Eq,
+    Neq,
+    Re,
+    NotRe,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabelMatcher {
+    pub label: String,
+    pub op: MatchOp,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterOp {
+    Contains,    // |=
+    NotContains, // !=
+    Regex,       // |~
+    NotRegex,    // !~
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LineFilter {
+    pub op: FilterOp,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct LogSelector {
+    pub matchers: Vec<LabelMatcher>,
+    pub filters: Vec<LineFilter>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricOp {
+    CountOverTime,
+    Rate,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MetricQuery {
+    pub selector: LogSelector,
+    pub range_millis: i64,
+    pub op: MetricOp,
+    /// Labels from `sum by (…)`; empty for plain `sum(…)` or no sum.
+    pub group_by: Vec<String>,
+    /// Whether a `sum` wrapper was present: `sum(rate(…))` collapses all
+    /// series into one, while bare `rate(…)` keeps one series per stream.
+    pub summed: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogQlQuery {
+    Log(LogSelector),
+    Metric(MetricQuery),
+}
+
+impl LogSelector {
+    /// The value of an `=`-matcher for `label`, if present.
+    pub fn eq_value(&self, label: &str) -> Option<&str> {
+        self.matchers
+            .iter()
+            .find(|m| m.label == label && m.op == MatchOp::Eq)
+            .map(|m| m.value.as_str())
+    }
+}
+
+struct Parser<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+pub fn parse(input: &str) -> Result<LogQlQuery, String> {
+    let mut parser = Parser {
+        input: input.as_bytes(),
+        pos: 0,
+    };
+    let query = parser.query()?;
+    parser.skip_ws();
+    if parser.pos != parser.input.len() {
+        return Err(format!(
+            "unexpected trailing input at byte {}: {:?}",
+            parser.pos,
+            &input[parser.pos..]
+        ));
+    }
+    Ok(query)
+}
+
+impl<'a> Parser<'a> {
+    fn skip_ws(&mut self) {
+        while self.pos < self.input.len() && self.input[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn eat(&mut self, token: &str) -> bool {
+        self.skip_ws();
+        if self.input[self.pos..].starts_with(token.as_bytes()) {
+            self.pos += token.len();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn expect(&mut self, token: &str) -> Result<(), String> {
+        if self.eat(token) {
+            Ok(())
+        } else {
+            Err(format!("expected '{token}' at byte {}", self.pos))
+        }
+    }
+
+    fn ident(&mut self) -> Result<String, String> {
+        self.skip_ws();
+        let start = self.pos;
+        while self
+            .peek()
+            .map(|b| b.is_ascii_alphanumeric() || b == b'_')
+            .unwrap_or(false)
+        {
+            self.pos += 1;
+        }
+        if self.pos == start {
+            return Err(format!("expected identifier at byte {}", self.pos));
+        }
+        Ok(String::from_utf8_lossy(&self.input[start..self.pos]).into_owned())
+    }
+
+    /// Double-quoted string with escapes, or a backtick raw string.
+    fn string(&mut self) -> Result<String, String> {
+        self.skip_ws();
+        match self.peek() {
+            Some(b'"') => {
+                self.pos += 1;
+                let mut out = String::new();
+                loop {
+                    match self.peek() {
+                        None => return Err("unterminated string".into()),
+                        Some(b'"') => {
+                            self.pos += 1;
+                            return Ok(out);
+                        }
+                        Some(b'\\') => {
+                            self.pos += 1;
+                            match self.peek() {
+                                Some(b'n') => out.push('\n'),
+                                Some(b't') => out.push('\t'),
+                                Some(b'r') => out.push('\r'),
+                                Some(other) => out.push(other as char),
+                                None => return Err("unterminated escape".into()),
+                            }
+                            self.pos += 1;
+                        }
+                        Some(_) => {
+                            // Consume one UTF-8 scalar, not one byte.
+                            let rest = std::str::from_utf8(&self.input[self.pos..])
+                                .map_err(|_| "invalid UTF-8 in string".to_string())?;
+                            let ch = rest.chars().next().unwrap();
+                            out.push(ch);
+                            self.pos += ch.len_utf8();
+                        }
+                    }
+                }
+            }
+            Some(b'`') => {
+                self.pos += 1;
+                let start = self.pos;
+                while self.peek().map(|b| b != b'`').unwrap_or(false) {
+                    self.pos += 1;
+                }
+                if self.peek().is_none() {
+                    return Err("unterminated raw string".into());
+                }
+                let out = String::from_utf8_lossy(&self.input[start..self.pos]).into_owned();
+                self.pos += 1;
+                Ok(out)
+            }
+            _ => Err(format!("expected string at byte {}", self.pos)),
+        }
+    }
+
+    /// `[5m]`-style range: sequence of number+unit components.
+    fn duration_millis(&mut self) -> Result<i64, String> {
+        self.skip_ws();
+        let mut total: i64 = 0;
+        let mut any = false;
+        loop {
+            let start = self.pos;
+            while self.peek().map(|b| b.is_ascii_digit()).unwrap_or(false) {
+                self.pos += 1;
+            }
+            if self.pos == start {
+                break;
+            }
+            let n: i64 = std::str::from_utf8(&self.input[start..self.pos])
+                .unwrap()
+                .parse()
+                .map_err(|_| "duration number too large".to_string())?;
+            let unit_millis = if self.eat("ms") {
+                1
+            } else if self.eat("s") {
+                1000
+            } else if self.eat("m") {
+                60_000
+            } else if self.eat("h") {
+                3_600_000
+            } else if self.eat("d") {
+                86_400_000
+            } else if self.eat("w") {
+                7 * 86_400_000
+            } else {
+                return Err(format!("expected duration unit at byte {}", self.pos));
+            };
+            total = total.saturating_add(n.saturating_mul(unit_millis));
+            any = true;
+        }
+        if !any {
+            return Err(format!("expected duration at byte {}", self.pos));
+        }
+        Ok(total)
+    }
+
+    fn query(&mut self) -> Result<LogQlQuery, String> {
+        self.skip_ws();
+        // sum [by (l1, l2)] ( <range-fn> ) — or a bare range-fn/selector.
+        if self.eat("sum") {
+            let mut group_by = Vec::new();
+            if self.eat("by") {
+                self.expect("(")?;
+                loop {
+                    group_by.push(self.ident()?);
+                    if !self.eat(",") {
+                        break;
+                    }
+                }
+                self.expect(")")?;
+            }
+            self.expect("(")?;
+            let mut metric = self.range_fn()?;
+            self.expect(")")?;
+            metric.group_by = group_by;
+            metric.summed = true;
+            return Ok(LogQlQuery::Metric(metric));
+        }
+        if self.looking_at_range_fn() {
+            return Ok(LogQlQuery::Metric(self.range_fn()?));
+        }
+        Ok(LogQlQuery::Log(self.selector_with_filters()?))
+    }
+
+    fn looking_at_range_fn(&self) -> bool {
+        let rest = &self.input[self.pos..];
+        rest.starts_with(b"count_over_time") || rest.starts_with(b"rate")
+    }
+
+    fn range_fn(&mut self) -> Result<MetricQuery, String> {
+        self.skip_ws();
+        let op = if self.eat("count_over_time") {
+            MetricOp::CountOverTime
+        } else if self.eat("rate") {
+            MetricOp::Rate
+        } else {
+            return Err(format!(
+                "expected count_over_time or rate at byte {} (supported metric functions)",
+                self.pos
+            ));
+        };
+        self.expect("(")?;
+        let selector = self.selector_with_filters()?;
+        self.expect("[")?;
+        let range_millis = self.duration_millis()?;
+        self.expect("]")?;
+        self.expect(")")?;
+        Ok(MetricQuery {
+            selector,
+            range_millis,
+            op,
+            group_by: Vec::new(),
+            summed: false,
+        })
+    }
+
+    fn selector_with_filters(&mut self) -> Result<LogSelector, String> {
+        self.expect("{")?;
+        let mut matchers = Vec::new();
+        self.skip_ws();
+        if self.peek() != Some(b'}') {
+            loop {
+                let label = self.ident()?;
+                self.skip_ws();
+                let op = if self.eat("=~") {
+                    MatchOp::Re
+                } else if self.eat("!~") {
+                    MatchOp::NotRe
+                } else if self.eat("!=") {
+                    MatchOp::Neq
+                } else if self.eat("=") {
+                    MatchOp::Eq
+                } else {
+                    return Err(format!("expected label operator at byte {}", self.pos));
+                };
+                let value = self.string()?;
+                matchers.push(LabelMatcher { label, op, value });
+                if !self.eat(",") {
+                    break;
+                }
+            }
+        }
+        self.expect("}")?;
+
+        let mut filters = Vec::new();
+        loop {
+            self.skip_ws();
+            let op = if self.eat("|=") {
+                FilterOp::Contains
+            } else if self.eat("!=") {
+                FilterOp::NotContains
+            } else if self.eat("|~") {
+                FilterOp::Regex
+            } else if self.eat("!~") {
+                FilterOp::NotRegex
+            } else {
+                break;
+            };
+            let text = self.string()?;
+            filters.push(LineFilter { op, text });
+        }
+        Ok(LogSelector { matchers, filters })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_selector_and_filters() {
+        let q = parse(r#"{service_name="api", level!="debug"} |= "timeout" != `retry`"#).unwrap();
+        let LogQlQuery::Log(sel) = q else { panic!() };
+        assert_eq!(sel.matchers.len(), 2);
+        assert_eq!(sel.eq_value("service_name"), Some("api"));
+        assert_eq!(sel.matchers[1].op, MatchOp::Neq);
+        assert_eq!(sel.filters.len(), 2);
+        assert_eq!(sel.filters[0].op, FilterOp::Contains);
+        assert_eq!(sel.filters[1].op, FilterOp::NotContains);
+        assert_eq!(sel.filters[1].text, "retry");
+    }
+
+    #[test]
+    fn parses_metric_wrappers() {
+        let q = parse(r#"sum by (level) (count_over_time({service_name="api"} |= "err" [5m]))"#)
+            .unwrap();
+        let LogQlQuery::Metric(m) = q else { panic!() };
+        assert_eq!(m.op, MetricOp::CountOverTime);
+        assert_eq!(m.range_millis, 300_000);
+        assert_eq!(m.group_by, vec!["level"]);
+        assert_eq!(m.selector.filters.len(), 1);
+
+        let q = parse(r#"rate({service_name="api"}[1m30s])"#).unwrap();
+        let LogQlQuery::Metric(m) = q else { panic!() };
+        assert_eq!(m.op, MetricOp::Rate);
+        assert_eq!(m.range_millis, 90_000);
+        assert!(m.group_by.is_empty());
+
+        let q = parse(r#"sum(count_over_time({app="x"}[1h]))"#).unwrap();
+        let LogQlQuery::Metric(m) = q else { panic!() };
+        assert!(m.group_by.is_empty());
+        assert!(m.summed);
+        assert_eq!(m.range_millis, 3_600_000);
+    }
+
+    #[test]
+    fn parses_regex_matchers_and_empty_selector() {
+        let q = parse(r#"{service_name=~"app-.+"}"#).unwrap();
+        let LogQlQuery::Log(sel) = q else { panic!() };
+        assert_eq!(sel.matchers[0].op, MatchOp::Re);
+
+        let q = parse("{}").unwrap();
+        let LogQlQuery::Log(sel) = q else { panic!() };
+        assert!(sel.matchers.is_empty());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(parse("").is_err());
+        assert!(parse("{unclosed=\"x\"").is_err());
+        assert!(parse(r#"avg(count_over_time({a="b"}[5m]))"#).is_err());
+        assert!(parse(r#"{a="b"} trailing"#).is_err());
+    }
+}

--- a/crates/rsearch-server/Cargo.toml
+++ b/crates/rsearch-server/Cargo.toml
@@ -41,3 +41,4 @@ serde.workspace = true
 tokio-util.workspace = true
 async-trait.workspace = true
 regex = "1.13.1"
+time = { version = "0.3.55", features = ["parsing", "formatting"] }

--- a/crates/rsearch-server/Cargo.toml
+++ b/crates/rsearch-server/Cargo.toml
@@ -40,3 +40,4 @@ url.workspace = true
 serde.workspace = true
 tokio-util.workspace = true
 async-trait.workspace = true
+regex = "1.13.1"

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -411,6 +411,17 @@ mod tests {
             Action::Search(Some("app-logs".into()))
         );
         assert_eq!(classify("GET", "/_cat/indices"), Action::Search(None));
+        // Loki-compatible surface: everything under /loki/api/v1 needs
+        // global search access; /ready is health-equivalent and open.
+        assert_eq!(classify("GET", "/loki/api/v1/query_range"), Action::Search(None));
+        assert_eq!(classify("POST", "/loki/api/v1/query"), Action::Search(None));
+        assert_eq!(
+            classify("GET", "/loki/api/v1/label/level/values"),
+            Action::Search(None)
+        );
+        assert_eq!(classify("GET", "/loki/api/v1/tail"), Action::Search(None));
+        assert_eq!(classify("GET", "/loki/api/v1/index/volume"), Action::Search(None));
+        assert_eq!(classify("GET", "/ready"), Action::Open);
         assert_eq!(classify("PUT", "/app-logs"), Action::Admin);
         assert_eq!(classify("PUT", "/_rsearch/users/alice"), Action::Admin);
         assert_eq!(

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -168,9 +168,14 @@ enum Action {
 fn classify(method: &str, path: &str) -> Action {
     let segments: Vec<&str> = path.trim_matches('/').split('/').collect();
     match (method, segments.as_slice()) {
-        // Open surface: handshake, health, login.
+        // Open surface: handshake, health, login. `/ready` is the Loki
+        // readiness probe — health-equivalent, no data exposure.
         (_, [""]) | (_, ["health"]) | (_, ["_cluster", "health"]) => Action::Open,
+        (_, ["ready"]) => Action::Open,
         ("POST", ["_rsearch", "login"]) => Action::Open,
+        // Loki-compatible read API (#11): selectors may span any stream,
+        // so like /_msearch it needs global search access.
+        (_, ["loki", "api", "v1", ..]) => Action::Search(None),
         // Ingest
         ("POST", ["_bulk"]) => Action::Ingest(None),
         ("POST", [index, "_bulk"]) => Action::Ingest(Some(index.to_string())),

--- a/crates/rsearch-server/src/loki_api.rs
+++ b/crates/rsearch-server/src/loki_api.rs
@@ -1,0 +1,944 @@
+//! Loki-compatible HTTP query API subset (#11) so Grafana's built-in
+//! Loki datasource (and Logs Drilldown) work against rSearch unmodified.
+//!
+//! Model mapping:
+//! - the `service_name` label ⇄ the rSearch stream name (Drilldown's
+//!   anchor label — every stream appears as a browsable service)
+//! - other labels ⇄ the stream's keyword-mapped fields; values come from
+//!   terms aggregations (capped at [`LABEL_VALUES_LIMIT`])
+//! - a log "line" is the doc's `message` field when present, else the
+//!   raw `_source` JSON
+//! - timestamps convert between Loki nanoseconds and rSearch millis
+//!
+//! Endpoints: query_range, query, labels, label values, series,
+//! index/volume, index/volume_range, tail (WebSocket), ready. LogQL
+//! coverage is the subset Grafana sends: selectors with =/!=/=~/!~,
+//! line filters |= and != (regex line filters are rejected with a clear
+//! error), count_over_time / rate, sum / sum by (…).
+
+use std::collections::{BTreeMap, HashMap};
+
+use axum::extract::State;
+use axum::http::{StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::{Value, json};
+
+use rsearch_search::SearchRequest;
+use rsearch_search::logql::{self, FilterOp, LogQlQuery, LogSelector, MatchOp, MetricOp, MetricQuery};
+
+use crate::state::AppState;
+
+/// Cap on distinct values returned per label.
+const LABEL_VALUES_LIMIT: usize = 1000;
+/// Bounded per-request stream fan-out.
+const STREAM_CONCURRENCY: usize = 8;
+/// Default / max entries for log queries (Loki's defaults are 100/5000).
+const DEFAULT_LIMIT: usize = 100;
+const MAX_LIMIT: usize = 5000;
+// ---------- parameter + time helpers ----------
+
+/// Merge query-string and (form-encoded) body parameters, so both the
+/// GET and POST forms Grafana uses are accepted.
+fn params(uri: &Uri, body: &str) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for source in [uri.query().unwrap_or(""), body] {
+        for (k, v) in url::form_urlencoded::parse(source.as_bytes()) {
+            out.entry(k.into_owned()).or_default().push(v.into_owned());
+        }
+    }
+    out
+}
+
+fn first<'a>(params: &'a HashMap<String, Vec<String>>, key: &str) -> Option<&'a str> {
+    params.get(key).and_then(|v| v.first()).map(String::as_str)
+}
+
+/// Loki times arrive as nanosecond epoch integers or float seconds.
+fn parse_time_ms(s: &str) -> Option<i64> {
+    if let Ok(n) = s.parse::<i128>() {
+        let ms = if n.abs() >= 100_000_000_000_000_000 {
+            n / 1_000_000 // nanoseconds
+        } else if n.abs() >= 100_000_000_000_000 {
+            n / 1_000 // microseconds
+        } else if n.abs() >= 100_000_000_000 {
+            n // milliseconds
+        } else {
+            n * 1000 // seconds
+        };
+        return i64::try_from(ms).ok();
+    }
+    s.parse::<f64>().ok().map(|secs| (secs * 1000.0) as i64)
+}
+
+/// Step arrives as float seconds ("15") or a duration string ("15s").
+fn parse_step_ms(s: &str) -> Option<i64> {
+    if let Ok(secs) = s.parse::<f64>() {
+        return Some((secs * 1000.0).max(1.0) as i64);
+    }
+    let mut total = 0i64;
+    let mut num = String::new();
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_ascii_digit() || c == '.' {
+            num.push(c);
+            continue;
+        }
+        let mut unit: String = c.to_string();
+        if let Some(&next) = chars.peek()
+            && next.is_ascii_alphabetic()
+        {
+            unit.push(next);
+            chars.next();
+        }
+        let scale = match unit.as_str() {
+            "ms" => 1.0,
+            "s" => 1000.0,
+            "m" => 60_000.0,
+            "h" => 3_600_000.0,
+            "d" => 86_400_000.0,
+            _ => return None,
+        };
+        total += (num.parse::<f64>().ok()? * scale) as i64;
+        num.clear();
+    }
+    (total > 0).then_some(total)
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn loki_error(status: StatusCode, message: &str) -> Response {
+    (
+        status,
+        Json(json!({
+            "status": "error",
+            "errorType": if status == StatusCode::BAD_REQUEST { "bad_data" } else { "internal" },
+            "error": message,
+        })),
+    )
+        .into_response()
+}
+
+fn success(data: Value) -> Response {
+    Json(json!({"status": "success", "data": data})).into_response()
+}
+
+// ---------- selector resolution ----------
+
+/// Streams a selector's `service_name` matchers allow.
+async fn resolve_streams(state: &AppState, selector: &LogSelector) -> Result<Vec<String>, String> {
+    let all = state
+        .cached_stream_names()
+        .await
+        .map_err(|e| format!("stream listing failed: {e}"))?;
+    let mut names: Vec<String> = all.iter().cloned().collect();
+    for matcher in selector.matchers.iter().filter(|m| m.label == "service_name") {
+        match matcher.op {
+            MatchOp::Eq => names.retain(|n| n == &matcher.value),
+            MatchOp::Neq => names.retain(|n| n != &matcher.value),
+            MatchOp::Re | MatchOp::NotRe => {
+                let re = anchored(&matcher.value)?;
+                let keep_match = matcher.op == MatchOp::Re;
+                names.retain(|n| re.is_match(n) == keep_match);
+            }
+        }
+    }
+    Ok(names)
+}
+
+/// Loki label regexes are fully anchored.
+fn anchored(pattern: &str) -> Result<regex::Regex, String> {
+    regex::Regex::new(&format!("^(?:{pattern})$")).map_err(|e| format!("invalid regex: {e}"))
+}
+
+/// Keyword-mapped fields of a stream — the fields exposed as labels.
+async fn label_fields(state: &AppState, stream: &str) -> Vec<String> {
+    let Ok(record) = state.metastore.get_stream(stream).await else {
+        return Vec::new();
+    };
+    let mut fields: Vec<String> = record
+        .mapping
+        .get("properties")
+        .and_then(Value::as_object)
+        .map(|props| {
+            props
+                .iter()
+                .filter(|(_, spec)| {
+                    spec.get("type").and_then(Value::as_str) == Some("keyword")
+                })
+                .map(|(name, _)| name.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    fields.sort();
+    fields
+}
+
+/// Distinct values of a label field within one stream (terms agg).
+async fn field_values(
+    state: &AppState,
+    stream: &str,
+    field: &str,
+    start_ms: Option<i64>,
+    end_ms: Option<i64>,
+) -> Vec<String> {
+    let Some(service) = state.search.clone() else {
+        return Vec::new();
+    };
+    let mut filters = vec![];
+    if start_ms.is_some() || end_ms.is_some() {
+        let mut range = serde_json::Map::new();
+        if let Some(s) = start_ms {
+            range.insert("gte".into(), json!(s));
+        }
+        if let Some(e) = end_ms {
+            range.insert("lte".into(), json!(e));
+        }
+        filters.push(json!({"range": {"@timestamp": Value::Object(range)}}));
+    }
+    let body = json!({
+        "size": 0,
+        "track_total_hits": false,
+        "query": {"bool": {"filter": filters}},
+        "aggs": {"v": {"terms": {"field": field, "size": LABEL_VALUES_LIMIT}}},
+    });
+    let Ok(request) = SearchRequest::parse(stream, &body) else {
+        return Vec::new();
+    };
+    match service.search(request).await {
+        Ok(result) => result["aggregations"]["v"]["buckets"]
+            .as_array()
+            .map(|buckets| {
+                buckets
+                    .iter()
+                    .filter_map(|b| b["key"].as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Build the ES bool query for a selector against one stream. Returns
+/// None when a matcher can never match in this stream (e.g. a regex that
+/// matches no values), so the stream is skipped entirely.
+async fn selector_query(
+    state: &AppState,
+    stream: &str,
+    selector: &LogSelector,
+    start_ms: i64,
+    end_ms: i64,
+) -> Result<Option<Value>, String> {
+    let mut filter = vec![json!({"range": {"@timestamp": {"gte": start_ms, "lte": end_ms}}})];
+    let mut must_not = vec![];
+
+    for matcher in &selector.matchers {
+        if matcher.label == "service_name" {
+            continue; // already applied via stream resolution
+        }
+        match matcher.op {
+            MatchOp::Eq => filter.push(json!({"term": {&matcher.label: matcher.value}})),
+            MatchOp::Neq => must_not.push(json!({"term": {&matcher.label: matcher.value}})),
+            MatchOp::Re | MatchOp::NotRe => {
+                let re = anchored(&matcher.value)?;
+                let values: Vec<String> = field_values(state, stream, &matcher.label, None, None)
+                    .await
+                    .into_iter()
+                    .filter(|v| re.is_match(v))
+                    .collect();
+                match matcher.op {
+                    MatchOp::Re if values.is_empty() => return Ok(None),
+                    MatchOp::Re => filter.push(json!({"terms": {&matcher.label: values}})),
+                    _ if !values.is_empty() => {
+                        must_not.push(json!({"terms": {&matcher.label: values}}));
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    for line_filter in &selector.filters {
+        match line_filter.op {
+            FilterOp::Contains => {
+                filter.push(json!({"match_phrase": {"message": line_filter.text}}));
+            }
+            FilterOp::NotContains => {
+                must_not.push(json!({"match_phrase": {"message": line_filter.text}}));
+            }
+            FilterOp::Regex | FilterOp::NotRegex => {
+                return Err(
+                    "regex line filters (|~, !~) are not supported yet; use |= / != text filters"
+                        .to_string(),
+                );
+            }
+        }
+    }
+
+    Ok(Some(json!({"bool": {"filter": filter, "must_not": must_not}})))
+}
+
+// ---------- log queries ----------
+
+struct LogHit {
+    ts_ms: i64,
+    labels: BTreeMap<String, String>,
+    line: String,
+}
+
+/// Run a log selector across its streams and return merged, direction-
+/// sorted, limit-truncated hits.
+async fn run_log_query(
+    state: &AppState,
+    selector: &LogSelector,
+    start_ms: i64,
+    end_ms: i64,
+    limit: usize,
+    forward: bool,
+) -> Result<Vec<LogHit>, String> {
+    use futures::stream::{self, StreamExt};
+    let service = state
+        .search
+        .clone()
+        .ok_or_else(|| "this node does not run the search role".to_string())?;
+    let streams = resolve_streams(state, selector).await?;
+    let order = if forward { "asc" } else { "desc" };
+
+    let futs: Vec<_> = streams
+        .iter()
+        .map(|stream| {
+            let service = service.clone();
+            async move {
+                let Some(query) = selector_query(state, stream, selector, start_ms, end_ms).await?
+                else {
+                    return Ok::<_, String>(Vec::new());
+                };
+                let fields = label_fields(state, stream).await;
+                let body = json!({
+                    "size": limit,
+                    "track_total_hits": false,
+                    "sort": [{"@timestamp": {"order": order}}],
+                    "query": query,
+                });
+                let request = SearchRequest::parse(stream, &body).map_err(|e| e.to_string())?;
+                let result = match service.search(request).await {
+                    Ok(result) => result,
+                    // A stream vanishing mid-query is not an error.
+                    Err(rsearch_search::SearchError::Metastore(
+                        rsearch_metastore::MetastoreError::StreamNotFound(_),
+                    )) => return Ok(Vec::new()),
+                    Err(e) => return Err(e.to_string()),
+                };
+                let hits = result["hits"]["hits"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                Ok(hits
+                    .into_iter()
+                    .filter_map(|hit| {
+                        let ts_ms = hit["sort"][0].as_i64()?;
+                        let source = &hit["_source"];
+                        let line = source
+                            .get("message")
+                            .and_then(Value::as_str)
+                            .map(str::to_string)
+                            .unwrap_or_else(|| source.to_string());
+                        let mut labels = BTreeMap::new();
+                        labels.insert("service_name".to_string(), stream.clone());
+                        for field in &fields {
+                            match source.get(field) {
+                                Some(Value::String(s)) => {
+                                    labels.insert(field.clone(), s.clone());
+                                }
+                                Some(Value::Number(n)) => {
+                                    labels.insert(field.clone(), n.to_string());
+                                }
+                                Some(Value::Bool(b)) => {
+                                    labels.insert(field.clone(), b.to_string());
+                                }
+                                _ => {}
+                            }
+                        }
+                        Some(LogHit { ts_ms, labels, line })
+                    })
+                    .collect::<Vec<_>>())
+            }
+        })
+        .collect();
+
+    let per_stream: Vec<Result<Vec<LogHit>, String>> = stream::iter(futs)
+        .buffer_unordered(STREAM_CONCURRENCY)
+        .collect()
+        .await;
+    let mut hits: Vec<LogHit> = Vec::new();
+    for result in per_stream {
+        hits.extend(result?);
+    }
+    if forward {
+        hits.sort_by_key(|h| h.ts_ms);
+    } else {
+        hits.sort_by_key(|h| std::cmp::Reverse(h.ts_ms));
+    }
+    hits.truncate(limit);
+    Ok(hits)
+}
+
+/// Group hits into Loki `streams` result entries.
+fn to_streams_result(hits: Vec<LogHit>) -> Value {
+    let mut by_labels: BTreeMap<String, (BTreeMap<String, String>, Vec<(i64, String)>)> =
+        BTreeMap::new();
+    for hit in hits {
+        let key = format!("{:?}", hit.labels);
+        by_labels
+            .entry(key)
+            .or_insert_with(|| (hit.labels.clone(), Vec::new()))
+            .1
+            .push((hit.ts_ms, hit.line));
+    }
+    let result: Vec<Value> = by_labels
+        .into_values()
+        .map(|(labels, values)| {
+            json!({
+                "stream": labels,
+                "values": values
+                    .into_iter()
+                    .map(|(ts_ms, line)| {
+                        json!([format!("{}", (ts_ms as i128) * 1_000_000), line])
+                    })
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    json!({"resultType": "streams", "result": result, "stats": {}})
+}
+
+// ---------- metric queries ----------
+
+/// One matrix/vector series under construction: label set + bucket sums.
+type SeriesMap = BTreeMap<String, (BTreeMap<String, String>, BTreeMap<i64, f64>)>;
+
+/// Execute a metric query, returning series of (labels, ts_ms → value).
+async fn run_metric_query(
+    state: &AppState,
+    metric: &MetricQuery,
+    start_ms: i64,
+    end_ms: i64,
+    step_ms: i64,
+) -> Result<SeriesMap, String> {
+    use futures::stream::{self, StreamExt};
+    let service = state
+        .search
+        .clone()
+        .ok_or_else(|| "this node does not run the search role".to_string())?;
+    if metric.group_by.len() > 1 {
+        return Err("sum by (…) supports at most one label".to_string());
+    }
+    let group_label = metric.group_by.first().map(String::as_str);
+    let streams = resolve_streams(state, &metric.selector).await?;
+    // Values are per-second for rate, raw counts for count_over_time.
+    let divisor = match metric.op {
+        MetricOp::Rate => (metric.range_millis.max(1) as f64) / 1000.0,
+        MetricOp::CountOverTime => 1.0,
+    };
+
+    let futs: Vec<_> = streams
+        .iter()
+        .map(|stream| {
+            let service = service.clone();
+            let stream = stream.clone();
+            async move {
+                let run = async {
+                let stream = stream.as_str();
+                let Some(query) =
+                    selector_query(state, stream, &metric.selector, start_ms, end_ms).await?
+                else {
+                    return Ok::<_, String>(Vec::new());
+                };
+                let histogram = json!({
+                    "date_histogram": {"field": "@timestamp", "fixed_interval": format!("{step_ms}ms")},
+                });
+                let aggs = match group_label {
+                    Some(label) if label != "service_name" => {
+                        let mut ts = histogram;
+                        ts["aggs"] =
+                            json!({"by": {"terms": {"field": label, "size": LABEL_VALUES_LIMIT}}});
+                        json!({"ts": ts})
+                    }
+                    _ => json!({"ts": histogram}),
+                };
+                let body = json!({
+                    "size": 0,
+                    "track_total_hits": false,
+                    "query": query,
+                    "aggs": aggs,
+                });
+                let request = SearchRequest::parse(stream, &body).map_err(|e| e.to_string())?;
+                let result = match service.search(request).await {
+                    Ok(result) => result,
+                    Err(rsearch_search::SearchError::Metastore(
+                        rsearch_metastore::MetastoreError::StreamNotFound(_),
+                    )) => return Ok(Vec::new()),
+                    Err(e) => return Err(e.to_string()),
+                };
+                let buckets = result["aggregations"]["ts"]["buckets"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                // (bucket ts, optional group value, count)
+                let mut out: Vec<(i64, Option<String>, f64)> = Vec::new();
+                for bucket in buckets {
+                    let ts = bucket["key"]
+                        .as_f64()
+                        .map(|k| k as i64)
+                        .or_else(|| bucket["key"].as_i64())
+                        .unwrap_or(0);
+                    match group_label {
+                        Some(label) if label != "service_name" => {
+                            for sub in bucket["by"]["buckets"].as_array().into_iter().flatten() {
+                                let value = match &sub["key"] {
+                                    Value::String(s) => s.clone(),
+                                    other => other.to_string(),
+                                };
+                                let count = sub["doc_count"].as_f64().unwrap_or(0.0);
+                                out.push((ts, Some(value), count));
+                            }
+                        }
+                        _ => {
+                            let count = bucket["doc_count"].as_f64().unwrap_or(0.0);
+                            out.push((ts, None, count));
+                        }
+                    }
+                }
+                Ok(out)
+                };
+                let result = run.await;
+                (stream, result)
+            }
+        })
+        .collect();
+
+    let per_stream: Vec<(String, Result<Vec<(i64, Option<String>, f64)>, String>)> =
+        stream::iter(futs)
+            .buffer_unordered(STREAM_CONCURRENCY)
+            .collect()
+            .await;
+
+    let mut series: SeriesMap = BTreeMap::new();
+    for (stream, result) in per_stream {
+        for (ts, group_value, count) in result? {
+            // Which series does this sample belong to?
+            let labels: BTreeMap<String, String> = match (group_label, &group_value) {
+                (Some(label), Some(value)) => {
+                    BTreeMap::from([(label.to_string(), value.clone())])
+                }
+                (Some("service_name"), None) => {
+                    BTreeMap::from([("service_name".to_string(), stream.clone())])
+                }
+                (None, _) if metric.summed => BTreeMap::new(),
+                _ => BTreeMap::from([("service_name".to_string(), stream.clone())]),
+            };
+            let key = format!("{labels:?}");
+            let entry = series.entry(key).or_insert_with(|| (labels, BTreeMap::new()));
+            *entry.1.entry(ts).or_insert(0.0) += count / divisor;
+        }
+    }
+    Ok(series)
+}
+
+fn to_matrix_result(series: SeriesMap) -> Value {
+    let result: Vec<Value> = series
+        .into_values()
+        .map(|(labels, points)| {
+            json!({
+                "metric": labels,
+                "values": points
+                    .into_iter()
+                    .map(|(ts_ms, v)| json!([ts_ms as f64 / 1000.0, format!("{v}")]))
+                    .collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    json!({"resultType": "matrix", "result": result, "stats": {}})
+}
+
+// ---------- handlers ----------
+
+/// GET/POST /loki/api/v1/query_range
+pub async fn query_range(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let params = params(&uri, &body);
+    let Some(query) = first(&params, "query") else {
+        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+    };
+    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
+    let start_ms = first(&params, "start")
+        .and_then(parse_time_ms)
+        .unwrap_or(end_ms - 3_600_000);
+    let limit = first(&params, "limit")
+        .and_then(|l| l.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_LIMIT)
+        .min(MAX_LIMIT);
+    let forward = first(&params, "direction") == Some("forward");
+
+    match logql::parse(query) {
+        Ok(LogQlQuery::Log(selector)) => {
+            match run_log_query(&state, &selector, start_ms, end_ms, limit, forward).await {
+                Ok(hits) => success(to_streams_result(hits)),
+                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+            }
+        }
+        Ok(LogQlQuery::Metric(metric)) => {
+            let step_ms = first(&params, "step")
+                .and_then(parse_step_ms)
+                .unwrap_or_else(|| ((end_ms - start_ms) / 250).max(1000));
+            match run_metric_query(&state, &metric, start_ms, end_ms, step_ms).await {
+                Ok(series) => success(to_matrix_result(series)),
+                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+            }
+        }
+        Err(e) => loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+    }
+}
+
+/// GET/POST /loki/api/v1/query — instant query.
+pub async fn query_instant(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let params = params(&uri, &body);
+    let Some(query) = first(&params, "query") else {
+        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+    };
+    let time_ms = first(&params, "time").and_then(parse_time_ms).unwrap_or_else(now_ms);
+    let limit = first(&params, "limit")
+        .and_then(|l| l.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_LIMIT)
+        .min(MAX_LIMIT);
+
+    match logql::parse(query) {
+        Ok(LogQlQuery::Log(selector)) => {
+            // Instant log query: last `limit` lines up to `time`.
+            match run_log_query(&state, &selector, time_ms - 3_600_000, time_ms, limit, false)
+                .await
+            {
+                Ok(hits) => success(to_streams_result(hits)),
+                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+            }
+        }
+        Ok(LogQlQuery::Metric(metric)) => {
+            // One bucket covering [time - range, time] → vector.
+            let start_ms = time_ms - metric.range_millis;
+            match run_metric_query(&state, &metric, start_ms, time_ms, metric.range_millis.max(1))
+                .await
+            {
+                Ok(series) => {
+                    let result: Vec<Value> = series
+                        .into_values()
+                        .map(|(labels, points)| {
+                            let total: f64 = points.values().sum();
+                            json!({
+                                "metric": labels,
+                                "value": [time_ms as f64 / 1000.0, format!("{total}")],
+                            })
+                        })
+                        .collect();
+                    success(json!({"resultType": "vector", "result": result, "stats": {}}))
+                }
+                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+            }
+        }
+        Err(e) => loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+    }
+}
+
+/// GET /loki/api/v1/labels
+pub async fn labels(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let _ = params(&uri, &body); // start/end accepted but unused
+    let streams = match state.cached_stream_names().await {
+        Ok(streams) => streams,
+        Err(e) => return loki_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+    let mut labels: Vec<String> = vec!["service_name".to_string()];
+    for stream in streams.iter() {
+        for field in label_fields(&state, stream).await {
+            if !labels.contains(&field) {
+                labels.push(field);
+            }
+        }
+    }
+    labels.sort();
+    success(json!(labels))
+}
+
+/// GET /loki/api/v1/label/{name}/values
+pub async fn label_values(
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    uri: Uri,
+    body: String,
+) -> Response {
+    let params = params(&uri, &body);
+    let start_ms = first(&params, "start").and_then(parse_time_ms);
+    let end_ms = first(&params, "end").and_then(parse_time_ms);
+    let streams = match state.cached_stream_names().await {
+        Ok(streams) => streams,
+        Err(e) => return loki_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+    };
+    if name == "service_name" {
+        let mut names: Vec<String> = streams.iter().cloned().collect();
+        names.sort();
+        return success(json!(names));
+    }
+    let mut values: Vec<String> = Vec::new();
+    for stream in streams.iter() {
+        if !label_fields(&state, stream).await.contains(&name) {
+            continue;
+        }
+        for value in field_values(&state, stream, &name, start_ms, end_ms).await {
+            if !values.contains(&value) {
+                values.push(value);
+            }
+        }
+        if values.len() >= LABEL_VALUES_LIMIT {
+            break;
+        }
+    }
+    values.sort();
+    values.truncate(LABEL_VALUES_LIMIT);
+    success(json!(values))
+}
+
+/// GET/POST /loki/api/v1/series
+pub async fn series(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let params = params(&uri, &body);
+    let selectors: Vec<&String> = params
+        .get("match[]")
+        .into_iter()
+        .flatten()
+        .chain(params.get("match").into_iter().flatten())
+        .collect();
+    let mut sets: Vec<Value> = Vec::new();
+    let mut seen: Vec<String> = Vec::new();
+    for raw in selectors {
+        let Ok(LogQlQuery::Log(selector)) = logql::parse(raw) else {
+            continue;
+        };
+        let Ok(streams) = resolve_streams(&state, &selector).await else {
+            continue;
+        };
+        for stream in streams {
+            if !seen.contains(&stream) {
+                sets.push(json!({"service_name": stream}));
+                seen.push(stream);
+            }
+        }
+    }
+    success(json!(sets))
+}
+
+/// GET/POST /loki/api/v1/index/volume — total counts per label set.
+pub async fn volume(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let params = params(&uri, &body);
+    let Some(query) = first(&params, "query") else {
+        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+    };
+    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
+    let start_ms = first(&params, "start")
+        .and_then(parse_time_ms)
+        .unwrap_or(end_ms - 3_600_000);
+    let selector = match logql::parse(query) {
+        Ok(LogQlQuery::Log(selector)) => selector,
+        Ok(LogQlQuery::Metric(metric)) => metric.selector,
+        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+    };
+    let group_label = first(&params, "targetLabels")
+        .or_else(|| first(&params, "aggregateBy"))
+        .and_then(|l| l.split(',').next())
+        .filter(|l| !l.is_empty() && *l != "none")
+        .map(str::to_string)
+        .or_else(|| {
+            selector
+                .matchers
+                .iter()
+                .map(|m| m.label.clone())
+                .next()
+        })
+        .unwrap_or_else(|| "service_name".to_string());
+
+    let metric = MetricQuery {
+        selector,
+        range_millis: (end_ms - start_ms).max(1),
+        op: MetricOp::CountOverTime,
+        group_by: vec![group_label],
+        summed: true,
+    };
+    match run_metric_query(&state, &metric, start_ms, end_ms, (end_ms - start_ms).max(1)).await {
+        Ok(series) => {
+            let mut result: Vec<Value> = series
+                .into_values()
+                .map(|(labels, points)| {
+                    let total: f64 = points.values().sum();
+                    json!({
+                        "metric": labels,
+                        "value": [end_ms as f64 / 1000.0, format!("{total}")],
+                    })
+                })
+                .collect();
+            // Loki orders volume results largest-first.
+            result.sort_by(|a, b| {
+                let val = |v: &Value| {
+                    v["value"][1]
+                        .as_str()
+                        .and_then(|s| s.parse::<f64>().ok())
+                        .unwrap_or(0.0)
+                };
+                val(b).partial_cmp(&val(a)).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            if let Some(limit) = first(&params, "limit").and_then(|l| l.parse::<usize>().ok()) {
+                result.truncate(limit);
+            }
+            success(json!({"resultType": "vector", "result": result, "stats": {}}))
+        }
+        Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+    }
+}
+
+/// GET/POST /loki/api/v1/index/volume_range — volume over time (matrix).
+pub async fn volume_range(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    let params = params(&uri, &body);
+    let Some(query) = first(&params, "query") else {
+        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+    };
+    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
+    let start_ms = first(&params, "start")
+        .and_then(parse_time_ms)
+        .unwrap_or(end_ms - 3_600_000);
+    let step_ms = first(&params, "step")
+        .and_then(parse_step_ms)
+        .unwrap_or_else(|| ((end_ms - start_ms) / 100).max(1000));
+    let selector = match logql::parse(query) {
+        Ok(LogQlQuery::Log(selector)) => selector,
+        Ok(LogQlQuery::Metric(metric)) => metric.selector,
+        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+    };
+    let group_label = first(&params, "targetLabels")
+        .or_else(|| first(&params, "aggregateBy"))
+        .and_then(|l| l.split(',').next())
+        .filter(|l| !l.is_empty() && *l != "none")
+        .unwrap_or("service_name")
+        .to_string();
+    let metric = MetricQuery {
+        selector,
+        range_millis: step_ms,
+        op: MetricOp::CountOverTime,
+        group_by: vec![group_label],
+        summed: true,
+    };
+    match run_metric_query(&state, &metric, start_ms, end_ms, step_ms).await {
+        Ok(series) => success(to_matrix_result(series)),
+        Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+    }
+}
+
+/// GET /loki/api/v1/tail — WebSocket live tail, implemented as a 1s poll
+/// with a monotonically advancing cursor.
+pub async fn tail(
+    State(state): State<AppState>,
+    ws: axum::extract::ws::WebSocketUpgrade,
+    uri: Uri,
+) -> Response {
+    let params = params(&uri, "");
+    let Some(query) = first(&params, "query").map(str::to_string) else {
+        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+    };
+    let selector = match logql::parse(&query) {
+        Ok(LogQlQuery::Log(selector)) => selector,
+        Ok(LogQlQuery::Metric(_)) => {
+            return loki_error(StatusCode::BAD_REQUEST, "tail requires a log selector");
+        }
+        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+    };
+    let limit = first(&params, "limit")
+        .and_then(|l| l.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_LIMIT)
+        .min(MAX_LIMIT);
+    // Docs become searchable only once their batch publishes a split
+    // (up to ingest.max_batch_secs after arrival), so a hard cursor at
+    // "now" would skip everything. Instead each tick re-scans a trailing
+    // window and dedupes what it already emitted; the watermark advances
+    // once entries are old enough that late publishes are no longer
+    // expected. Emission latency is one publish + one poll tick.
+    const TAIL_RESCAN_MS: i64 = 60_000;
+    const TAIL_SEEN_CAP: usize = 100_000;
+    let mut watermark_ms = first(&params, "start")
+        .and_then(parse_time_ms)
+        .unwrap_or_else(|| now_ms() - 5_000);
+
+    ws.on_upgrade(move |mut socket| async move {
+        use std::hash::{Hash, Hasher};
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        loop {
+            tokio::select! {
+                message = socket.recv() => {
+                    // Client closed (or errored): stop tailing.
+                    match message {
+                        None | Some(Err(_)) => return,
+                        Some(Ok(axum::extract::ws::Message::Close(_))) => return,
+                        Some(Ok(_)) => {}
+                    }
+                }
+                _ = interval.tick() => {
+                    let end_ms = now_ms();
+                    if end_ms <= watermark_ms {
+                        continue;
+                    }
+                    let hits = match run_log_query(
+                        &state, &selector, watermark_ms, end_ms, limit, true,
+                    ).await {
+                        Ok(hits) => hits,
+                        Err(_) => continue, // transient; retry next tick
+                    };
+                    let fresh: Vec<LogHit> = hits
+                        .into_iter()
+                        .filter(|hit| {
+                            let mut hasher =
+                                std::collections::hash_map::DefaultHasher::new();
+                            (hit.ts_ms, &hit.line, &hit.labels).hash(&mut hasher);
+                            seen.insert(hasher.finish())
+                        })
+                        .collect();
+                    // Advance past entries old enough that a late split
+                    // publish can no longer add to them; prune the dedup
+                    // set to the remaining window (or reset if flooded).
+                    watermark_ms = watermark_ms.max(end_ms - TAIL_RESCAN_MS);
+                    if seen.len() > TAIL_SEEN_CAP {
+                        seen.clear();
+                        watermark_ms = end_ms;
+                    }
+                    if fresh.is_empty() {
+                        continue;
+                    }
+                    let frame = to_streams_result(fresh);
+                    let payload = json!({
+                        "streams": frame["result"],
+                        "dropped_entries": Value::Null,
+                    });
+                    if socket
+                        .send(axum::extract::ws::Message::Text(payload.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// GET /ready — Loki readiness probe (Grafana datasource health check).
+pub async fn ready() -> Response {
+    (StatusCode::OK, "ready\n").into_response()
+}

--- a/crates/rsearch-server/src/loki_api.rs
+++ b/crates/rsearch-server/src/loki_api.rs
@@ -10,13 +10,16 @@
 //!   raw `_source` JSON
 //! - timestamps convert between Loki nanoseconds and rSearch millis
 //!
-//! Endpoints: query_range, query, labels, label values, series,
-//! index/volume, index/volume_range, tail (WebSocket), ready. LogQL
-//! coverage is the subset Grafana sends: selectors with =/!=/=~/!~,
-//! line filters |= and != (regex line filters are rejected with a clear
-//! error), count_over_time / rate, sum / sum by (…).
+//! Line filters (`|=`, `!=`, `|~`, `!~`) are true substring/regex tests
+//! against the rendered line, applied after fetching — never a tokenized
+//! index match that could silently miss "error" when searching "err".
+//! The cost of that honesty: a filtered query examines at most
+//! [`SCAN_LIMIT`] selector-matching docs per stream per request, newest
+//! first; results deeper than the scan window require narrowing the
+//! selector or time range.
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use axum::extract::State;
 use axum::http::{StatusCode, Uri};
@@ -25,7 +28,9 @@ use axum::Json;
 use serde_json::{Value, json};
 
 use rsearch_search::SearchRequest;
-use rsearch_search::logql::{self, FilterOp, LogQlQuery, LogSelector, MatchOp, MetricOp, MetricQuery};
+use rsearch_search::logql::{
+    self, FilterOp, LineFilter, LogQlQuery, LogSelector, MatchOp, MetricOp, MetricQuery,
+};
 
 use crate::state::AppState;
 
@@ -36,6 +41,71 @@ const STREAM_CONCURRENCY: usize = 8;
 /// Default / max entries for log queries (Loki's defaults are 100/5000).
 const DEFAULT_LIMIT: usize = 100;
 const MAX_LIMIT: usize = 5000;
+/// Docs examined per stream when line filters (or filtered metrics)
+/// require post-filtering the rendered lines.
+const SCAN_LIMIT: usize = 5000;
+/// Ceiling on histogram buckets for a metric query — guards absurd
+/// step/range combinations from allocating unbounded bucket maps.
+const MAX_METRIC_BUCKETS: i64 = 20_000;
+/// Concurrent WebSocket tail sessions per node.
+const MAX_TAIL_SESSIONS: usize = 16;
+/// Hard ceiling on one tail session's lifetime.
+const TAIL_MAX_SESSION_SECS: u64 = 3600;
+
+// ---------- errors ----------
+
+/// User errors become 400 `bad_data`; backend errors become 503 so
+/// clients (and shippers behind Grafana) treat them as retryable rather
+/// than as a broken query.
+enum QueryError {
+    User(String),
+    Backend(String),
+}
+
+impl QueryError {
+    fn into_response(self) -> Response {
+        match self {
+            QueryError::User(message) => (
+                StatusCode::BAD_REQUEST,
+                Json(json!({"status": "error", "errorType": "bad_data", "error": message})),
+            )
+                .into_response(),
+            QueryError::Backend(message) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(json!({"status": "error", "errorType": "internal", "error": message})),
+            )
+                .into_response(),
+        }
+    }
+
+    fn message(&self) -> &str {
+        match self {
+            QueryError::User(m) | QueryError::Backend(m) => m,
+        }
+    }
+
+    fn from_search(e: rsearch_search::SearchError) -> Self {
+        match e {
+            rsearch_search::SearchError::BadRequest(m) => QueryError::User(m),
+            other => QueryError::Backend(other.to_string()),
+        }
+    }
+}
+
+fn bad_request(message: impl Into<String>) -> Response {
+    QueryError::User(message.into()).into_response()
+}
+
+/// Success envelope; Loki carries partial-result warnings at the top
+/// level next to `data`.
+fn success(data: Value, warnings: Vec<String>) -> Response {
+    let mut body = json!({"status": "success", "data": data});
+    if !warnings.is_empty() {
+        body["warnings"] = json!(warnings);
+    }
+    Json(body).into_response()
+}
+
 // ---------- parameter + time helpers ----------
 
 /// Merge query-string and (form-encoded) body parameters, so both the
@@ -54,7 +124,8 @@ fn first<'a>(params: &'a HashMap<String, Vec<String>>, key: &str) -> Option<&'a 
     params.get(key).and_then(|v| v.first()).map(String::as_str)
 }
 
-/// Loki times arrive as nanosecond epoch integers or float seconds.
+/// Loki times arrive as nanosecond epoch integers, float seconds, or
+/// RFC3339 strings.
 fn parse_time_ms(s: &str) -> Option<i64> {
     if let Ok(n) = s.parse::<i128>() {
         let ms = if n.abs() >= 100_000_000_000_000_000 {
@@ -68,7 +139,26 @@ fn parse_time_ms(s: &str) -> Option<i64> {
         };
         return i64::try_from(ms).ok();
     }
-    s.parse::<f64>().ok().map(|secs| (secs * 1000.0) as i64)
+    if let Ok(secs) = s.parse::<f64>() {
+        return Some((secs * 1000.0) as i64);
+    }
+    time::OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+        .ok()
+        .map(|dt| (dt.unix_timestamp_nanos() / 1_000_000) as i64)
+}
+
+/// A time param that is present but unparseable is a 400, not a silent
+/// fallback to the default window.
+fn time_param(
+    params: &HashMap<String, Vec<String>>,
+    key: &str,
+    default: i64,
+) -> Result<i64, Response> {
+    match first(params, key) {
+        None => Ok(default),
+        Some(raw) => parse_time_ms(raw)
+            .ok_or_else(|| bad_request(format!("invalid '{key}' timestamp: {raw:?}"))),
+    }
 }
 
 /// Step arrives as float seconds ("15") or a duration string ("15s").
@@ -112,30 +202,40 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-fn loki_error(status: StatusCode, message: &str) -> Response {
-    (
-        status,
-        Json(json!({
-            "status": "error",
-            "errorType": if status == StatusCode::BAD_REQUEST { "bad_data" } else { "internal" },
-            "error": message,
-        })),
-    )
-        .into_response()
-}
-
-fn success(data: Value) -> Response {
-    Json(json!({"status": "success", "data": data})).into_response()
-}
-
 // ---------- selector resolution ----------
 
+/// Loki rejects selectors where every matcher is "empty-compatible"
+/// (would match the empty string) — such a query fans out to everything.
+fn validate_selector(selector: &LogSelector) -> Result<(), QueryError> {
+    for matcher in &selector.matchers {
+        match matcher.op {
+            MatchOp::Eq if !matcher.value.is_empty() => return Ok(()),
+            MatchOp::Re => {
+                if let Ok(re) = anchored(&matcher.value)
+                    && !re.is_match("")
+                {
+                    return Ok(());
+                }
+            }
+            _ => {}
+        }
+    }
+    Err(QueryError::User(
+        "queries require at least one matcher that does not match the empty string \
+         (e.g. {service_name=~\".+\"})"
+            .to_string(),
+    ))
+}
+
 /// Streams a selector's `service_name` matchers allow.
-async fn resolve_streams(state: &AppState, selector: &LogSelector) -> Result<Vec<String>, String> {
+async fn resolve_streams(
+    state: &AppState,
+    selector: &LogSelector,
+) -> Result<Vec<String>, QueryError> {
     let all = state
         .cached_stream_names()
         .await
-        .map_err(|e| format!("stream listing failed: {e}"))?;
+        .map_err(|e| QueryError::Backend(format!("stream listing failed: {e}")))?;
     let mut names: Vec<String> = all.iter().cloned().collect();
     for matcher in selector.matchers.iter().filter(|m| m.label == "service_name") {
         match matcher.op {
@@ -152,43 +252,26 @@ async fn resolve_streams(state: &AppState, selector: &LogSelector) -> Result<Vec
 }
 
 /// Loki label regexes are fully anchored.
-fn anchored(pattern: &str) -> Result<regex::Regex, String> {
-    regex::Regex::new(&format!("^(?:{pattern})$")).map_err(|e| format!("invalid regex: {e}"))
+fn anchored(pattern: &str) -> Result<regex::Regex, QueryError> {
+    regex::Regex::new(&format!("^(?:{pattern})$"))
+        .map_err(|e| QueryError::User(format!("invalid regex: {e}")))
 }
 
-/// Keyword-mapped fields of a stream — the fields exposed as labels.
-async fn label_fields(state: &AppState, stream: &str) -> Vec<String> {
-    let Ok(record) = state.metastore.get_stream(stream).await else {
-        return Vec::new();
-    };
-    let mut fields: Vec<String> = record
-        .mapping
-        .get("properties")
-        .and_then(Value::as_object)
-        .map(|props| {
-            props
-                .iter()
-                .filter(|(_, spec)| {
-                    spec.get("type").and_then(Value::as_str) == Some("keyword")
-                })
-                .map(|(name, _)| name.clone())
-                .collect()
-        })
-        .unwrap_or_default();
-    fields.sort();
-    fields
-}
-
-/// Distinct values of a label field within one stream (terms agg).
+/// Distinct values of a label field within one stream (terms agg),
+/// bounded to the query's time range. `saturated` is set when the agg
+/// hit [`LABEL_VALUES_LIMIT`] — callers that need completeness (regex
+/// matcher expansion) must treat that as an error, not silence.
 async fn field_values(
     state: &AppState,
     stream: &str,
     field: &str,
     start_ms: Option<i64>,
     end_ms: Option<i64>,
-) -> Vec<String> {
+) -> Result<(Vec<String>, bool), QueryError> {
     let Some(service) = state.search.clone() else {
-        return Vec::new();
+        return Err(QueryError::Backend(
+            "this node does not run the search role".to_string(),
+        ));
     };
     let mut filters = vec![];
     if start_ms.is_some() || end_ms.is_some() {
@@ -207,33 +290,31 @@ async fn field_values(
         "query": {"bool": {"filter": filters}},
         "aggs": {"v": {"terms": {"field": field, "size": LABEL_VALUES_LIMIT}}},
     });
-    let Ok(request) = SearchRequest::parse(stream, &body) else {
-        return Vec::new();
-    };
-    match service.search(request).await {
-        Ok(result) => result["aggregations"]["v"]["buckets"]
-            .as_array()
-            .map(|buckets| {
-                buckets
-                    .iter()
-                    .filter_map(|b| b["key"].as_str().map(str::to_string))
-                    .collect()
-            })
-            .unwrap_or_default(),
-        Err(_) => Vec::new(),
-    }
+    let request = SearchRequest::parse(stream, &body).map_err(QueryError::from_search)?;
+    let result = service.search(request).await.map_err(QueryError::from_search)?;
+    let values: Vec<String> = result["aggregations"]["v"]["buckets"]
+        .as_array()
+        .map(|buckets| {
+            buckets
+                .iter()
+                .filter_map(|b| b["key"].as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let saturated = values.len() >= LABEL_VALUES_LIMIT;
+    Ok((values, saturated))
 }
 
-/// Build the ES bool query for a selector against one stream. Returns
-/// None when a matcher can never match in this stream (e.g. a regex that
-/// matches no values), so the stream is skipped entirely.
+/// Build the ES bool query for a selector's label matchers against one
+/// stream (line filters are applied later, against rendered lines).
+/// Returns None when a matcher can never match in this stream.
 async fn selector_query(
     state: &AppState,
     stream: &str,
     selector: &LogSelector,
     start_ms: i64,
     end_ms: i64,
-) -> Result<Option<Value>, String> {
+) -> Result<Option<Value>, QueryError> {
     let mut filter = vec![json!({"range": {"@timestamp": {"gte": start_ms, "lte": end_ms}}})];
     let mut must_not = vec![];
 
@@ -246,11 +327,19 @@ async fn selector_query(
             MatchOp::Neq => must_not.push(json!({"term": {&matcher.label: matcher.value}})),
             MatchOp::Re | MatchOp::NotRe => {
                 let re = anchored(&matcher.value)?;
-                let values: Vec<String> = field_values(state, stream, &matcher.label, None, None)
-                    .await
-                    .into_iter()
-                    .filter(|v| re.is_match(v))
-                    .collect();
+                let (values, saturated) =
+                    field_values(state, stream, &matcher.label, Some(start_ms), Some(end_ms))
+                        .await?;
+                if saturated {
+                    return Err(QueryError::User(format!(
+                        "label '{}' has more than {LABEL_VALUES_LIMIT} distinct values in \
+                         the query range; regex matchers cannot be applied — narrow the \
+                         time range or use =/!= matchers",
+                        matcher.label
+                    )));
+                }
+                let values: Vec<String> =
+                    values.into_iter().filter(|v| re.is_match(v)).collect();
                 match matcher.op {
                     MatchOp::Re if values.is_empty() => return Ok(None),
                     MatchOp::Re => filter.push(json!({"terms": {&matcher.label: values}})),
@@ -263,24 +352,46 @@ async fn selector_query(
         }
     }
 
-    for line_filter in &selector.filters {
-        match line_filter.op {
-            FilterOp::Contains => {
-                filter.push(json!({"match_phrase": {"message": line_filter.text}}));
-            }
-            FilterOp::NotContains => {
-                must_not.push(json!({"match_phrase": {"message": line_filter.text}}));
-            }
-            FilterOp::Regex | FilterOp::NotRegex => {
-                return Err(
-                    "regex line filters (|~, !~) are not supported yet; use |= / != text filters"
-                        .to_string(),
-                );
-            }
-        }
-    }
-
     Ok(Some(json!({"bool": {"filter": filter, "must_not": must_not}})))
+}
+
+// ---------- line filters (post-fetch, true substring/regex) ----------
+
+enum CompiledFilter {
+    Contains(String),
+    NotContains(String),
+    Regex(regex::Regex),
+    NotRegex(regex::Regex),
+}
+
+fn compile_filters(filters: &[LineFilter]) -> Result<Vec<CompiledFilter>, QueryError> {
+    filters
+        .iter()
+        .map(|f| {
+            Ok(match f.op {
+                FilterOp::Contains => CompiledFilter::Contains(f.text.clone()),
+                FilterOp::NotContains => CompiledFilter::NotContains(f.text.clone()),
+                // Line-filter regexes are unanchored in Loki.
+                FilterOp::Regex => CompiledFilter::Regex(
+                    regex::Regex::new(&f.text)
+                        .map_err(|e| QueryError::User(format!("invalid line regex: {e}")))?,
+                ),
+                FilterOp::NotRegex => CompiledFilter::NotRegex(
+                    regex::Regex::new(&f.text)
+                        .map_err(|e| QueryError::User(format!("invalid line regex: {e}")))?,
+                ),
+            })
+        })
+        .collect()
+}
+
+fn line_matches(line: &str, filters: &[CompiledFilter]) -> bool {
+    filters.iter().all(|f| match f {
+        CompiledFilter::Contains(text) => line.contains(text.as_str()),
+        CompiledFilter::NotContains(text) => !line.contains(text.as_str()),
+        CompiledFilter::Regex(re) => re.is_match(line),
+        CompiledFilter::NotRegex(re) => !re.is_match(line),
+    })
 }
 
 // ---------- log queries ----------
@@ -291,8 +402,16 @@ struct LogHit {
     line: String,
 }
 
-/// Run a log selector across its streams and return merged, direction-
-/// sorted, limit-truncated hits.
+struct LogQueryOutcome {
+    hits: Vec<LogHit>,
+    /// Per-stream failures (partial results) and scan-window saturation.
+    warnings: Vec<String>,
+}
+
+/// Run a log selector across its streams: fetch selector-matching docs,
+/// apply line filters to the rendered lines, merge with direction, and
+/// truncate to `limit`. Individual stream failures degrade to warnings;
+/// the query only errors when every stream fails.
 async fn run_log_query(
     state: &AppState,
     selector: &LogSelector,
@@ -300,84 +419,133 @@ async fn run_log_query(
     end_ms: i64,
     limit: usize,
     forward: bool,
-) -> Result<Vec<LogHit>, String> {
+) -> Result<LogQueryOutcome, QueryError> {
     use futures::stream::{self, StreamExt};
     let service = state
         .search
         .clone()
-        .ok_or_else(|| "this node does not run the search role".to_string())?;
+        .ok_or_else(|| QueryError::Backend("this node does not run the search role".into()))?;
     let streams = resolve_streams(state, selector).await?;
+    let filters = compile_filters(&selector.filters)?;
+    let filters = &filters;
+    // Line filters are applied after the fetch, so filtered queries
+    // over-fetch: examine up to SCAN_LIMIT selector-matching docs per
+    // stream (newest/oldest per direction) and filter those.
+    let fetch = if filters.is_empty() { limit.min(MAX_LIMIT) } else { SCAN_LIMIT };
     let order = if forward { "asc" } else { "desc" };
 
     let futs: Vec<_> = streams
         .iter()
         .map(|stream| {
             let service = service.clone();
+            let stream = stream.clone();
             async move {
-                let Some(query) = selector_query(state, stream, selector, start_ms, end_ms).await?
-                else {
-                    return Ok::<_, String>(Vec::new());
-                };
-                let fields = label_fields(state, stream).await;
-                let body = json!({
-                    "size": limit,
-                    "track_total_hits": false,
-                    "sort": [{"@timestamp": {"order": order}}],
-                    "query": query,
-                });
-                let request = SearchRequest::parse(stream, &body).map_err(|e| e.to_string())?;
-                let result = match service.search(request).await {
-                    Ok(result) => result,
-                    // A stream vanishing mid-query is not an error.
-                    Err(rsearch_search::SearchError::Metastore(
-                        rsearch_metastore::MetastoreError::StreamNotFound(_),
-                    )) => return Ok(Vec::new()),
-                    Err(e) => return Err(e.to_string()),
-                };
-                let hits = result["hits"]["hits"]
-                    .as_array()
-                    .cloned()
-                    .unwrap_or_default();
-                Ok(hits
-                    .into_iter()
-                    .filter_map(|hit| {
-                        let ts_ms = hit["sort"][0].as_i64()?;
-                        let source = &hit["_source"];
-                        let line = source
-                            .get("message")
-                            .and_then(Value::as_str)
-                            .map(str::to_string)
-                            .unwrap_or_else(|| source.to_string());
-                        let mut labels = BTreeMap::new();
-                        labels.insert("service_name".to_string(), stream.clone());
-                        for field in &fields {
-                            match source.get(field) {
-                                Some(Value::String(s)) => {
-                                    labels.insert(field.clone(), s.clone());
-                                }
-                                Some(Value::Number(n)) => {
-                                    labels.insert(field.clone(), n.to_string());
-                                }
-                                Some(Value::Bool(b)) => {
-                                    labels.insert(field.clone(), b.to_string());
-                                }
-                                _ => {}
+                let run = async {
+                    let stream = stream.as_str();
+                    let Some(query) =
+                        selector_query(state, stream, selector, start_ms, end_ms).await?
+                    else {
+                        return Ok::<_, QueryError>((Vec::new(), false));
+                    };
+                    let fields = state.cached_label_fields(stream).await;
+                    let body = json!({
+                        "size": fetch,
+                        "track_total_hits": false,
+                        "sort": [{"@timestamp": {"order": order}}],
+                        "query": query,
+                    });
+                    let request =
+                        SearchRequest::parse(stream, &body).map_err(QueryError::from_search)?;
+                    let result = match service.search(request).await {
+                        Ok(result) => result,
+                        // A stream vanishing mid-query is not an error.
+                        Err(rsearch_search::SearchError::Metastore(
+                            rsearch_metastore::MetastoreError::StreamNotFound(_),
+                        )) => return Ok((Vec::new(), false)),
+                        Err(e) => return Err(QueryError::from_search(e)),
+                    };
+                    let raw = result["hits"]["hits"]
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default();
+                    let scanned = raw.len();
+                    let hits: Vec<LogHit> = raw
+                        .into_iter()
+                        .filter_map(|hit| {
+                            let ts_ms = hit["sort"][0].as_i64()?;
+                            let source = &hit["_source"];
+                            let line = source
+                                .get("message")
+                                .and_then(Value::as_str)
+                                .map(str::to_string)
+                                .unwrap_or_else(|| source.to_string());
+                            if !line_matches(&line, filters) {
+                                return None;
                             }
-                        }
-                        Some(LogHit { ts_ms, labels, line })
-                    })
-                    .collect::<Vec<_>>())
+                            let mut labels = BTreeMap::new();
+                            labels.insert("service_name".to_string(), stream.to_string());
+                            for field in fields.iter() {
+                                match source.get(field) {
+                                    Some(Value::String(s)) => {
+                                        labels.insert(field.clone(), s.clone());
+                                    }
+                                    Some(Value::Number(n)) => {
+                                        labels.insert(field.clone(), n.to_string());
+                                    }
+                                    Some(Value::Bool(b)) => {
+                                        labels.insert(field.clone(), b.to_string());
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            Some(LogHit { ts_ms, labels, line })
+                        })
+                        .collect();
+                    // Saturated scan: matches may exist beyond the window.
+                    let saturated = !filters.is_empty() && scanned >= fetch;
+                    Ok((hits, saturated))
+                };
+                let result = run.await;
+                (stream, result)
             }
         })
         .collect();
 
-    let per_stream: Vec<Result<Vec<LogHit>, String>> = stream::iter(futs)
+    let per_stream: Vec<(String, Result<(Vec<LogHit>, bool), QueryError>)> = stream::iter(futs)
         .buffer_unordered(STREAM_CONCURRENCY)
         .collect()
         .await;
+
     let mut hits: Vec<LogHit> = Vec::new();
-    for result in per_stream {
-        hits.extend(result?);
+    let mut warnings: Vec<String> = Vec::new();
+    let mut failures = 0usize;
+    let total = per_stream.len();
+    let mut first_error: Option<QueryError> = None;
+    for (stream, result) in per_stream {
+        match result {
+            Ok((stream_hits, saturated)) => {
+                if saturated {
+                    warnings.push(format!(
+                        "stream '{stream}': line filters examined only the \
+                         {SCAN_LIMIT} most recent matching docs; narrow the time \
+                         range for complete results"
+                    ));
+                }
+                hits.extend(stream_hits);
+            }
+            Err(e) => {
+                failures += 1;
+                warnings.push(format!("stream '{stream}' failed: {}", e.message()));
+                if first_error.is_none() {
+                    first_error = Some(e);
+                }
+            }
+        }
+    }
+    if failures == total
+        && let Some(error) = first_error
+    {
+        return Err(error);
     }
     if forward {
         hits.sort_by_key(|h| h.ts_ms);
@@ -385,7 +553,7 @@ async fn run_log_query(
         hits.sort_by_key(|h| std::cmp::Reverse(h.ts_ms));
     }
     hits.truncate(limit);
-    Ok(hits)
+    Ok(LogQueryOutcome { hits, warnings })
 }
 
 /// Group hits into Loki `streams` result entries.
@@ -419,33 +587,88 @@ fn to_streams_result(hits: Vec<LogHit>) -> Value {
 
 // ---------- metric queries ----------
 
-/// One matrix/vector series under construction: label set + bucket sums.
+/// Series under construction: label set + (bucket ts → count). Buckets
+/// are at gcd(step, range) granularity; step points are derived after.
 type SeriesMap = BTreeMap<String, (BTreeMap<String, String>, BTreeMap<i64, f64>)>;
 
-/// Execute a metric query, returning series of (labels, ts_ms → value).
+fn gcd(a: i64, b: i64) -> i64 {
+    let (mut a, mut b) = (a.max(1), b.max(1));
+    while b != 0 {
+        (a, b) = (b, a % b);
+    }
+    a
+}
+
+struct MetricOutcome {
+    series: SeriesMap,
+    bucket_ms: i64,
+    warnings: Vec<String>,
+}
+
+/// Collect per-bucket counts for a metric query. Buckets come from a
+/// date_histogram when there are no line filters, or from scanning and
+/// bucketing rendered lines when there are (same honesty trade-off as
+/// log queries — the scan is bounded and saturation is surfaced).
 async fn run_metric_query(
     state: &AppState,
     metric: &MetricQuery,
     start_ms: i64,
     end_ms: i64,
     step_ms: i64,
-) -> Result<SeriesMap, String> {
+) -> Result<MetricOutcome, QueryError> {
     use futures::stream::{self, StreamExt};
+    if metric.group_by.len() > 1 {
+        return Err(QueryError::User(
+            "sum by (…) supports at most one label".to_string(),
+        ));
+    }
+    let group_label = metric.group_by.first().map(String::as_str);
+    // Sliding windows: buckets at gcd granularity so every step point's
+    // trailing range window is an exact sum of whole buckets.
+    let bucket_ms = gcd(step_ms, metric.range_millis);
+    if (end_ms - start_ms + metric.range_millis) / bucket_ms > MAX_METRIC_BUCKETS {
+        return Err(QueryError::User(format!(
+            "step/range combination produces too many buckets (limit {MAX_METRIC_BUCKETS}); \
+             use a coarser step"
+        )));
+    }
+    // The first step point's window reaches back before `start`.
+    let fetch_start_ms = start_ms - metric.range_millis;
+
+    if !metric.selector.filters.is_empty() {
+        // Filtered metrics: fetch matching lines and bucket in-process.
+        let outcome = run_log_query(
+            state,
+            &metric.selector,
+            fetch_start_ms,
+            end_ms,
+            usize::MAX,
+            false,
+        )
+        .await?;
+        let mut series: SeriesMap = BTreeMap::new();
+        for hit in outcome.hits {
+            let labels = series_labels(metric, group_label, &hit.labels);
+            // Grouping by a label the doc lacks drops the sample, like a
+            // terms agg would.
+            let Some(labels) = labels else { continue };
+            let bucket = hit.ts_ms.div_euclid(bucket_ms) * bucket_ms;
+            let key = format!("{labels:?}");
+            let entry = series.entry(key).or_insert_with(|| (labels, BTreeMap::new()));
+            *entry.1.entry(bucket).or_insert(0.0) += 1.0;
+        }
+        return Ok(MetricOutcome {
+            series,
+            bucket_ms,
+            warnings: outcome.warnings,
+        });
+    }
+
     let service = state
         .search
         .clone()
-        .ok_or_else(|| "this node does not run the search role".to_string())?;
-    if metric.group_by.len() > 1 {
-        return Err("sum by (…) supports at most one label".to_string());
-    }
-    let group_label = metric.group_by.first().map(String::as_str);
+        .ok_or_else(|| QueryError::Backend("this node does not run the search role".into()))?;
     let streams = resolve_streams(state, &metric.selector).await?;
-    // Values are per-second for rate, raw counts for count_over_time.
-    let divisor = match metric.op {
-        MetricOp::Rate => (metric.range_millis.max(1) as f64) / 1000.0,
-        MetricOp::CountOverTime => 1.0,
-    };
-
     let futs: Vec<_> = streams
         .iter()
         .map(|stream| {
@@ -453,68 +676,81 @@ async fn run_metric_query(
             let stream = stream.clone();
             async move {
                 let run = async {
-                let stream = stream.as_str();
-                let Some(query) =
-                    selector_query(state, stream, &metric.selector, start_ms, end_ms).await?
-                else {
-                    return Ok::<_, String>(Vec::new());
-                };
-                let histogram = json!({
-                    "date_histogram": {"field": "@timestamp", "fixed_interval": format!("{step_ms}ms")},
-                });
-                let aggs = match group_label {
-                    Some(label) if label != "service_name" => {
-                        let mut ts = histogram;
-                        ts["aggs"] =
-                            json!({"by": {"terms": {"field": label, "size": LABEL_VALUES_LIMIT}}});
-                        json!({"ts": ts})
-                    }
-                    _ => json!({"ts": histogram}),
-                };
-                let body = json!({
-                    "size": 0,
-                    "track_total_hits": false,
-                    "query": query,
-                    "aggs": aggs,
-                });
-                let request = SearchRequest::parse(stream, &body).map_err(|e| e.to_string())?;
-                let result = match service.search(request).await {
-                    Ok(result) => result,
-                    Err(rsearch_search::SearchError::Metastore(
-                        rsearch_metastore::MetastoreError::StreamNotFound(_),
-                    )) => return Ok(Vec::new()),
-                    Err(e) => return Err(e.to_string()),
-                };
-                let buckets = result["aggregations"]["ts"]["buckets"]
-                    .as_array()
-                    .cloned()
-                    .unwrap_or_default();
-                // (bucket ts, optional group value, count)
-                let mut out: Vec<(i64, Option<String>, f64)> = Vec::new();
-                for bucket in buckets {
-                    let ts = bucket["key"]
-                        .as_f64()
-                        .map(|k| k as i64)
-                        .or_else(|| bucket["key"].as_i64())
-                        .unwrap_or(0);
-                    match group_label {
+                    let stream = stream.as_str();
+                    let Some(query) = selector_query(
+                        state,
+                        stream,
+                        &metric.selector,
+                        fetch_start_ms,
+                        end_ms,
+                    )
+                    .await?
+                    else {
+                        return Ok::<_, QueryError>(Vec::new());
+                    };
+                    let histogram = json!({
+                        "date_histogram": {
+                            "field": "@timestamp",
+                            "fixed_interval": format!("{bucket_ms}ms"),
+                        },
+                    });
+                    let aggs = match group_label {
                         Some(label) if label != "service_name" => {
-                            for sub in bucket["by"]["buckets"].as_array().into_iter().flatten() {
-                                let value = match &sub["key"] {
-                                    Value::String(s) => s.clone(),
-                                    other => other.to_string(),
-                                };
-                                let count = sub["doc_count"].as_f64().unwrap_or(0.0);
-                                out.push((ts, Some(value), count));
+                            let mut ts = histogram;
+                            ts["aggs"] = json!({
+                                "by": {"terms": {"field": label, "size": LABEL_VALUES_LIMIT}}
+                            });
+                            json!({"ts": ts})
+                        }
+                        _ => json!({"ts": histogram}),
+                    };
+                    let body = json!({
+                        "size": 0,
+                        "track_total_hits": false,
+                        "query": query,
+                        "aggs": aggs,
+                    });
+                    let request =
+                        SearchRequest::parse(stream, &body).map_err(QueryError::from_search)?;
+                    let result = match service.search(request).await {
+                        Ok(result) => result,
+                        Err(rsearch_search::SearchError::Metastore(
+                            rsearch_metastore::MetastoreError::StreamNotFound(_),
+                        )) => return Ok(Vec::new()),
+                        Err(e) => return Err(QueryError::from_search(e)),
+                    };
+                    let buckets = result["aggregations"]["ts"]["buckets"]
+                        .as_array()
+                        .cloned()
+                        .unwrap_or_default();
+                    // (bucket ts, optional group value, count)
+                    let mut out: Vec<(i64, Option<String>, f64)> = Vec::new();
+                    for bucket in buckets {
+                        let ts = bucket["key"]
+                            .as_f64()
+                            .map(|k| k as i64)
+                            .or_else(|| bucket["key"].as_i64())
+                            .unwrap_or(0);
+                        match group_label {
+                            Some(label) if label != "service_name" => {
+                                for sub in
+                                    bucket["by"]["buckets"].as_array().into_iter().flatten()
+                                {
+                                    let value = match &sub["key"] {
+                                        Value::String(s) => s.clone(),
+                                        other => other.to_string(),
+                                    };
+                                    let count = sub["doc_count"].as_f64().unwrap_or(0.0);
+                                    out.push((ts, Some(value), count));
+                                }
+                            }
+                            _ => {
+                                let count = bucket["doc_count"].as_f64().unwrap_or(0.0);
+                                out.push((ts, None, count));
                             }
                         }
-                        _ => {
-                            let count = bucket["doc_count"].as_f64().unwrap_or(0.0);
-                            out.push((ts, None, count));
-                        }
                     }
-                }
-                Ok(out)
+                    Ok(out)
                 };
                 let result = run.await;
                 (stream, result)
@@ -525,13 +761,24 @@ async fn run_metric_query(
     let per_stream: Vec<(String, Result<Vec<(i64, Option<String>, f64)>, String>)> =
         stream::iter(futs)
             .buffer_unordered(STREAM_CONCURRENCY)
+            .map(|(stream, result)| (stream, result.map_err(|e: QueryError| e.message().to_string())))
             .collect()
             .await;
 
     let mut series: SeriesMap = BTreeMap::new();
+    let mut warnings: Vec<String> = Vec::new();
+    let mut failures = 0usize;
+    let total = per_stream.len();
     for (stream, result) in per_stream {
-        for (ts, group_value, count) in result? {
-            // Which series does this sample belong to?
+        let samples = match result {
+            Ok(samples) => samples,
+            Err(message) => {
+                failures += 1;
+                warnings.push(format!("stream '{stream}' failed: {message}"));
+                continue;
+            }
+        };
+        for (ts, group_value, count) in samples {
             let labels: BTreeMap<String, String> = match (group_label, &group_value) {
                 (Some(label), Some(value)) => {
                     BTreeMap::from([(label.to_string(), value.clone())])
@@ -544,15 +791,96 @@ async fn run_metric_query(
             };
             let key = format!("{labels:?}");
             let entry = series.entry(key).or_insert_with(|| (labels, BTreeMap::new()));
-            *entry.1.entry(ts).or_insert(0.0) += count / divisor;
+            *entry.1.entry(ts).or_insert(0.0) += count;
         }
     }
-    Ok(series)
+    if failures == total && total > 0 {
+        return Err(QueryError::Backend(
+            warnings.first().cloned().unwrap_or_else(|| "all streams failed".into()),
+        ));
+    }
+    Ok(MetricOutcome {
+        series,
+        bucket_ms,
+        warnings,
+    })
 }
 
-fn to_matrix_result(series: SeriesMap) -> Value {
-    let result: Vec<Value> = series
+/// The series labels a scanned hit contributes to, honoring sum-by.
+fn series_labels(
+    metric: &MetricQuery,
+    group_label: Option<&str>,
+    hit_labels: &BTreeMap<String, String>,
+) -> Option<BTreeMap<String, String>> {
+    match group_label {
+        Some(label) => hit_labels
+            .get(label)
+            .map(|value| BTreeMap::from([(label.to_string(), value.clone())])),
+        None if metric.summed => Some(BTreeMap::new()),
+        None => Some(BTreeMap::from([(
+            "service_name".to_string(),
+            hit_labels.get("service_name").cloned().unwrap_or_default(),
+        )])),
+    }
+}
+
+/// Turn per-bucket counts into per-step samples: each step point T sums
+/// the trailing `range` window of buckets — matching Loki, where
+/// `count_over_time({…}[5m])` at T counts [T-5m, T) regardless of step.
+fn to_step_points(
+    metric: &MetricQuery,
+    outcome: MetricOutcome,
+    start_ms: i64,
+    end_ms: i64,
+    step_ms: i64,
+) -> Vec<(BTreeMap<String, String>, Vec<(i64, f64)>)> {
+    let divisor = match metric.op {
+        MetricOp::Rate => (metric.range_millis.max(1) as f64) / 1000.0,
+        MetricOp::CountOverTime => 1.0,
+    };
+    let bucket_ms = outcome.bucket_ms;
+    // Single evaluation point (instant queries, volume): the whole
+    // range-filtered query IS the window, so the exact total is simply
+    // every bucket — no alignment concerns.
+    let single_point = start_ms == end_ms;
+    outcome
+        .series
         .into_values()
+        .map(|(labels, buckets)| {
+            let mut points = Vec::new();
+            if single_point {
+                let sum: f64 = buckets.values().sum();
+                if sum > 0.0 {
+                    points.push((start_ms, sum / divisor));
+                }
+                return (labels, points);
+            }
+            let mut t = start_ms;
+            while t <= end_ms {
+                // Histogram buckets are epoch-aligned to bucket_ms, but T
+                // follows the caller's step grid — snap the window to the
+                // bucket grid so it always sums whole buckets. The window
+                // effectively evaluates at the nearest bucket boundary at
+                // or before T (skew < bucket_ms ≤ step).
+                let t_aligned = t.div_euclid(bucket_ms) * bucket_ms;
+                let sum: f64 = buckets
+                    .range(t_aligned - metric.range_millis..t_aligned)
+                    .map(|(_, v)| v)
+                    .sum();
+                if sum > 0.0 {
+                    points.push((t, sum / divisor));
+                }
+                t += step_ms;
+            }
+            (labels, points)
+        })
+        .filter(|(_, points)| !points.is_empty())
+        .collect()
+}
+
+fn to_matrix_result(series: Vec<(BTreeMap<String, String>, Vec<(i64, f64)>)>) -> Value {
+    let result: Vec<Value> = series
+        .into_iter()
         .map(|(labels, points)| {
             json!({
                 "metric": labels,
@@ -572,12 +900,16 @@ fn to_matrix_result(series: SeriesMap) -> Value {
 pub async fn query_range(State(state): State<AppState>, uri: Uri, body: String) -> Response {
     let params = params(&uri, &body);
     let Some(query) = first(&params, "query") else {
-        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+        return bad_request("missing 'query' parameter");
     };
-    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
-    let start_ms = first(&params, "start")
-        .and_then(parse_time_ms)
-        .unwrap_or(end_ms - 3_600_000);
+    let end_ms = match time_param(&params, "end", now_ms()) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    let start_ms = match time_param(&params, "start", end_ms - 3_600_000) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
     let limit = first(&params, "limit")
         .and_then(|l| l.parse::<usize>().ok())
         .unwrap_or(DEFAULT_LIMIT)
@@ -586,21 +918,34 @@ pub async fn query_range(State(state): State<AppState>, uri: Uri, body: String) 
 
     match logql::parse(query) {
         Ok(LogQlQuery::Log(selector)) => {
+            if let Err(e) = validate_selector(&selector) {
+                return e.into_response();
+            }
             match run_log_query(&state, &selector, start_ms, end_ms, limit, forward).await {
-                Ok(hits) => success(to_streams_result(hits)),
-                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+                Ok(outcome) => {
+                    let warnings = outcome.warnings.clone();
+                    success(to_streams_result(outcome.hits), warnings)
+                }
+                Err(e) => e.into_response(),
             }
         }
         Ok(LogQlQuery::Metric(metric)) => {
+            if let Err(e) = validate_selector(&metric.selector) {
+                return e.into_response();
+            }
             let step_ms = first(&params, "step")
                 .and_then(parse_step_ms)
                 .unwrap_or_else(|| ((end_ms - start_ms) / 250).max(1000));
             match run_metric_query(&state, &metric, start_ms, end_ms, step_ms).await {
-                Ok(series) => success(to_matrix_result(series)),
-                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+                Ok(outcome) => {
+                    let warnings = outcome.warnings.clone();
+                    let series = to_step_points(&metric, outcome, start_ms, end_ms, step_ms);
+                    success(to_matrix_result(series), warnings)
+                }
+                Err(e) => e.into_response(),
             }
         }
-        Err(e) => loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+        Err(e) => bad_request(format!("LogQL parse error: {e}")),
     }
 }
 
@@ -608,9 +953,12 @@ pub async fn query_range(State(state): State<AppState>, uri: Uri, body: String) 
 pub async fn query_instant(State(state): State<AppState>, uri: Uri, body: String) -> Response {
     let params = params(&uri, &body);
     let Some(query) = first(&params, "query") else {
-        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+        return bad_request("missing 'query' parameter");
     };
-    let time_ms = first(&params, "time").and_then(parse_time_ms).unwrap_or_else(now_ms);
+    let time_ms = match time_param(&params, "time", now_ms()) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
     let limit = first(&params, "limit")
         .and_then(|l| l.parse::<usize>().ok())
         .unwrap_or(DEFAULT_LIMIT)
@@ -618,57 +966,83 @@ pub async fn query_instant(State(state): State<AppState>, uri: Uri, body: String
 
     match logql::parse(query) {
         Ok(LogQlQuery::Log(selector)) => {
+            if let Err(e) = validate_selector(&selector) {
+                return e.into_response();
+            }
             // Instant log query: last `limit` lines up to `time`.
             match run_log_query(&state, &selector, time_ms - 3_600_000, time_ms, limit, false)
                 .await
             {
-                Ok(hits) => success(to_streams_result(hits)),
-                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+                Ok(outcome) => {
+                    let warnings = outcome.warnings.clone();
+                    success(to_streams_result(outcome.hits), warnings)
+                }
+                Err(e) => e.into_response(),
             }
         }
         Ok(LogQlQuery::Metric(metric)) => {
-            // One bucket covering [time - range, time] → vector.
-            let start_ms = time_ms - metric.range_millis;
-            match run_metric_query(&state, &metric, start_ms, time_ms, metric.range_millis.max(1))
+            if let Err(e) = validate_selector(&metric.selector) {
+                return e.into_response();
+            }
+            // One step point at `time` (its window is [time-range, time]).
+            match run_metric_query(&state, &metric, time_ms, time_ms, metric.range_millis.max(1))
                 .await
             {
-                Ok(series) => {
+                Ok(outcome) => {
+                    let warnings = outcome.warnings.clone();
+                    let series =
+                        to_step_points(&metric, outcome, time_ms, time_ms, metric.range_millis.max(1));
                     let result: Vec<Value> = series
-                        .into_values()
+                        .into_iter()
                         .map(|(labels, points)| {
-                            let total: f64 = points.values().sum();
+                            let total: f64 = points.last().map(|(_, v)| *v).unwrap_or(0.0);
                             json!({
                                 "metric": labels,
                                 "value": [time_ms as f64 / 1000.0, format!("{total}")],
                             })
                         })
                         .collect();
-                    success(json!({"resultType": "vector", "result": result, "stats": {}}))
+                    success(
+                        json!({"resultType": "vector", "result": result, "stats": {}}),
+                        warnings,
+                    )
                 }
-                Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+                Err(e) => e.into_response(),
             }
         }
-        Err(e) => loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+        Err(e) => bad_request(format!("LogQL parse error: {e}")),
     }
 }
 
 /// GET /loki/api/v1/labels
 pub async fn labels(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    use futures::stream::{self, StreamExt};
     let _ = params(&uri, &body); // start/end accepted but unused
     let streams = match state.cached_stream_names().await {
         Ok(streams) => streams,
-        Err(e) => return loki_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        Err(e) => return QueryError::Backend(e.to_string()).into_response(),
     };
+    let futs: Vec<_> = streams
+        .iter()
+        .map(|stream| {
+            let state = &state;
+            async move { state.cached_label_fields(stream).await }
+        })
+        .collect();
+    let per_stream: Vec<_> = stream::iter(futs)
+        .buffer_unordered(STREAM_CONCURRENCY)
+        .collect()
+        .await;
     let mut labels: Vec<String> = vec!["service_name".to_string()];
-    for stream in streams.iter() {
-        for field in label_fields(&state, stream).await {
-            if !labels.contains(&field) {
-                labels.push(field);
+    for fields in per_stream {
+        for field in fields.iter() {
+            if !labels.contains(field) {
+                labels.push(field.clone());
             }
         }
     }
     labels.sort();
-    success(json!(labels))
+    success(json!(labels), Vec::new())
 }
 
 /// GET /loki/api/v1/label/{name}/values
@@ -678,40 +1052,72 @@ pub async fn label_values(
     uri: Uri,
     body: String,
 ) -> Response {
+    use futures::stream::{self, StreamExt};
     let params = params(&uri, &body);
-    let start_ms = first(&params, "start").and_then(parse_time_ms);
-    let end_ms = first(&params, "end").and_then(parse_time_ms);
+    let start_ms = match first(&params, "start").map(parse_time_ms) {
+        Some(None) => return bad_request("invalid 'start' timestamp"),
+        other => other.flatten(),
+    };
+    let end_ms = match first(&params, "end").map(parse_time_ms) {
+        Some(None) => return bad_request("invalid 'end' timestamp"),
+        other => other.flatten(),
+    };
     let streams = match state.cached_stream_names().await {
         Ok(streams) => streams,
-        Err(e) => return loki_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()),
+        Err(e) => return QueryError::Backend(e.to_string()).into_response(),
     };
     if name == "service_name" {
         let mut names: Vec<String> = streams.iter().cloned().collect();
         names.sort();
-        return success(json!(names));
+        return success(json!(names), Vec::new());
     }
+    let name = &name;
+    let futs: Vec<_> = streams
+        .iter()
+        .map(|stream| {
+            let state = &state;
+            async move {
+                if !state.cached_label_fields(stream).await.contains(name) {
+                    return Vec::new();
+                }
+                // Values endpoint tolerates the cap (it is a browse
+                // surface); errors degrade to empty per stream.
+                match field_values(state, stream, name, start_ms, end_ms).await {
+                    Ok((values, _)) => values,
+                    Err(_) => Vec::new(),
+                }
+            }
+        })
+        .collect();
+    let per_stream: Vec<Vec<String>> = stream::iter(futs)
+        .buffer_unordered(STREAM_CONCURRENCY)
+        .collect()
+        .await;
     let mut values: Vec<String> = Vec::new();
-    for stream in streams.iter() {
-        if !label_fields(&state, stream).await.contains(&name) {
-            continue;
-        }
-        for value in field_values(&state, stream, &name, start_ms, end_ms).await {
+    for stream_values in per_stream {
+        for value in stream_values {
             if !values.contains(&value) {
                 values.push(value);
             }
         }
-        if values.len() >= LABEL_VALUES_LIMIT {
-            break;
-        }
     }
     values.sort();
     values.truncate(LABEL_VALUES_LIMIT);
-    success(json!(values))
+    success(json!(values), Vec::new())
 }
 
 /// GET/POST /loki/api/v1/series
 pub async fn series(State(state): State<AppState>, uri: Uri, body: String) -> Response {
+    use futures::stream::{self, StreamExt};
     let params = params(&uri, &body);
+    let end_ms = match time_param(&params, "end", now_ms()) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    let start_ms = match time_param(&params, "start", end_ms - 3_600_000) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
     let selectors: Vec<&String> = params
         .get("match[]")
         .into_iter()
@@ -721,64 +1127,151 @@ pub async fn series(State(state): State<AppState>, uri: Uri, body: String) -> Re
     let mut sets: Vec<Value> = Vec::new();
     let mut seen: Vec<String> = Vec::new();
     for raw in selectors {
-        let Ok(LogQlQuery::Log(selector)) = logql::parse(raw) else {
-            continue;
+        let selector = match logql::parse(raw) {
+            Ok(LogQlQuery::Log(selector)) => selector,
+            Ok(LogQlQuery::Metric(_)) => {
+                return bad_request(format!("series match must be a log selector: {raw}"));
+            }
+            Err(e) => return bad_request(format!("invalid series match {raw:?}: {e}")),
         };
-        let Ok(streams) = resolve_streams(&state, &selector).await else {
-            continue;
+        let streams = match resolve_streams(&state, &selector).await {
+            Ok(streams) => streams,
+            Err(e) => return e.into_response(),
         };
-        for stream in streams {
+        let has_field_matchers =
+            selector.matchers.iter().any(|m| m.label != "service_name");
+        // With only service_name matchers the stream list is the answer;
+        // otherwise probe each stream for at least one matching doc.
+        let matched: Vec<String> = if !has_field_matchers {
+            streams
+        } else {
+            let selector = &selector;
+            let futs: Vec<_> = streams
+                .into_iter()
+                .map(|stream| {
+                    let state = &state;
+                    async move {
+                        let outcome = run_log_query(
+                            state,
+                            &LogSelector {
+                                matchers: selector
+                                    .matchers
+                                    .iter()
+                                    .filter(|m| m.label != "service_name")
+                                    .cloned()
+                                    .chain(std::iter::once(logql::LabelMatcher {
+                                        label: "service_name".to_string(),
+                                        op: MatchOp::Eq,
+                                        value: stream.clone(),
+                                    }))
+                                    .collect(),
+                                filters: Vec::new(),
+                            },
+                            start_ms,
+                            end_ms,
+                            1,
+                            false,
+                        )
+                        .await;
+                        match outcome {
+                            Ok(o) if !o.hits.is_empty() => Some(stream),
+                            _ => None,
+                        }
+                    }
+                })
+                .collect();
+            stream::iter(futs)
+                .buffer_unordered(STREAM_CONCURRENCY)
+                .collect::<Vec<Option<String>>>()
+                .await
+                .into_iter()
+                .flatten()
+                .collect()
+        };
+        for stream in matched {
             if !seen.contains(&stream) {
                 sets.push(json!({"service_name": stream}));
                 seen.push(stream);
             }
         }
     }
-    success(json!(sets))
+    success(json!(sets), Vec::new())
+}
+
+/// Shared selector + group-label extraction for the volume endpoints.
+/// Only one grouping label is supported; extras become a warning.
+fn volume_grouping(
+    params: &HashMap<String, Vec<String>>,
+    selector: &LogSelector,
+) -> (String, Vec<String>) {
+    let mut warnings = Vec::new();
+    let requested: Vec<&str> = first(params, "targetLabels")
+        .or_else(|| first(params, "aggregateBy"))
+        .map(|l| {
+            l.split(',')
+                .map(str::trim)
+                .filter(|l| !l.is_empty() && *l != "none")
+                .collect()
+        })
+        .unwrap_or_default();
+    if requested.len() > 1 {
+        warnings.push(format!(
+            "volume grouping supports one label; grouping by '{}' and ignoring {:?}",
+            requested[0],
+            &requested[1..]
+        ));
+    }
+    let label = requested.first().map(|l| l.to_string()).unwrap_or_else(|| {
+        selector
+            .matchers
+            .iter()
+            // Only positive matchers make a sensible grouping default.
+            .find(|m| matches!(m.op, MatchOp::Eq | MatchOp::Re))
+            .map(|m| m.label.clone())
+            .unwrap_or_else(|| "service_name".to_string())
+    });
+    (label, warnings)
 }
 
 /// GET/POST /loki/api/v1/index/volume — total counts per label set.
 pub async fn volume(State(state): State<AppState>, uri: Uri, body: String) -> Response {
     let params = params(&uri, &body);
     let Some(query) = first(&params, "query") else {
-        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+        return bad_request("missing 'query' parameter");
     };
-    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
-    let start_ms = first(&params, "start")
-        .and_then(parse_time_ms)
-        .unwrap_or(end_ms - 3_600_000);
+    let end_ms = match time_param(&params, "end", now_ms()) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    let start_ms = match time_param(&params, "start", end_ms - 3_600_000) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
     let selector = match logql::parse(query) {
         Ok(LogQlQuery::Log(selector)) => selector,
         Ok(LogQlQuery::Metric(metric)) => metric.selector,
-        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+        Err(e) => return bad_request(format!("LogQL parse error: {e}")),
     };
-    let group_label = first(&params, "targetLabels")
-        .or_else(|| first(&params, "aggregateBy"))
-        .and_then(|l| l.split(',').next())
-        .filter(|l| !l.is_empty() && *l != "none")
-        .map(str::to_string)
-        .or_else(|| {
-            selector
-                .matchers
-                .iter()
-                .map(|m| m.label.clone())
-                .next()
-        })
-        .unwrap_or_else(|| "service_name".to_string());
-
+    if let Err(e) = validate_selector(&selector) {
+        return e.into_response();
+    }
+    let (group_label, mut warnings) = volume_grouping(&params, &selector);
+    let range = (end_ms - start_ms).max(1);
     let metric = MetricQuery {
         selector,
-        range_millis: (end_ms - start_ms).max(1),
+        range_millis: range,
         op: MetricOp::CountOverTime,
         group_by: vec![group_label],
         summed: true,
     };
-    match run_metric_query(&state, &metric, start_ms, end_ms, (end_ms - start_ms).max(1)).await {
-        Ok(series) => {
+    match run_metric_query(&state, &metric, end_ms, end_ms, range).await {
+        Ok(outcome) => {
+            warnings.extend(outcome.warnings.clone());
+            let series = to_step_points(&metric, outcome, end_ms, end_ms, range);
             let mut result: Vec<Value> = series
-                .into_values()
+                .into_iter()
                 .map(|(labels, points)| {
-                    let total: f64 = points.values().sum();
+                    let total: f64 = points.last().map(|(_, v)| *v).unwrap_or(0.0);
                     json!({
                         "metric": labels,
                         "value": [end_ms as f64 / 1000.0, format!("{total}")],
@@ -798,9 +1291,12 @@ pub async fn volume(State(state): State<AppState>, uri: Uri, body: String) -> Re
             if let Some(limit) = first(&params, "limit").and_then(|l| l.parse::<usize>().ok()) {
                 result.truncate(limit);
             }
-            success(json!({"resultType": "vector", "result": result, "stats": {}}))
+            success(
+                json!({"resultType": "vector", "result": result, "stats": {}}),
+                warnings,
+            )
         }
-        Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+        Err(e) => e.into_response(),
     }
 }
 
@@ -808,26 +1304,28 @@ pub async fn volume(State(state): State<AppState>, uri: Uri, body: String) -> Re
 pub async fn volume_range(State(state): State<AppState>, uri: Uri, body: String) -> Response {
     let params = params(&uri, &body);
     let Some(query) = first(&params, "query") else {
-        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+        return bad_request("missing 'query' parameter");
     };
-    let end_ms = first(&params, "end").and_then(parse_time_ms).unwrap_or_else(now_ms);
-    let start_ms = first(&params, "start")
-        .and_then(parse_time_ms)
-        .unwrap_or(end_ms - 3_600_000);
+    let end_ms = match time_param(&params, "end", now_ms()) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
+    let start_ms = match time_param(&params, "start", end_ms - 3_600_000) {
+        Ok(v) => v,
+        Err(response) => return response,
+    };
     let step_ms = first(&params, "step")
         .and_then(parse_step_ms)
         .unwrap_or_else(|| ((end_ms - start_ms) / 100).max(1000));
     let selector = match logql::parse(query) {
         Ok(LogQlQuery::Log(selector)) => selector,
         Ok(LogQlQuery::Metric(metric)) => metric.selector,
-        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+        Err(e) => return bad_request(format!("LogQL parse error: {e}")),
     };
-    let group_label = first(&params, "targetLabels")
-        .or_else(|| first(&params, "aggregateBy"))
-        .and_then(|l| l.split(',').next())
-        .filter(|l| !l.is_empty() && *l != "none")
-        .unwrap_or("service_name")
-        .to_string();
+    if let Err(e) = validate_selector(&selector) {
+        return e.into_response();
+    }
+    let (group_label, mut warnings) = volume_grouping(&params, &selector);
     let metric = MetricQuery {
         selector,
         range_millis: step_ms,
@@ -836,13 +1334,50 @@ pub async fn volume_range(State(state): State<AppState>, uri: Uri, body: String)
         summed: true,
     };
     match run_metric_query(&state, &metric, start_ms, end_ms, step_ms).await {
-        Ok(series) => success(to_matrix_result(series)),
-        Err(e) => loki_error(StatusCode::BAD_REQUEST, &e),
+        Ok(outcome) => {
+            warnings.extend(outcome.warnings.clone());
+            let series = to_step_points(&metric, outcome, start_ms, end_ms, step_ms);
+            success(to_matrix_result(series), warnings)
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+// ---------- tail ----------
+
+/// Live concurrent tail sessions on this node.
+static TAIL_SESSIONS: AtomicUsize = AtomicUsize::new(0);
+
+struct TailSlot;
+
+impl TailSlot {
+    fn acquire() -> Option<TailSlot> {
+        let mut current = TAIL_SESSIONS.load(Ordering::Relaxed);
+        loop {
+            if current >= MAX_TAIL_SESSIONS {
+                return None;
+            }
+            match TAIL_SESSIONS.compare_exchange(
+                current,
+                current + 1,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(TailSlot),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+impl Drop for TailSlot {
+    fn drop(&mut self) {
+        TAIL_SESSIONS.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
 /// GET /loki/api/v1/tail — WebSocket live tail, implemented as a 1s poll
-/// with a monotonically advancing cursor.
+/// with a trailing re-scan window.
 pub async fn tail(
     State(state): State<AppState>,
     ws: axum::extract::ws::WebSocketUpgrade,
@@ -850,43 +1385,69 @@ pub async fn tail(
 ) -> Response {
     let params = params(&uri, "");
     let Some(query) = first(&params, "query").map(str::to_string) else {
-        return loki_error(StatusCode::BAD_REQUEST, "missing 'query' parameter");
+        return bad_request("missing 'query' parameter");
     };
     let selector = match logql::parse(&query) {
         Ok(LogQlQuery::Log(selector)) => selector,
-        Ok(LogQlQuery::Metric(_)) => {
-            return loki_error(StatusCode::BAD_REQUEST, "tail requires a log selector");
-        }
-        Err(e) => return loki_error(StatusCode::BAD_REQUEST, &format!("LogQL parse error: {e}")),
+        Ok(LogQlQuery::Metric(_)) => return bad_request("tail requires a log selector"),
+        Err(e) => return bad_request(format!("LogQL parse error: {e}")),
     };
-    let limit = first(&params, "limit")
-        .and_then(|l| l.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_LIMIT)
-        .min(MAX_LIMIT);
+    if let Err(e) = validate_selector(&selector) {
+        return e.into_response();
+    }
+    let Some(_slot) = TailSlot::acquire() else {
+        return QueryError::Backend(format!(
+            "too many concurrent tail sessions (limit {MAX_TAIL_SESSIONS})"
+        ))
+        .into_response();
+    };
     // Docs become searchable only once their batch publishes a split
     // (up to ingest.max_batch_secs after arrival), so a hard cursor at
     // "now" would skip everything. Instead each tick re-scans a trailing
     // window and dedupes what it already emitted; the watermark advances
     // once entries are old enough that late publishes are no longer
-    // expected. Emission latency is one publish + one poll tick.
+    // expected. Emission latency is one publish + one poll tick. Dedup
+    // hashes (ts, line, labels) — identical duplicate lines within one
+    // millisecond collapse to one emission; an accepted trade-off of the
+    // re-scan design.
     const TAIL_RESCAN_MS: i64 = 60_000;
     const TAIL_SEEN_CAP: usize = 100_000;
-    let mut watermark_ms = first(&params, "start")
-        .and_then(parse_time_ms)
-        .unwrap_or_else(|| now_ms() - 5_000);
+    let mut watermark_ms = match first(&params, "start").map(parse_time_ms) {
+        Some(None) => return bad_request("invalid 'start' timestamp"),
+        Some(Some(start)) => start,
+        None => now_ms() - 5_000,
+    };
 
     ws.on_upgrade(move |mut socket| async move {
         use std::hash::{Hash, Hasher};
+        let _slot = _slot; // owned by the session; frees the slot on exit
         let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
+        // Detect half-open peers (client vanished without a close frame):
+        // periodic pings force the socket to surface the failure.
+        let mut ping_interval = tokio::time::interval(std::time::Duration::from_secs(10));
+        let deadline =
+            tokio::time::Instant::now() + std::time::Duration::from_secs(TAIL_MAX_SESSION_SECS);
         loop {
             tokio::select! {
                 message = socket.recv() => {
-                    // Client closed (or errored): stop tailing.
                     match message {
                         None | Some(Err(_)) => return,
                         Some(Ok(axum::extract::ws::Message::Close(_))) => return,
-                        Some(Ok(_)) => {}
+                        Some(Ok(_)) => {} // pongs and client chatter
+                    }
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    let _ = socket.send(axum::extract::ws::Message::Close(None)).await;
+                    return;
+                }
+                _ = ping_interval.tick() => {
+                    if socket
+                        .send(axum::extract::ws::Message::Ping(Vec::new().into()))
+                        .await
+                        .is_err()
+                    {
+                        return;
                     }
                 }
                 _ = interval.tick() => {
@@ -894,13 +1455,17 @@ pub async fn tail(
                     if end_ms <= watermark_ms {
                         continue;
                     }
-                    let hits = match run_log_query(
-                        &state, &selector, watermark_ms, end_ms, limit, true,
+                    // Fetch newest-first with the full scan budget (not the
+                    // client display limit) so a busy window doesn't starve
+                    // recent lines behind old ones.
+                    let outcome = match run_log_query(
+                        &state, &selector, watermark_ms, end_ms, SCAN_LIMIT, false,
                     ).await {
-                        Ok(hits) => hits,
+                        Ok(outcome) => outcome,
                         Err(_) => continue, // transient; retry next tick
                     };
-                    let fresh: Vec<LogHit> = hits
+                    let saturated = outcome.hits.len() >= SCAN_LIMIT;
+                    let mut fresh: Vec<LogHit> = outcome.hits
                         .into_iter()
                         .filter(|hit| {
                             let mut hasher =
@@ -909,9 +1474,13 @@ pub async fn tail(
                             seen.insert(hasher.finish())
                         })
                         .collect();
-                    // Advance past entries old enough that a late split
-                    // publish can no longer add to them; prune the dedup
-                    // set to the remaining window (or reset if flooded).
+                    fresh.sort_by_key(|h| h.ts_ms);
+                    if saturated {
+                        tracing::warn!(
+                            query = %query,
+                            "tail window saturated; oldest lines in the window may be skipped"
+                        );
+                    }
                     watermark_ms = watermark_ms.max(end_ms - TAIL_RESCAN_MS);
                     if seen.len() > TAIL_SEEN_CAP {
                         seen.clear();

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -5,6 +5,7 @@ mod auth_api;
 mod bulk_api;
 mod control;
 mod internal_api;
+mod loki_api;
 mod metrics;
 mod placement;
 mod routes;

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -39,6 +39,38 @@ pub fn router(state: AppState) -> Router {
             post(search_api::search).get(search_api::search),
         )
         .route("/_msearch", post(search_api::msearch))
+        // Loki-compatible query API subset (#11): lets Grafana's built-in
+        // Loki datasource and Logs Drilldown run against rSearch.
+        .route("/ready", get(crate::loki_api::ready))
+        .route(
+            "/loki/api/v1/query_range",
+            get(crate::loki_api::query_range).post(crate::loki_api::query_range),
+        )
+        .route(
+            "/loki/api/v1/query",
+            get(crate::loki_api::query_instant).post(crate::loki_api::query_instant),
+        )
+        .route(
+            "/loki/api/v1/labels",
+            get(crate::loki_api::labels).post(crate::loki_api::labels),
+        )
+        .route(
+            "/loki/api/v1/label/{name}/values",
+            get(crate::loki_api::label_values),
+        )
+        .route(
+            "/loki/api/v1/series",
+            get(crate::loki_api::series).post(crate::loki_api::series),
+        )
+        .route(
+            "/loki/api/v1/index/volume",
+            get(crate::loki_api::volume).post(crate::loki_api::volume),
+        )
+        .route(
+            "/loki/api/v1/index/volume_range",
+            get(crate::loki_api::volume_range).post(crate::loki_api::volume_range),
+        )
+        .route("/loki/api/v1/tail", get(crate::loki_api::tail))
         .route("/{index}/_mapping", get(search_api::get_mapping))
         .route("/{index}", axum::routing::put(search_api::put_index))
         .route("/_cat/indices", get(crate::admin_api::cat_indices))

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -33,6 +33,15 @@ pub struct AppState {
     /// `_msearch` refresh resolves `logs-*` once per TTL instead of one
     /// `list_streams` query per header/body pair per viewer.
     pub stream_names: Arc<std::sync::Mutex<Option<(Arc<Vec<String>>, std::time::Instant)>>>,
+    /// Stream → keyword-mapped field names (its Loki "labels"), cached
+    /// briefly: the Loki endpoints and every tail poll would otherwise
+    /// hit the metastore once per stream per request.
+    #[allow(clippy::type_complexity)]
+    pub label_fields: Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<String, (Arc<Vec<String>>, std::time::Instant)>,
+        >,
+    >,
 }
 
 impl AppState {
@@ -57,7 +66,47 @@ impl AppState {
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             control: None,
             stream_names: Arc::new(std::sync::Mutex::new(None)),
+            label_fields: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }
+    }
+
+    /// A stream's keyword-mapped field names, cached for a few seconds.
+    /// Missing streams resolve to an empty list (not an error).
+    pub async fn cached_label_fields(&self, stream: &str) -> Arc<Vec<String>> {
+        const TTL: std::time::Duration = std::time::Duration::from_secs(10);
+        if let Some((fields, at)) = self.label_fields.lock().unwrap().get(stream)
+            && at.elapsed() < TTL
+        {
+            return fields.clone();
+        }
+        let fields: Arc<Vec<String>> = Arc::new(match self.metastore.get_stream(stream).await {
+            Ok(record) => {
+                let mut fields: Vec<String> = record
+                    .mapping
+                    .get("properties")
+                    .and_then(serde_json::Value::as_object)
+                    .map(|props| {
+                        props
+                            .iter()
+                            .filter(|(_, spec)| {
+                                spec.get("type").and_then(serde_json::Value::as_str)
+                                    == Some("keyword")
+                            })
+                            .map(|(name, _)| name.clone())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                fields.sort();
+                fields
+            }
+            Err(_) => Vec::new(),
+        });
+        let mut cache = self.label_fields.lock().unwrap();
+        if cache.len() > 10_000 {
+            cache.clear();
+        }
+        cache.insert(stream.to_string(), (fields.clone(), std::time::Instant::now()));
+        fields
     }
 
     /// All stream names, cached briefly (see `stream_names`).


### PR DESCRIPTION
Closes #11.

Adds a Loki HTTP query API subset so Grafana's built-in Loki datasource — and Logs Drilldown — work against rSearch with no plugins.

## Endpoints
- `GET/POST /loki/api/v1/query_range` — log selectors return `streams`; `count_over_time`/`rate` (with `sum` / `sum by (label)`) return `matrix`
- `GET/POST /loki/api/v1/query` — instant queries (vector for metrics, recent lines for selectors)
- `GET /loki/api/v1/labels`, `GET /loki/api/v1/label/{name}/values` — label discovery
- `GET/POST /loki/api/v1/series`
- `GET/POST /loki/api/v1/index/volume` + `/index/volume_range` — Drilldown's volume breakdowns (`targetLabels`/`aggregateBy` honored)
- `GET /loki/api/v1/tail` — WebSocket live tail
- `GET /ready` — Loki readiness probe (open, like `/health`)

## Model mapping
- **`service_name` label ⇄ stream name** — every stream shows up as a browsable service in Drilldown
- **Other labels ⇄ the stream's keyword-mapped fields**, values from terms aggregations capped at 1000
- **Line** = the doc's `message` field, else the raw `_source` JSON; Loki nanosecond timestamps converted at the edge

## Implementation notes
- New `rsearch_search::logql` parser (hand-rolled, unit-tested) covering the subset Grafana sends: `=`/`!=`/`=~`/`!~` matchers, `|=`/`!=` line filters (regex line filters return a clear 400), `count_over_time`, `rate`, `sum`/`sum by`
- Execution reuses the existing ES-DSL search path per stream with bounded 8-way fan-out; regex label matchers expand against aggregated field values; a matcher that can never match skips the stream entirely
- **Tail** re-scans a trailing 60s window with a dedup set instead of a hard cursor — docs only become searchable when their batch publishes a split (up to `ingest.max_batch_secs` later), and a hard cursor at *now* would silently skip everything. Emission latency is one publish + one 1s poll tick.
- Auth: `/loki/api/v1/*` classifies as global search access (same as `/_msearch`); Grafana's Basic auth rides the cached-PBKDF2 path from #7
- `/loki/api/v1/patterns` intentionally not implemented — Drilldown degrades gracefully without it

## Verification
- `cargo check --workspace --all-targets` clean; 63 tests pass (4 new LogQL parser tests)
- Exercised end-to-end against a live node: label discovery, filtered/negated/regex-selector log queries across multiple streams, `sum by (level)` matrices, per-stream `rate`, volume + volume-by-label ordering, series, instant vector, error paths — all returned correct Loki-shaped results
- WebSocket tail verified with a raw WS client: handshake 101, then a live-pushed doc arrived as a correctly-shaped `streams` frame