### PR TITLE
Prepare workspace for crates.io: 100% rustdoc coverage + publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.97"
 publish = true
 repository = "https://github.com/ZerosAndOnesLLC/rSearch"
 readme = "README.md"
-keywords = ["search", "logging", "opensearch", "fips", "tantivy"]
+keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -9,14 +9,23 @@ use crate::role::Role;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RsearchConfig {
+    /// Node identity, roles, data directory, and advertise address.
     pub node: NodeConfig,
+    /// HTTP API bind address, TLS, and CORS settings.
     pub http: HttpConfig,
+    /// Object storage backend (fs, s3, or replicated) settings.
     pub storage: StorageConfig,
+    /// Postgres metastore connection settings.
     pub metastore: MetastoreConfig,
+    /// Ingest batching, queue, and WAL settings.
     pub ingest: IngestConfig,
+    /// Search-node settings (split cache budget).
     pub search: SearchConfig,
+    /// Control-plane (leader) job settings.
     pub control: ControlConfig,
+    /// Syslog/GELF input listener settings.
     pub inputs: InputsConfig,
+    /// Node-to-node settings for the replicated storage backend.
     pub cluster: ClusterConfig,
 }
 
@@ -50,16 +59,21 @@ pub struct ClusterConfig {
     pub peer_ca_file: String,
 }
 
+/// Built-in log input listeners (syslog and GELF).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct InputsConfig {
+    /// Syslog (UDP/TCP) listener settings.
     pub syslog: SyslogInputConfig,
+    /// GELF (TCP) listener settings.
     pub gelf: GelfInputConfig,
 }
 
+/// Syslog input listener (RFC3164/RFC5424 over UDP and TCP).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SyslogInputConfig {
+    /// Whether the syslog listeners run at all. Default false.
     pub enabled: bool,
     /// UDP bind address; empty disables UDP.
     pub bind_udp: String,
@@ -67,6 +81,7 @@ pub struct SyslogInputConfig {
     pub bind_tcp: String,
     /// TLS for the TCP listener (FIPS provider); both paths set = enabled.
     pub tls_cert_path: String,
+    /// TLS private key path for the TCP listener.
     pub tls_key_path: String,
     /// Stream syslog messages are routed to by default.
     pub stream: String,
@@ -85,14 +100,19 @@ impl Default for SyslogInputConfig {
     }
 }
 
+/// GELF input listener (Graylog Extended Log Format over TCP).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct GelfInputConfig {
+    /// Whether the GELF listener runs at all. Default false.
     pub enabled: bool,
     /// TCP bind address (null-byte-framed GELF).
     pub bind_tcp: String,
+    /// TLS certificate path; both paths set = TLS enabled.
     pub tls_cert_path: String,
+    /// TLS private key path for the listener.
     pub tls_key_path: String,
+    /// Stream GELF messages are routed to by default.
     pub stream: String,
 }
 
@@ -108,6 +128,7 @@ impl Default for GelfInputConfig {
     }
 }
 
+/// Leader-run control-plane jobs: merge, GC, orphan sweeps, repair.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ControlConfig {
@@ -155,6 +176,7 @@ impl Default for ControlConfig {
     }
 }
 
+/// Search-node settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct SearchConfig {
@@ -168,6 +190,7 @@ impl Default for SearchConfig {
     }
 }
 
+/// Identity and local layout of this node.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct NodeConfig {
@@ -198,10 +221,13 @@ impl Default for NodeConfig {
     }
 }
 
+/// HTTP API server settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct HttpConfig {
+    /// Listen address for the HTTP API. Default "0.0.0.0:9200".
     pub bind_addr: String,
+    /// TLS settings for the HTTP listener.
     pub tls: TlsConfig,
     /// Value for Access-Control-Allow-Origin. Defaults to "*"; set to a
     /// specific origin to restrict browser access (auth is header-based,
@@ -219,11 +245,15 @@ impl Default for HttpConfig {
     }
 }
 
+/// TLS material for the HTTP listener (FIPS rustls provider).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TlsConfig {
+    /// Serve HTTPS instead of plain HTTP. Default false.
     pub enabled: bool,
+    /// Path to the PEM certificate chain.
     pub cert_path: String,
+    /// Path to the PEM private key.
     pub key_path: String,
 }
 
@@ -237,6 +267,7 @@ impl Default for TlsConfig {
     }
 }
 
+/// Object storage settings shared by all backends.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
@@ -260,6 +291,7 @@ pub struct StorageConfig {
     /// When empty, the AWS credential chain is used (env, profile,
     /// task role, IMDS) — intended for real AWS with IAM roles.
     pub access_key_id: String,
+    /// Secret half of the static credentials; see access_key_id.
     pub secret_access_key: String,
     /// Replicated backend: copies kept per object across storage nodes.
     pub replication_factor: usize,
@@ -301,11 +333,13 @@ impl StorageConfig {
     }
 }
 
+/// Postgres metastore connection settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct MetastoreConfig {
     /// Postgres connection URL; empty means read DATABASE_URL.
     pub database_url: String,
+    /// Connection pool size. Default 10.
     pub max_connections: u32,
 }
 
@@ -318,6 +352,7 @@ impl Default for MetastoreConfig {
     }
 }
 
+/// Ingest pipeline batching, queueing, and WAL settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct IngestConfig {
@@ -385,6 +420,8 @@ impl RsearchConfig {
         Ok(loaded)
     }
 
