### PR TITLE
Fix #18: share one SplitCache between search and control roles

### DIFF
--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -67,15 +67,10 @@ impl ControlPlane {
         config: &RsearchConfig,
         metastore: Metastore,
         storage: Arc<dyn Storage>,
+        cache: Arc<SplitCache>,
         metrics: Arc<crate::metrics::ControlMetrics>,
     ) -> anyhow::Result<Self> {
         let data_dir = std::path::PathBuf::from(&config.node.data_dir);
-        // Same operator-configured budget as the search cache — a
-        // hard-coded size silently ate disk on small control nodes.
-        let cache = Arc::new(SplitCache::new(
-            data_dir.join("cache/control"),
-            config.search.cache_max_mb << 20,
-        )?);
         let search =
             rsearch_search::SearchService::new(metastore.clone(), storage.clone(), cache.clone());
         let replication = if config.storage.backend == "replicated" {

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -192,17 +192,37 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    // Search role: split cache + stateless search service.
+    // One split cache per node, shared by the search and control roles:
+    // cache_max_mb is the node's whole budget, so two roles must not each
+    // claim it in full (issue #18). Sharing also lets control-side merge
+    // reads warm the cache search serves from.
+    let split_cache = if roles.contains(&Role::Search) || roles.contains(&Role::Control) {
+        let cache_dir = PathBuf::from(&config.node.data_dir).join("cache");
+        // Earlier releases gave control its own budget-sized cache here;
+        // reclaim the dead directory rather than let it sit at up to a
+        // full cache_max_mb of disk.
+        match std::fs::remove_dir_all(cache_dir.join("control")) {
+            Ok(()) => info!("removed legacy control split cache"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => warn!(error = %e, "removing legacy control split cache failed"),
+        }
+        Some(std::sync::Arc::new(
+            rsearch_index::SplitCache::new(
+                cache_dir.join("splits"),
+                config.search.cache_max_mb << 20,
+            )
+            .context("initializing split cache")?,
+        ))
+    } else {
+        None
+    };
+
+    // Search role: stateless search service over the shared cache.
     let search = if roles.contains(&Role::Search) {
-        let cache = rsearch_index::SplitCache::new(
-            PathBuf::from(&config.node.data_dir).join("cache/splits"),
-            config.search.cache_max_mb << 20,
-        )
-        .context("initializing split cache")?;
         Some(std::sync::Arc::new(rsearch_search::SearchService::new(
             metastore.clone(),
             storage.clone(),
-            std::sync::Arc::new(cache),
+            split_cache.clone().expect("split cache exists for search role"),
         )))
     } else {
         None
@@ -216,6 +236,7 @@ async fn main() -> anyhow::Result<()> {
             &config,
             metastore.clone(),
             storage.clone(),
+            split_cache.clone().expect("split cache exists for control role"),
             metrics.clone(),
         )
         .context("initializing control plane")?;


### PR DESCRIPTION
Fixes #18.

All-role nodes built two full-budget split caches (`cache/splits` for search, `cache/control` for control), so `cache_max_mb` was consumed twice — up to double the documented node-local budget on disk.

- Build a single `SplitCache` in `main()` when either role is enabled and hand the same `Arc` to both `SearchService` and `ControlPlane` (whose constructor now takes the cache instead of building its own).
- Control-side merge reads now warm the same cache search serves from.
- The legacy `cache/control` directory is deleted at startup so upgraded nodes reclaim its disk (up to a full `cache_max_mb`).

`cargo check` clean, unit tests pass.