+    /// Configured node id, falling back to "rsearch-node" when neither
+    /// config nor hostname provided one.
     pub fn node_id(&self) -> String {
         self.node
             .id

--- a/crates/rsearch-common/src/error.rs
+++ b/crates/rsearch-common/src/error.rs
@@ -1,21 +1,29 @@
 use thiserror::Error;
 
+/// Workspace-wide error type shared by all rSearch crates.
 #[derive(Debug, Error)]
 pub enum RsearchError {
+    /// Invalid or unloadable configuration (bad TOML, env vars, TLS
+    /// material).
     #[error("configuration error: {0}")]
     Config(String),
 
+    /// Object storage operation failed.
     #[error("storage error: {0}")]
     Storage(String),
 
+    /// Postgres metastore query or connection failed.
     #[error("metastore error: {0}")]
     Metastore(String),
 
+    /// Index build, open, or search failed.
     #[error("index error: {0}")]
     Index(String),
 
+    /// Underlying filesystem/network I/O failed.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
 
+/// Convenience alias for results carrying [`RsearchError`].
 pub type Result<T> = std::result::Result<T, RsearchError>;

--- a/crates/rsearch-common/src/lib.rs
+++ b/crates/rsearch-common/src/lib.rs
@@ -1,10 +1,16 @@
+#![warn(missing_docs)]
 //! Shared foundations for the rSearch workspace: configuration loading
 //! (TOML + `RSEARCH_` env overrides), node roles, FIPS TLS setup,
 //! password/token crypto, error types, and telemetry init.
 
+/// Configuration types and TOML/env loading.
 pub mod config;
 pub mod crypto;
+/// Shared error type and result alias.
 pub mod error;
+/// Node roles (ingest/search/control) and role-list parsing.
 pub mod role;
+/// Tracing/logging initialization.
 pub mod telemetry;
+/// FIPS-provider rustls setup for servers and clients.
 pub mod tls;

--- a/crates/rsearch-common/src/role.rs
+++ b/crates/rsearch-common/src/role.rs
@@ -8,12 +8,16 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
+    /// Accepts writes: runs the WAL, batching, and split building.
     Ingest,
+    /// Serves queries: downloads and caches splits, executes searches.
     Search,
+    /// Runs leader-elected cluster jobs: merge, GC, repair, alerts.
     Control,
 }
 
 impl Role {
+    /// Every role, in canonical order; the default role set for a node.
     pub const ALL: [Role; 3] = [Role::Ingest, Role::Search, Role::Control];
 }
 

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -24,8 +24,11 @@ pub struct SplitBuilder {
 /// A finished split: a single bundled file on local disk plus its
 /// metadata, ready to upload and publish.
 pub struct PackagedSplit {
+    /// The split's descriptive metadata (also in the bundle footer).
     pub meta: SplitMeta,
+    /// Path of the bundled split file on local disk.
     pub file_path: PathBuf,
+    /// Total size of the bundled file in bytes.
     pub size_bytes: u64,
     /// Length of the footer metadata JSON (for single-range-read opens).
     pub footer_len: u64,
@@ -63,10 +66,12 @@ impl SplitBuilder {
         })
     }
 
+    /// The generated id this split will be published under.
     pub fn split_id(&self) -> &str {
         &self.split_id
     }
 
+    /// Documents buffered so far.
     pub fn doc_count(&self) -> u64 {
         self.doc_count
     }

--- a/crates/rsearch-index/src/cache.rs
+++ b/crates/rsearch-index/src/cache.rs
@@ -27,6 +27,8 @@ struct CacheState {
 }
 
 impl SplitCache {
+    /// Open a cache rooted at `root` with a `max_bytes` budget, adopting
+    /// any entries already on disk from a previous run.
     pub fn new(root: impl Into<PathBuf>, max_bytes: u64) -> std::io::Result<Self> {
         let root = root.into();
         std::fs::create_dir_all(&root)?;
@@ -194,10 +196,12 @@ impl SplitCache {
         Ok(path)
     }
 
+    /// Current bytes held across all cached entries.
     pub fn total_bytes(&self) -> u64 {
         self.state.lock().unwrap().total_bytes
     }
 
+    /// The cache's on-disk root directory.
     pub fn root(&self) -> &Path {
         &self.root
     }

--- a/crates/rsearch-index/src/document.rs
+++ b/crates/rsearch-index/src/document.rs
@@ -67,10 +67,12 @@ pub struct DocumentConverter {
 }
 
 impl DocumentConverter {
+    /// Create a converter for the given schema.
     pub fn new(schema: MappedSchema) -> Self {
         Self { schema }
     }
 
+    /// The schema documents are converted against.
     pub fn schema(&self) -> &MappedSchema {
         &self.schema
     }

--- a/crates/rsearch-index/src/error.rs
+++ b/crates/rsearch-index/src/error.rs
@@ -1,18 +1,25 @@
 use thiserror::Error;
 
+/// Errors from mapping parsing, split building, and split reading.
 #[derive(Debug, Error)]
 pub enum IndexError {
+    /// The ES-style mapping JSON is malformed or uses an unsupported
+    /// field type / reserved name.
     #[error("invalid mapping: {0}")]
     InvalidMapping(String),
 
+    /// A document or split object could not be parsed or read.
     #[error("invalid document: {0}")]
     InvalidDocument(String),
 
+    /// Underlying Tantivy index operation failed.
     #[error("tantivy error: {0}")]
     Tantivy(#[from] tantivy::TantivyError),
 
+    /// Underlying filesystem I/O failed.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
 
+/// Convenience alias for results carrying [`IndexError`].
 pub type IndexResult<T> = Result<T, IndexError>;

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Index engine: ES-style mappings translated onto Tantivy schemas, and
 //! immutable split files built from batches of log documents.
 

--- a/crates/rsearch-index/src/mapping.rs
+++ b/crates/rsearch-index/src/mapping.rs
@@ -16,12 +16,19 @@ pub const DYNAMIC_FIELD: &str = "_dynamic";
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FieldType {
+    /// Exact-match string (indexed untokenized, fast field).
     Keyword,
+    /// Full-text string (tokenized, scored).
     Text,
+    /// 64-bit signed integer (also covers ES integer/short/byte).
     Long,
+    /// 64-bit float (also covers ES float/half_float).
     Double,
+    /// Boolean flag.
     Boolean,
+    /// Timestamp, indexed at millisecond precision.
     Date,
+    /// IP address (v4 mapped to v6), range-queryable.
     Ip,
 }
 
@@ -47,6 +54,7 @@ impl FieldType {
 /// indexed dynamically under the `_dynamic` JSON field.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct IndexMapping {
+    /// Field name -> declared type for explicitly mapped fields.
     pub properties: BTreeMap<String, FieldType>,
 }
 
@@ -98,15 +106,23 @@ impl IndexMapping {
 /// reserved fields and every mapped field.
 #[derive(Clone)]
 pub struct MappedSchema {
+    /// The built Tantivy schema.
     pub schema: Schema,
+    /// Handle to the stored `_source` field.
     pub source: Field,
+    /// Handle to the indexed `_timestamp` fast field.
     pub timestamp: Field,
+    /// Handle to the `_dynamic` JSON field for unmapped keys.
     pub dynamic: Field,
+    /// Handles and types for every explicitly mapped field.
     pub fields: BTreeMap<String, (Field, FieldType)>,
+    /// The mapping this schema was built from.
     pub mapping: IndexMapping,
 }
 
 impl MappedSchema {
+    /// Build the Tantivy schema: reserved fields plus one field per
+    /// mapping entry, typed per [`FieldType`].
     pub fn build(mapping: IndexMapping) -> Self {
         let mut builder = Schema::builder();
         let source = builder.add_text_field(SOURCE_FIELD, STORED);

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -18,6 +18,7 @@ use crate::split_file::{BundleMeta, FOOTER_TAIL_LEN, parse_footer_tail, parse_me
 /// Opening reads only the footer; internal files are range-read from
 /// storage on first use and cached on local disk.
 pub struct SplitReader {
+    /// Footer metadata: bundled file map plus split metadata.
     pub meta: BundleMeta,
     index: Index,
     /// Built once and reused: splits are immutable, so re-opening every
@@ -91,6 +92,7 @@ impl SplitReader {
         })
     }
 
+    /// The underlying lazily-fetching Tantivy index.
     pub fn index(&self) -> &Index {
         &self.index
     }

--- a/crates/rsearch-index/src/split_file.rs
+++ b/crates/rsearch-index/src/split_file.rs
@@ -22,7 +22,9 @@ pub const FOOTER_TAIL_LEN: u64 = 16;
 /// Location of one bundled file within the split object.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FileSpan {
+    /// Byte offset of the file within the split object.
     pub offset: u64,
+    /// File length in bytes.
     pub len: u64,
 }
 
@@ -30,11 +32,15 @@ pub struct FileSpan {
 /// the metastore when the split is published.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct SplitMeta {
+    /// Unique split identifier (UUID, simple format).
     pub split_id: String,
+    /// Stream the split's documents belong to.
     pub stream: String,
+    /// Number of documents in the split.
     pub doc_count: u64,
     /// Inclusive document-timestamp range, epoch milliseconds.
     pub time_start_millis: i64,
+    /// Upper end of the inclusive timestamp range, epoch millis.
     pub time_end_millis: i64,
     /// The index mapping the split was built with (ES mapping shape).
     pub mapping: serde_json::Value,
@@ -43,7 +49,9 @@ pub struct SplitMeta {
 /// Full footer contents: bundled file map + split metadata.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BundleMeta {
+    /// Bundled file name -> its byte span within the object.
     pub files: BTreeMap<String, FileSpan>,
+    /// Descriptive split metadata.
     pub split: SplitMeta,
 }
 

--- a/crates/rsearch-ingest/src/bulk.rs
+++ b/crates/rsearch-ingest/src/bulk.rs
@@ -4,13 +4,18 @@
 
 use serde_json::Value;
 
+/// Accepted bulk action kinds (both index the document; the immutable
+/// log store makes no update-vs-create distinction).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BulkAction {
+    /// An `{"index": …}` action line.
     Index,
+    /// A `{"create": …}` action line.
     Create,
 }
 
 impl BulkAction {
+    /// The action name as it appears on the wire (for responses).
     pub fn as_str(&self) -> &'static str {
         match self {
             BulkAction::Index => "index",
@@ -22,9 +27,13 @@ impl BulkAction {
 /// One accepted document.
 #[derive(Debug)]
 pub struct BulkItem {
+    /// The action kind that carried the document.
     pub action: BulkAction,
+    /// Target stream: the action line's `_index`, or the URL default.
     pub stream: String,
+    /// Document id: the action line's `_id`, or a generated UUID.
     pub doc_id: String,
+    /// The parsed document body.
     pub doc: Value,
     /// The client's original document line, stored verbatim as `_source`
     /// and written to the WAL — avoids re-serializing the parsed value.

--- a/crates/rsearch-ingest/src/error.rs
+++ b/crates/rsearch-ingest/src/error.rs
@@ -1,24 +1,32 @@
 use thiserror::Error;
 
+/// Errors returned by the ingest path.
 #[derive(Debug, Error)]
 pub enum IngestError {
+    /// Bulk body too malformed to produce per-item responses.
     #[error("malformed bulk body: {0}")]
     MalformedBulk(String),
 
+    /// The stream's bounded queue is full — callers report 429.
     #[error("ingest queue is full")]
     Saturated,
 
+    /// WAL I/O failure (append, fsync, or replay).
     #[error("wal error: {0}")]
     Wal(#[from] std::io::Error),
 
+    /// Split build/packaging failure.
     #[error("index error: {0}")]
     Index(#[from] rsearch_index::IndexError),
 
+    /// Metastore operation failure.
     #[error("metastore error: {0}")]
     Metastore(#[from] rsearch_metastore::MetastoreError),
 
+    /// Object storage failure (split upload).
     #[error("storage error: {0}")]
     Storage(#[from] rsearch_storage::StorageError),
 }
 
+/// Convenience alias for fallible ingest operations.
 pub type IngestResult<T> = Result<T, IngestError>;

--- a/crates/rsearch-ingest/src/lib.rs
+++ b/crates/rsearch-ingest/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Ingest path: `_bulk` parsing, append-before-ack WAL, and the per-stream
 //! indexer pipeline that turns buffered documents into published splits.
 

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -19,13 +19,22 @@ use rsearch_storage::Storage;
 use crate::error::{IngestError, IngestResult};
 use crate::wal::{Wal, WalPos, WalReplay};
 
+/// Tuning knobs for the ingest pipeline.
 #[derive(Clone)]
 pub struct PipelineConfig {
+    /// Flush a batch into a split once it holds this many documents.
     pub max_batch_docs: usize,
+    /// Flush a non-empty batch after this many seconds regardless of
+    /// size (bounds time-to-searchable).
     pub max_batch_secs: u64,
+    /// Per-stream bounded queue depth in documents; a full queue
+    /// rejects with [`IngestError::Saturated`].
     pub queue_capacity: usize,
+    /// Local scratch directory splits are built in before upload.
     pub work_dir: PathBuf,
+    /// Indexer memory budget in bytes for each split build.
     pub memory_budget: usize,
+    /// This node's id, recorded as each split's creator.
     pub node_id: String,
 }
 
@@ -41,11 +50,17 @@ struct WorkItem {
 /// Ingest metrics counters (monotonic).
 #[derive(Default)]
 pub struct IngestMetrics {
+    /// Documents accepted onto worker queues.
     pub docs_enqueued: AtomicU64,
+    /// Source bytes accepted onto worker queues.
     pub bytes_enqueued: AtomicU64,
+    /// Documents indexed into built splits.
     pub docs_indexed: AtomicU64,
+    /// Splits published in the metastore.
     pub splits_published: AtomicU64,
+    /// Failed split flushes (build/upload/publish errors).
     pub flush_failures: AtomicU64,
+    /// Current documents queued across all streams (gauge).
     pub queue_depth: AtomicU64,
 }
 
@@ -67,6 +82,8 @@ struct PipelineInner {
     rules: std::sync::RwLock<Arc<Vec<rsearch_metastore::RoutingRuleRecord>>>,
 }
 
+/// Cloneable handle to the shared ingest pipeline: routes documents,
+/// appends them to the WAL, and feeds per-stream indexer workers.
 #[derive(Clone)]
 pub struct IngestPipeline {
     inner: Arc<PipelineInner>,
@@ -81,6 +98,8 @@ fn now_datetime() -> rsearch_index::DateTime {
 }
 
 impl IngestPipeline {
+    /// Build the pipeline and spawn the periodic routing-rule refresh
+    /// task. Workers are created lazily per stream on first enqueue.
     pub fn new(
         config: PipelineConfig,
         storage: Arc<dyn Storage>,
@@ -209,10 +228,12 @@ impl IngestPipeline {
         Ok((accepted, dropped))
     }
 
+    /// The pipeline's metrics counters.
     pub fn metrics(&self) -> &IngestMetrics {
         &self.inner.metrics
     }
 
+    /// The shared WAL handle.
     pub fn wal(&self) -> &Arc<Wal> {
         &self.inner.wal
     }

--- a/crates/rsearch-ingest/src/wal.rs
+++ b/crates/rsearch-ingest/src/wal.rs
@@ -13,14 +13,18 @@ use std::sync::Mutex;
 /// Position of a record: the segment that holds it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WalPos {
+    /// Sequence number of the segment file holding the record.
     pub segment: u64,
 }
 
 /// A replayed record.
 #[derive(Debug, Clone)]
 pub struct WalRecord {
+    /// Target stream the document was accepted for.
     pub stream: String,
+    /// Raw document JSON bytes as originally appended.
     pub doc: Vec<u8>,
+    /// Position to confirm once the document is published.
     pub pos: WalPos,
 }
 

--- a/crates/rsearch-metastore/src/alerts.rs
+++ b/crates/rsearch-metastore/src/alerts.rs
@@ -3,19 +3,33 @@
 use crate::error::{MetastoreError, MetastoreResult};
 use crate::metastore::Metastore;
 
+/// An alert definition: periodically run `query` over the trailing
+/// window and fire a webhook when the hit count crosses `threshold`.
 #[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
 pub struct AlertRecord {
+    /// Primary key.
     pub id: i64,
+    /// Unique alert name (upsert key).
     pub name: String,
+    /// Stream (index) the query runs against.
     pub stream: String,
+    /// ES query DSL body executed for each run.
     pub query: serde_json::Value,
+    /// gt | lt — how the hit count is compared to `threshold`.
     pub condition_op: String,
+    /// Hit-count threshold the comparison uses.
     pub threshold: i64,
+    /// Trailing time window each run queries, in seconds.
     pub window_secs: i64,
+    /// Minimum seconds between runs.
     pub interval_secs: i64,
+    /// URL POSTed to when the condition is met.
     pub webhook_url: String,
+    /// Disabled alerts are never scheduled.
     pub enabled: bool,
+    /// Status recorded by the most recent run; None before the first.
     pub last_status: Option<String>,
+    /// Hit count from the most recent run; None before the first.
     pub last_count: Option<i64>,
 }
 
@@ -23,6 +37,8 @@ const ALERT_COLUMNS: &str = "id, name, stream, query, condition_op, threshold, \
      window_secs, interval_secs, webhook_url, enabled, last_status, last_count";
 
 impl Metastore {
+    /// Create or update (by name) an alert definition. Rejects any
+    /// `condition_op` other than gt or lt.
     #[allow(clippy::too_many_arguments)]
     pub async fn upsert_alert(
         &self,
@@ -66,6 +82,7 @@ impl Metastore {
             .await?)
     }
 
+    /// All alerts, ordered by name.
     pub async fn list_alerts(&self) -> MetastoreResult<Vec<AlertRecord>> {
         let query = format!("SELECT {ALERT_COLUMNS} FROM alerts ORDER BY name");
         Ok(sqlx::query_as::<_, AlertRecord>(sqlx::AssertSqlSafe(query))
@@ -73,6 +90,7 @@ impl Metastore {
             .await?)
     }
 
+    /// Delete an alert by name; false if no such alert existed.
     pub async fn delete_alert(&self, name: &str) -> MetastoreResult<bool> {
         let result = sqlx::query("DELETE FROM alerts WHERE name = $1")
             .bind(name)
@@ -95,6 +113,8 @@ impl Metastore {
             .await?)
     }
 
+    /// Stamp an alert's last run: time, status, and hit count (None
+    /// when the run failed before counting).
     pub async fn record_alert_run(
         &self,
         name: &str,

--- a/crates/rsearch-metastore/src/auth.rs
+++ b/crates/rsearch-metastore/src/auth.rs
@@ -5,27 +5,39 @@ use sqlx::Row;
 use crate::error::MetastoreResult;
 use crate::metastore::Metastore;
 
+/// A console user row.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UserRecord {
+    /// Primary key; sessions reference it via `user_id`.
     pub id: i64,
+    /// Unique login name.
     pub username: String,
+    /// Hashed password (never the plaintext).
     pub password_hash: String,
     /// admin | user
     pub role: String,
+    /// Streams the user may access; `"*"` grants all streams.
     pub streams: Vec<String>,
 }
 
+/// An API key row. The key itself is never stored — only its hash —
+/// so this record is safe to serialize in listings.
 #[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
 pub struct ApiKeyRecord {
+    /// Primary key.
     pub id: i64,
+    /// Unique key name (upsert key).
     pub name: String,
+    /// Granted actions: subset of ingest, search, admin.
     pub actions: Vec<String>,
+    /// Streams the key may access; `"*"` grants all streams.
     pub streams: Vec<String>,
 }
 
 const USER_COLUMNS: &str = "id, username, password_hash, role, streams";
 
 impl Metastore {
+    /// Total number of users (used for first-run admin bootstrap).
     pub async fn count_users(&self) -> MetastoreResult<i64> {
         let row = sqlx::query("SELECT count(*) AS n FROM users")
             .fetch_one(self.pool())
@@ -33,6 +45,7 @@ impl Metastore {
         Ok(row.get::<i64, _>("n"))
     }
 
+    /// Create or update (by username) a user.
     pub async fn upsert_user(
         &self,
         username: &str,
@@ -56,6 +69,7 @@ impl Metastore {
             .await?)
     }
 
+    /// Look up a user by username.
     pub async fn get_user(&self, username: &str) -> MetastoreResult<Option<UserRecord>> {
         let query = format!("SELECT {USER_COLUMNS} FROM users WHERE username = $1");
         Ok(sqlx::query_as::<_, UserRecord>(sqlx::AssertSqlSafe(query))
@@ -64,6 +78,7 @@ impl Metastore {
             .await?)
     }
 
+    /// All users, ordered by username.
     pub async fn list_users(&self) -> MetastoreResult<Vec<UserRecord>> {
         let query = format!("SELECT {USER_COLUMNS} FROM users ORDER BY username");
         Ok(sqlx::query_as::<_, UserRecord>(sqlx::AssertSqlSafe(query))
@@ -71,6 +86,7 @@ impl Metastore {
             .await?)
     }
 
+    /// Delete a user by username; false if no such user existed.
     pub async fn delete_user(&self, username: &str) -> MetastoreResult<bool> {
         let result = sqlx::query("DELETE FROM users WHERE username = $1")
             .bind(username)
@@ -81,6 +97,8 @@ impl Metastore {
 
     // ---- sessions ----
 
+    /// Store a login session keyed by token hash, expiring after
+    /// `ttl_secs`. Also sweeps already-expired sessions.
     pub async fn create_session(
         &self,
         token_hash: &str,
@@ -103,6 +121,8 @@ impl Metastore {
         Ok(())
     }
 
+    /// Resolve a session token hash to its user; None when the token
+    /// is unknown or the session has expired.
     pub async fn session_user(&self, token_hash: &str) -> MetastoreResult<Option<UserRecord>> {
         Ok(sqlx::query_as::<_, UserRecord>(
             "SELECT u.id, u.username, u.password_hash, u.role, u.streams
@@ -116,6 +136,7 @@ impl Metastore {
 
     // ---- api keys ----
 
+    /// Create or update (by name) an API key, storing only the hash.
     pub async fn create_api_key(
         &self,
         name: &str,
@@ -138,6 +159,8 @@ impl Metastore {
         .await?)
     }
 
+    /// Resolve an API key by its hash, stamping `last_used_at` at most
+    /// once per minute.
     pub async fn api_key_by_hash(&self, key_hash: &str) -> MetastoreResult<Option<ApiKeyRecord>> {
         // Throttle the last_used_at write to at most once per minute per
         // key so shipper auth doesn't generate a row write (+ dead tuples)
@@ -164,6 +187,7 @@ impl Metastore {
         .await?)
     }
 
+    /// All API keys, ordered by name.
     pub async fn list_api_keys(&self) -> MetastoreResult<Vec<ApiKeyRecord>> {
         Ok(sqlx::query_as::<_, ApiKeyRecord>(
             "SELECT id, name, actions, streams FROM api_keys ORDER BY name",
@@ -172,6 +196,7 @@ impl Metastore {
         .await?)
     }
 
+    /// Delete an API key by name; false if no such key existed.
     pub async fn delete_api_key(&self, name: &str) -> MetastoreResult<bool> {
         let result = sqlx::query("DELETE FROM api_keys WHERE name = $1")
             .bind(name)

--- a/crates/rsearch-metastore/src/error.rs
+++ b/crates/rsearch-metastore/src/error.rs
@@ -1,18 +1,25 @@
 use thiserror::Error;
 
+/// Errors returned by metastore operations.
 #[derive(Debug, Error)]
 pub enum MetastoreError {
+    /// Underlying Postgres/sqlx failure (also wraps invalid-input
+    /// configuration errors raised before a query runs).
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
 
+    /// Embedded schema migration failed at startup.
     #[error("migration error: {0}")]
     Migration(#[from] sqlx::migrate::MigrateError),
 
+    /// No stream with the given name (or id).
     #[error("stream not found: {0}")]
     StreamNotFound(String),
 
+    /// Split missing, or not in the state a transition requires.
     #[error("split not found or not in expected state: {0}")]
     SplitStateConflict(String),
 }
 
+/// Convenience alias for fallible metastore operations.
 pub type MetastoreResult<T> = Result<T, MetastoreError>;

--- a/crates/rsearch-metastore/src/lib.rs
+++ b/crates/rsearch-metastore/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Postgres metastore: the cluster's coordination layer. Tracks streams,
 //! split lifecycle (staged → published → marked_for_delete), and node
 //! liveness. All cross-node state lives here or in object storage.

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -9,6 +9,9 @@ use crate::types::{SplitRecord, SplitState, StreamRecord, StreamStats};
 const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
      size_bytes, time_start_millis, time_end_millis, footer_len, created_by";
 
+/// Postgres-backed metadata store shared by every node role: streams,
+/// splits, nodes, placement, auth, routing rules, and alerts. Cloning
+/// is cheap (shared pool).
 #[derive(Clone)]
 pub struct Metastore {
     pool: PgPool,
@@ -46,6 +49,7 @@ impl Metastore {
         })
     }
 
+    /// The underlying connection pool.
     pub fn pool(&self) -> &PgPool {
         &self.pool
     }
@@ -65,6 +69,7 @@ impl Metastore {
         Ok(row)
     }
 
+    /// Look up a stream by name; `StreamNotFound` if missing.
     pub async fn get_stream(&self, name: &str) -> MetastoreResult<StreamRecord> {
         sqlx::query_as::<_, StreamRecord>(
             "SELECT id, name, mapping, retention_hours FROM streams WHERE name = $1",
@@ -91,6 +96,7 @@ impl Metastore {
         .await?)
     }
 
+    /// Look up a stream by id; `StreamNotFound` if missing.
     pub async fn get_stream_by_id(&self, id: i64) -> MetastoreResult<StreamRecord> {
         sqlx::query_as::<_, StreamRecord>(
             "SELECT id, name, mapping, retention_hours FROM streams WHERE id = $1",
@@ -101,6 +107,7 @@ impl Metastore {
         .ok_or_else(|| MetastoreError::StreamNotFound(format!("id={id}")))
     }
 
+    /// All streams, ordered by name.
     pub async fn list_streams(&self) -> MetastoreResult<Vec<StreamRecord>> {
         Ok(sqlx::query_as::<_, StreamRecord>(
             "SELECT id, name, mapping, retention_hours FROM streams ORDER BY name",
@@ -109,6 +116,8 @@ impl Metastore {
         .await?)
     }
 
+    /// Replace a stream's mapping JSON (PUT /{index}); existing splits
+    /// keep the schema they were built with.
     pub async fn update_stream_mapping(
         &self,
         name: &str,
@@ -127,6 +136,7 @@ impl Metastore {
         Ok(())
     }
 
+    /// Set (or clear, with None) a stream's retention window in hours.
     pub async fn set_stream_retention(
         &self,
         name: &str,
@@ -145,6 +155,7 @@ impl Metastore {
         Ok(())
     }
 
+    /// Delete a stream row by name (idempotent).
     pub async fn delete_stream(&self, name: &str) -> MetastoreResult<()> {
         sqlx::query("DELETE FROM streams WHERE name = $1")
             .bind(name)
@@ -251,6 +262,8 @@ impl Metastore {
             .await?)
     }
 
+    /// Up to `limit` splits in `state`, oldest update first (so the
+    /// janitor and publisher drain backlogs in order).
     pub async fn splits_in_state(
         &self,
         state: SplitState,
@@ -267,6 +280,7 @@ impl Metastore {
             .await?)
     }
 
+    /// Look up a split by its split id.
     pub async fn get_split(&self, split_id: &str) -> MetastoreResult<Option<SplitRecord>> {
         let query = format!("SELECT {SPLIT_COLUMNS} FROM splits WHERE split_id = $1");
         Ok(sqlx::query_as::<_, SplitRecord>(sqlx::AssertSqlSafe(query))

--- a/crates/rsearch-metastore/src/routing.rs
+++ b/crates/rsearch-metastore/src/routing.rs
@@ -4,21 +4,31 @@
 use crate::error::{MetastoreError, MetastoreResult};
 use crate::metastore::Metastore;
 
+/// A routing rule: if `field` matches per `op`/`value`, the document is
+/// moved (or, with `copy`, also written) to `target_stream`.
 #[derive(Debug, Clone, sqlx::FromRow, serde::Serialize)]
 pub struct RoutingRuleRecord {
+    /// Primary key.
     pub id: i64,
+    /// Unique rule name (upsert key).
     pub name: String,
+    /// Top-level document field the condition inspects.
     pub field: String,
     /// eq | contains | exists
     pub op: String,
+    /// Comparison value; unused for `exists`.
     pub value: String,
+    /// Stream matching documents are routed to.
     pub target_stream: String,
+    /// true = copy (also keep the original destination);
+    /// false = move (replace it).
     pub copy: bool,
 }
 
 const RULE_COLUMNS: &str = "id, name, field, op, value, target_stream, copy";
 
 impl Metastore {
+    /// All routing rules, ordered by id (creation order).
     pub async fn list_routing_rules(&self) -> MetastoreResult<Vec<RoutingRuleRecord>> {
         let query = format!("SELECT {RULE_COLUMNS} FROM routing_rules ORDER BY id");
         Ok(sqlx::query_as::<_, RoutingRuleRecord>(sqlx::AssertSqlSafe(query))
@@ -26,6 +36,8 @@ impl Metastore {
             .await?)
     }
 
+    /// Create or update (by name) a routing rule. Rejects any `op`
+    /// other than eq, contains, or exists.
     pub async fn create_routing_rule(
         &self,
         name: &str,
@@ -59,6 +71,7 @@ impl Metastore {
             .await?)
     }
 
+    /// Delete a rule by name; false if no such rule existed.
     pub async fn delete_routing_rule(&self, name: &str) -> MetastoreResult<bool> {
         let result = sqlx::query("DELETE FROM routing_rules WHERE name = $1")
             .bind(name)

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -1,14 +1,19 @@
 use serde::{Deserialize, Serialize};
 
+/// Lifecycle state of a split.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SplitState {
+    /// Uploaded to storage but not yet visible to search.
     Staged,
+    /// Live: visible to search queries.
     Published,
+    /// Retired; the janitor deletes the object then the row.
     MarkedForDelete,
 }
 
 impl SplitState {
+    /// The snake_case string stored in the `state` column.
     pub fn as_str(&self) -> &'static str {
         match self {
             SplitState::Staged => "staged",
@@ -30,56 +35,86 @@ impl std::str::FromStr for SplitState {
     }
 }
 
+/// A stream (index) row.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct StreamRecord {
+    /// Primary key; splits reference it via `stream_id`.
     pub id: i64,
+    /// Unique stream (index) name.
     pub name: String,
+    /// ES-style field mapping JSON the index schema is built from.
     pub mapping: serde_json::Value,
+    /// Retention window in hours; None = keep forever.
     pub retention_hours: Option<i32>,
 }
 
+/// A split (immutable index file) row.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct SplitRecord {
+    /// Primary key.
     pub id: i64,
+    /// Globally unique split identifier.
     pub split_id: String,
+    /// Owning stream's `StreamRecord::id`.
     pub stream_id: i64,
+    /// Raw state string; parse via [`SplitRecord::state`].
     pub state: String,
+    /// Object key of the split file in storage.
     pub storage_key: String,
+    /// Number of documents in the split.
     pub doc_count: i64,
+    /// Split file size in bytes.
     pub size_bytes: i64,
+    /// Earliest document timestamp (epoch millis, inclusive).
     pub time_start_millis: i64,
+    /// Latest document timestamp (epoch millis, inclusive).
     pub time_end_millis: i64,
+    /// Byte length of the split file's footer metadata, so readers can
+    /// open the split with ranged reads of just the tail.
     pub footer_len: i64,
+    /// Id of the node that built the split, when known.
     pub created_by: Option<String>,
 }
 
 impl SplitRecord {
+    /// Parsed [`SplitState`]; unknown strings fall back to `Staged`.
     pub fn state(&self) -> SplitState {
         self.state.parse().unwrap_or(SplitState::Staged)
     }
 }
 
+/// Per-stream rollup over published splits (for `_cat/indices`).
 #[derive(Debug, Clone, sqlx::FromRow, Serialize)]
 pub struct StreamStats {
+    /// Stream name.
     pub name: String,
+    /// Retention window in hours; None = keep forever.
     pub retention_hours: Option<i32>,
+    /// Number of published splits.
     pub split_count: i64,
+    /// Total documents across published splits.
     pub doc_count: i64,
+    /// Total split bytes across published splits.
     pub size_bytes: i64,
 }
 
 /// A storage object with fewer live copies than the replication factor.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct UnderReplicatedKey {
+    /// Object key that needs more copies.
     pub storage_key: String,
     /// Copies on nodes whose heartbeat is within the staleness threshold.
     pub live_holders: i64,
 }
 
+/// A registered cluster node (for `_cat/nodes` and placement).
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct NodeRecord {
+    /// Unique node id.
     pub id: String,
+    /// Roles the node serves (e.g. ingest, search, control).
     pub roles: Vec<String>,
+    /// Advertised peer address; None if the node never announced one.
     pub address: Option<String>,
     /// Seconds since the node's last heartbeat.
     pub heartbeat_age_secs: f64,

--- a/crates/rsearch-search/src/error.rs
+++ b/crates/rsearch-search/src/error.rs
@@ -1,22 +1,28 @@
 use thiserror::Error;
 
+/// Errors returned by the search path.
 #[derive(Debug, Error)]
 pub enum SearchError {
     /// Client error — maps to HTTP 400 with the reason.
     #[error("{0}")]
     BadRequest(String),
 
+    /// Split open/read failure.
     #[error("index error: {0}")]
     Index(#[from] rsearch_index::IndexError),
 
+    /// Metastore operation failure (split pruning, stream lookup).
     #[error("metastore error: {0}")]
     Metastore(#[from] rsearch_metastore::MetastoreError),
 
+    /// Query execution failure inside Tantivy.
     #[error("tantivy error: {0}")]
     Tantivy(#[from] tantivy::TantivyError),
 
+    /// Internal failure (e.g. a search task panicked or was dropped).
     #[error("search task failed: {0}")]
     Internal(String),
 }
 
+/// Convenience alias for fallible search operations.
 pub type SearchResult<T> = Result<T, SearchError>;

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -52,12 +52,19 @@ const MAX_QUERY_SPLITS: usize = 10_000;
 
 /// A parsed `_search` request body.
 pub struct SearchRequest {
+    /// Stream (index) the search runs against.
     pub stream: String,
+    /// ES query DSL clause; defaults to `match_all`.
     pub query: Value,
+    /// Result offset (pagination); from+size is capped at 10k.
     pub from: usize,
+    /// Page size; defaults to 10.
     pub size: usize,
+    /// Timestamp sort direction; true (default) = newest first.
     pub sort_desc: bool,
+    /// ES `aggs`/`aggregations` body, if present.
     pub aggs: Option<Value>,
+    /// Whether hits include `_source` (`"_source": false` disables).
     pub include_source: bool,
     /// Exact-count ceiling; None = unbounded (always exact).
     pub track_total_hits: Option<usize>,
@@ -181,6 +188,8 @@ pub struct SearchService {
 }
 
 impl SearchService {
+    /// Build a search service over the given metastore, storage, and
+    /// shared split cache.
     pub fn new(metastore: Metastore, storage: Arc<dyn Storage>, cache: Arc<SplitCache>) -> Self {
         Self {
             metastore,

--- a/crates/rsearch-search/src/lib.rs
+++ b/crates/rsearch-search/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Search path: OpenSearch query-DSL subset translated onto Tantivy,
 //! executed across published splits, merged into ES-shaped responses.
 

--- a/crates/rsearch-search/src/logql.rs
+++ b/crates/rsearch-search/src/logql.rs
@@ -3,51 +3,80 @@
 //! Grafana's Loki datasource and Logs Drilldown actually send —
 //! `count_over_time`, `rate`, optionally wrapped in `sum` / `sum by (…)`.
 
+/// Label matcher operator inside a stream selector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MatchOp {
+    /// `=` — label equals the value.
     Eq,
+    /// `!=` — label differs from the value.
     Neq,
+    /// `=~` — label matches the regex.
     Re,
+    /// `!~` — label does not match the regex.
     NotRe,
 }
 
+/// One `label op "value"` matcher from a `{…}` stream selector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LabelMatcher {
+    /// Label name on the left of the operator.
     pub label: String,
+    /// The comparison operator.
     pub op: MatchOp,
+    /// The (unquoted) right-hand value or regex.
     pub value: String,
 }
 
+/// Line filter operator applied to log line contents.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FilterOp {
+    /// `|=` — line contains the text.
     Contains,    // |=
+    /// `!=` — line does not contain the text.
     NotContains, // !=
+    /// `|~` — line matches the regex.
     Regex,       // |~
+    /// `!~` — line does not match the regex.
     NotRegex,    // !~
 }
 
+/// One line filter stage, e.g. `|= "error"`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LineFilter {
+    /// The filter operator.
     pub op: FilterOp,
+    /// The (unquoted) text or regex to match lines against.
     pub text: String,
 }
 
+/// A log stream selector: `{matchers} filters…` — the log-query form
+/// and the inner part of every metric query.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct LogSelector {
+    /// Label matchers from the `{…}` selector.
     pub matchers: Vec<LabelMatcher>,
+    /// Line filter stages, applied in order.
     pub filters: Vec<LineFilter>,
 }
 
+/// Range-aggregation function of a metric query.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricOp {
+    /// `count_over_time(…)` — log lines per range interval.
     CountOverTime,
+    /// `rate(…)` — log lines per second over the range interval.
     Rate,
 }
 
+/// A metric query: `count_over_time`/`rate` over a selector and range,
+/// optionally wrapped in `sum` / `sum by (…)`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MetricQuery {
+    /// The wrapped stream selector.
     pub selector: LogSelector,
+    /// The `[range]` window converted to milliseconds.
     pub range_millis: i64,
+    /// Which range function was applied.
     pub op: MetricOp,
     /// Labels from `sum by (…)`; empty for plain `sum(…)` or no sum.
     pub group_by: Vec<String>,
@@ -56,9 +85,12 @@ pub struct MetricQuery {
     pub summed: bool,
 }
 
+/// A parsed LogQL query: either a plain log query or a metric query.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LogQlQuery {
+    /// A log query: stream selector plus line filters.
     Log(LogSelector),
+    /// A metric query over a range aggregation.
     Metric(MetricQuery),
 }
 
@@ -77,6 +109,8 @@ struct Parser<'a> {
     pos: usize,
 }
 
+/// Parse a LogQL query string (the supported subset); the error is a
+/// human-readable reason suitable for an HTTP 400 body.
 pub fn parse(input: &str) -> Result<LogQlQuery, String> {
     let mut parser = Parser {
         input: input.as_bytes(),

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -1,3 +1,6 @@
+//! rSearch server binary: role-driven node (ingest, search, control)
+//! exposing the OpenSearch- and Loki-compatible HTTP APIs.
+
 mod admin_api;
 mod alerts_api;
 mod auth;

--- a/crates/rsearch-storage/src/error.rs
+++ b/crates/rsearch-storage/src/error.rs
@@ -1,22 +1,38 @@
 use thiserror::Error;
 
+/// Errors returned by the object storage backends.
 #[derive(Debug, Error)]
 pub enum StorageError {
+    /// The requested object key does not exist.
     #[error("object not found: {0}")]
     NotFound(String),
 
+    /// Key rejected before any I/O (traversal, absolute path, or
+    /// otherwise malformed).
     #[error("invalid object key: {0}")]
     InvalidKey(String),
 
+    /// Filesystem or network I/O failed while operating on a key.
     #[error("io error on {key}: {source}")]
     Io {
+        /// Object key the operation was acting on.
         key: String,
+        /// Underlying I/O error.
         #[source]
         source: std::io::Error,
     },
 
+    /// Backend-specific failure (S3 API error, peer refusal, quorum
+    /// shortfall, misconfiguration).
     #[error("backend error on {key}: {message}")]
-    Backend { key: String, message: String },
+    Backend {
+        /// Object key the operation was acting on (may be empty for
+        /// configuration errors).
+        key: String,
+        /// Backend-provided failure description.
+        message: String,
+    },
 }
 
+/// Convenience alias for results carrying [`StorageError`].
 pub type StorageResult<T> = Result<T, StorageError>;

--- a/crates/rsearch-storage/src/fs.rs
+++ b/crates/rsearch-storage/src/fs.rs
@@ -21,6 +21,8 @@ pub struct FsStorage {
 static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 impl FsStorage {
+    /// Create a backend rooted at `root`; spawns a background sweep of
+    /// temp files stranded by earlier crashes.
     pub fn new(root: impl Into<PathBuf>) -> Self {
         let root: PathBuf = root.into();
         // Failed writes delete their temp on the error path, but a crash

--- a/crates/rsearch-storage/src/lib.rs
+++ b/crates/rsearch-storage/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(missing_docs)]
 //! Object storage abstraction. Local filesystem, S3, and S3-compatible
 //! (MinIO) backends are equal citizens: splits and other artifacts only
 //! ever go through the [`Storage`] trait.

--- a/crates/rsearch-storage/src/placement.rs
+++ b/crates/rsearch-storage/src/placement.rs
@@ -5,6 +5,7 @@ use crate::error::StorageResult;
 /// A peer node that can hold object copies.
 #[derive(Debug, Clone)]
 pub struct PeerNode {
+    /// Stable node identifier (nodes-table primary key).
     pub id: String,
     /// Dialable base URL from the node's heartbeat (advertise_url).
     pub address: Option<String>,

--- a/crates/rsearch-storage/src/replicated.rs
+++ b/crates/rsearch-storage/src/replicated.rs
@@ -28,6 +28,8 @@ enum PushSource {
     File(std::path::PathBuf),
 }
 
+/// Storage backend that replicates every object across peer nodes,
+/// backed by a local [`FsStorage`] root plus HTTP pushes/reads to peers.
 pub struct ReplicatedStorage {
     local: FsStorage,
     placement: Arc<dyn Placement>,
@@ -38,6 +40,9 @@ pub struct ReplicatedStorage {
 }
 
 impl ReplicatedStorage {
+    /// Build a replicated backend over a local root, a placement tracker,
+    /// and a peer HTTP client. `write_quorum` is clamped to
+    /// `replication_factor` (floor 1) at write time.
     pub fn new(
         local: FsStorage,
         placement: Arc<dyn Placement>,

--- a/crates/rsearch-storage/src/s3.rs
+++ b/crates/rsearch-storage/src/s3.rs
@@ -19,6 +19,8 @@ pub struct S3Storage {
 }
 
 impl S3Storage {
+    /// Build a client from config: FIPS TLS, optional custom endpoint /
+    /// path-style / static credentials. Requires storage.bucket to be set.
     pub async fn from_config(cfg: &StorageConfig) -> StorageResult<Self> {
         if cfg.bucket.is_empty() {
             return Err(StorageError::Backend {


### PR DESCRIPTION
Gets the workspace ready to publish to crates.io.

## Doc coverage
- `#![warn(missing_docs)]` enabled on all six library crates; **282 previously undocumented public items** now carry rustdoc written from the actual implementations (config defaults from `Default` impls, error variants state when they occur, units spelled out — epoch millis vs seconds, bytes). Zero missing-documentation warnings workspace-wide; the lint keeps it that way.
- Crate-level doc header added to the server binary.

## Publish metadata
- Verified per-crate: descriptions, `GPL-3.0-or-later`, repository/readme/categories inherited from `workspace.package`; `rsearch-bench` stays `publish = false`.
- Keywords refreshed for discovery: `search, logging, opensearch, loki, fips` (crates.io caps at 5).
- `cargo publish --dry-run -p rsearch-common` passes end-to-end (package, verify build, upload abort). Dependent crates can't dry-run against the registry until their parents exist there — first-publish order is: **common → storage → index → metastore → ingest → search → server** (`cargo publish -p <crate>` in that order once you're ready; needs a crates.io token via `cargo login`).

64 tests pass, `cargo check --workspace --all-targets` clean.

Repo metadata updated alongside (not part of this diff): description now leads with both wire protocols, topics gained `loki` + `logql`.