### PR TITLE
Fix #19: server-side bulk ingest balancing across peers

### DIFF
--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -367,6 +367,12 @@ pub struct IngestConfig {
     pub memory_budget_mb: usize,
     /// WAL segment rotation size, in megabytes.
     pub wal_segment_mb: u64,
+    /// Spread `/_bulk` batches round-robin across live ingest peers
+    /// instead of indexing every batch on the node the client happens to
+    /// hold a connection to. Takes effect only when
+    /// `cluster.internal_token` is set (the handoff authenticates with
+    /// it); with no token or no live peers, batches stay local.
+    pub balance_bulk: bool,
 }
 
 impl Default for IngestConfig {
@@ -377,6 +383,7 @@ impl Default for IngestConfig {
             queue_capacity: 100_000,
             memory_budget_mb: 256,
             wal_segment_mb: 64,
+            balance_bulk: true,
         }
     }
 }

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -1,12 +1,16 @@
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use axum::extract::{Path, State};
-use axum::http::StatusCode;
+use axum::extract::{Path, Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::{Value, json};
 
+use rsearch_common::crypto;
 use rsearch_ingest::{BulkParseOutcome, IngestError, parse_bulk_body};
+use rsearch_storage::INTERNAL_TOKEN_HEADER;
+use tracing::warn;
 
 use crate::state::AppState;
 
@@ -22,9 +26,44 @@ pub async fn bulk_index(
     handle_bulk(state, Some(index), body).await
 }
 
+#[derive(serde::Deserialize)]
+pub struct InternalBulkQuery {
+    index: Option<String>,
+}
+
+/// Receive a batch handed off by a peer (#19). Authenticated by the
+/// cluster token like the internal object API; always indexes locally —
+/// a handed-off batch is never re-forwarded, so no hop loops.
+pub async fn bulk_internal(
+    State(state): State<AppState>,
+    Query(query): Query<InternalBulkQuery>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    let Some(forwarder) = state.bulk_forward.clone() else {
+        return error_response(StatusCode::NOT_FOUND, "bulk handoff not enabled");
+    };
+    let presented = headers
+        .get(INTERNAL_TOKEN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if presented.is_empty() || crypto::token_digest(presented) != forwarder.token_digest {
+        return (StatusCode::UNAUTHORIZED, "invalid cluster token").into_response();
+    }
+    if state.draining.load(Ordering::Relaxed) {
+        // A peer picked this node before the drain reached the registry;
+        // the 503 makes the sender fall back to indexing locally.
+        return error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "node is draining; index this batch elsewhere",
+        );
+    }
+    forwarder.received.fetch_add(1, Ordering::Relaxed);
+    handle_bulk_local(state, query.index, body).await
+}
+
 async fn handle_bulk(state: AppState, default_index: Option<String>, body: String) -> Response {
-    let started = Instant::now();
-    if state.draining.load(std::sync::atomic::Ordering::Relaxed) {
+    if state.draining.load(Ordering::Relaxed) {
         // Draining: refuse new writes so the WAL empties out before
         // shutdown; shippers retry against another ingest node.
         return error_response(
@@ -32,6 +71,57 @@ async fn handle_bulk(state: AppState, default_index: Option<String>, body: Strin
             "node is draining; send bulk traffic to another ingest node",
         );
     }
+    if state.pipeline.is_none() {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "this node does not run the ingest role",
+        );
+    }
+    // Server-side balancing (#19): shippers pin keep-alive connections to
+    // one node, so spread whole batches round-robin across live ingest
+    // peers. The ack then comes from the target's WAL. Any handoff
+    // failure falls back to local indexing — like shipper retries after a
+    // timeout, that is at-least-once, never lost.
+    if let Some(forwarder) = state.bulk_forward.clone()
+        && let Some((peer_id, peer_addr)) = forwarder.pick_target().await
+    {
+        match forwarder
+            .forward(&peer_addr, default_index.as_deref(), body.clone().into())
+            .await
+        {
+            // Relay only a peer 2xx (its per-item results). Anything else
+            // — refused (draining, saturated), failed, or a peer version
+            // without the endpoint — falls through to local indexing,
+            // which reproduces the right client-facing outcome itself.
+            Ok((status, response)) if (200..300).contains(&status) => {
+                forwarder.forwarded.fetch_add(1, Ordering::Relaxed);
+                let status = StatusCode::from_u16(status).unwrap_or(StatusCode::OK);
+                return (
+                    status,
+                    [(header::CONTENT_TYPE, "application/json")],
+                    response,
+                )
+                    .into_response();
+            }
+            Ok((status, _)) => {
+                forwarder.forward_fallbacks.fetch_add(1, Ordering::Relaxed);
+                warn!(peer = %peer_id, status, "bulk handoff refused; indexing locally");
+            }
+            Err(e) => {
+                forwarder.forward_fallbacks.fetch_add(1, Ordering::Relaxed);
+                warn!(peer = %peer_id, error = %e, "bulk handoff failed; indexing locally");
+            }
+        }
+    }
+    handle_bulk_local(state, default_index, body).await
+}
+
+async fn handle_bulk_local(
+    state: AppState,
+    default_index: Option<String>,
+    body: String,
+) -> Response {
+    let started = Instant::now();
     let Some(pipeline) = state.pipeline.clone() else {
         return error_response(
             StatusCode::BAD_REQUEST,

--- a/crates/rsearch-server/src/bulk_forward.rs
+++ b/crates/rsearch-server/src/bulk_forward.rs
@@ -1,0 +1,132 @@
+//! Server-side bulk ingest balancing (#19): shippers hold keep-alive
+//! connections, so without help every batch lands on whichever node the
+//! client happened to connect to. When enabled, the receiving node hands
+//! whole `/_bulk` bodies round-robin to live ingest peers over the
+//! internal API (cluster-token auth), and relays the peer's response.
+//! A handed-off batch is durable in the *target's* WAL before the ack.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use hyper::body::Bytes;
+use rsearch_metastore::Metastore;
+use rsearch_storage::PeerClient;
+use tracing::warn;
+
+/// A peer is a handoff candidate only if it heartbeated this recently.
+const PEER_STALE_SECS: f64 = 30.0;
+/// How long a fetched peer list is reused before the registry is re-read.
+const PEER_LIST_TTL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Round-robin bulk handoff across the cluster's live ingest nodes.
+pub struct BulkForwarder {
+    metastore: Metastore,
+    client: PeerClient,
+    node_id: String,
+    /// Digest of the cluster token; inbound handoffs are checked against
+    /// it (digest-to-digest, same scheme as the internal object API).
+    pub token_digest: String,
+    /// `ingest.balance_bulk` — when false this node never hands off, but
+    /// still accepts handoffs from peers that do.
+    balance: bool,
+    counter: AtomicU64,
+    /// (targets sorted by id — self included so rotation is fair, fetch time)
+    peers: std::sync::Mutex<Option<(Arc<Vec<(String, String)>>, Instant)>>,
+    /// Batches handed to a peer / handoffs that fell back to local.
+    pub forwarded: AtomicU64,
+    pub forward_fallbacks: AtomicU64,
+    /// Batches accepted from a peer via the internal endpoint.
+    pub received: AtomicU64,
+}
+
+impl BulkForwarder {
+    pub fn new(
+        metastore: Metastore,
+        client: PeerClient,
+        node_id: String,
+        token_digest: String,
+        balance: bool,
+    ) -> Self {
+        Self {
+            metastore,
+            client,
+            node_id,
+            token_digest,
+            balance,
+            counter: AtomicU64::new(0),
+            peers: std::sync::Mutex::new(None),
+            forwarded: AtomicU64::new(0),
+            forward_fallbacks: AtomicU64::new(0),
+            received: AtomicU64::new(0),
+        }
+    }
+
+    /// Live, non-draining ingest nodes with an advertised address, sorted
+    /// by id so every node walks the same rotation order.
+    async fn candidates(&self) -> Arc<Vec<(String, String)>> {
+        if let Some((peers, at)) = self.peers.lock().unwrap().as_ref()
+            && at.elapsed() < PEER_LIST_TTL
+        {
+            return peers.clone();
+        }
+        let peers: Arc<Vec<(String, String)>> = match self.metastore.list_nodes().await {
+            Ok(nodes) => Arc::new(
+                nodes
+                    .into_iter()
+                    .filter(|n| {
+                        n.heartbeat_age_secs < PEER_STALE_SECS
+                            && !n.draining
+                            && n.roles.iter().any(|r| r == "ingest")
+                    })
+                    .filter_map(|n| n.address.map(|addr| (n.id, addr)))
+                    .collect(),
+            ),
+            Err(e) => {
+                // Registry unreachable: keep ingesting locally rather than
+                // fail batches over a balancing nicety.
+                warn!(error = %e, "bulk balance: listing ingest nodes failed");
+                Arc::new(Vec::new())
+            }
+        };
+        *self.peers.lock().unwrap() = Some((peers.clone(), Instant::now()));
+        peers
+    }
+
+    /// The peer the next batch should go to, or `None` to index locally
+    /// (balancing off, no live peers, or the rotation landed on self).
+    pub async fn pick_target(&self) -> Option<(String, String)> {
+        if !self.balance {
+            return None;
+        }
+        let peers = self.candidates().await;
+        if peers.len() < 2 {
+            return None;
+        }
+        let slot = self.counter.fetch_add(1, Ordering::Relaxed) as usize % peers.len();
+        let (id, addr) = &peers[slot];
+        if *id == self.node_id {
+            return None;
+        }
+        Some((id.clone(), addr.clone()))
+    }
+
+    /// Hand a raw bulk body to `addr` and return the peer's verbatim
+    /// `(status, response body)`.
+    pub async fn forward(
+        &self,
+        addr: &str,
+        default_index: Option<&str>,
+        body: Bytes,
+    ) -> Result<(u16, Bytes), String> {
+        let mut url = url::Url::parse(addr).map_err(|e| format!("peer address '{addr}': {e}"))?;
+        url.set_path("/_rsearch/internal/bulk");
+        if let Some(index) = default_index {
+            url.query_pairs_mut().append_pair("index", index);
+        }
+        self.client
+            .post_raw(url.as_str(), body)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -6,6 +6,7 @@ mod alerts_api;
 mod auth;
 mod auth_api;
 mod bulk_api;
+mod bulk_forward;
 mod control;
 mod internal_api;
 mod loki_api;
@@ -261,6 +262,24 @@ async fn main() -> anyhow::Result<()> {
     let mut state = AppState::new(&config, &roles, metastore, pipeline, search);
     state.draining = draining_flag;
     state.control = control_metrics;
+    // Bulk handoff between ingest peers needs the cluster token both to
+    // authenticate outbound handoffs and to verify inbound ones; without
+    // a token the node simply indexes everything it receives itself.
+    if roles.contains(&Role::Ingest) && !config.cluster.internal_token.is_empty() {
+        state.bulk_forward = Some(std::sync::Arc::new(bulk_forward::BulkForwarder::new(
+            state.metastore.clone(),
+            rsearch_storage::PeerClient::new(
+                &config.cluster.internal_token,
+                (!config.cluster.peer_ca_file.is_empty())
+                    .then_some(config.cluster.peer_ca_file.as_str()),
+            )
+            .map_err(|e| anyhow::anyhow!(e))
+            .context("building bulk handoff peer client")?,
+            config.node_id(),
+            rsearch_common::crypto::token_digest(&config.cluster.internal_token),
+            config.ingest.balance_bulk,
+        )));
+    }
     if config.storage.backend == "replicated" {
         state.internal = Some(std::sync::Arc::new(internal_api::InternalState {
             fs: rsearch_storage::FsStorage::new(config.storage.root.clone()),

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -137,6 +137,15 @@ pub fn router(state: AppState) -> Router {
     } else {
         router
     };
+    // Same for the bulk handoff receiver (#19).
+    let router = if state.bulk_forward.is_some() {
+        router.route(
+            "/_rsearch/internal/bulk",
+            post(bulk_api::bulk_internal).layer(DefaultBodyLimit::max(BULK_BODY_LIMIT)),
+        )
+    } else {
+        router
+    };
     router.with_state(state)
 }
 
@@ -216,9 +225,17 @@ async fn node_stats(State(state): State<AppState>) -> Json<Value> {
             "wal_segments": p.wal().segment_count(),
         })
     });
+    let bulk_balance = state.bulk_forward.as_ref().map(|f| {
+        json!({
+            "forwarded": f.forwarded.load(Ordering::Relaxed),
+            "forward_fallbacks": f.forward_fallbacks.load(Ordering::Relaxed),
+            "received": f.received.load(Ordering::Relaxed),
+        })
+    });
     Json(json!({
         "node": state.node_id,
         "ingest": ingest,
+        "bulk_balance": bulk_balance,
     }))
 }
 

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -23,6 +23,10 @@ pub struct AppState {
     pub cors_allow_origin: String,
     /// Peer-transfer state, present only on replicated-backend nodes.
     pub internal: Option<Arc<crate::internal_api::InternalState>>,
+    /// Bulk handoff between ingest peers (#19). Present on ingest nodes
+    /// with a cluster token; whether this node *initiates* handoffs is
+    /// its `ingest.balance_bulk` setting.
+    pub bulk_forward: Option<Arc<crate::bulk_forward::BulkForwarder>>,
     /// Set when the operator drains this node (learned via heartbeat):
     /// bulk ingest is refused so the WAL empties out ahead of shutdown.
     pub draining: Arc<std::sync::atomic::AtomicBool>,
@@ -63,6 +67,7 @@ impl AppState {
             allow_insecure_webhooks: config.control.allow_insecure_webhooks,
             cors_allow_origin: config.http.cors_allow_origin.clone(),
             internal: None,
+            bulk_forward: None,
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             control: None,
             stream_names: Arc::new(std::sync::Mutex::new(None)),

--- a/crates/rsearch-storage/src/peer.rs
+++ b/crates/rsearch-storage/src/peer.rs
@@ -319,4 +319,38 @@ impl PeerClient {
         })
         .await
     }
+
+    /// POST a raw body to an already-built internal URL on a peer and
+    /// return `(status, response bytes)` verbatim — unlike [`send`], no
+    /// status is treated as an error, so a proxying caller (bulk handoff)
+    /// can relay the peer's real response to its own client.
+    pub async fn post_raw(&self, url: &str, body: Bytes) -> StorageResult<(u16, Bytes)> {
+        let uri: hyper::Uri = url.parse().map_err(|e| StorageError::Backend {
+            key: String::new(),
+            message: format!("building peer uri '{url}': {e}"),
+        })?;
+        let request = self.request("POST", uri, full_body(body))?;
+        Self::bounded("", TRANSFER_TIMEOUT, async {
+            let response =
+                self.client
+                    .request(request)
+                    .await
+                    .map_err(|e| StorageError::Backend {
+                        key: String::new(),
+                        message: format!("peer request failed: {e}"),
+                    })?;
+            let status = response.status().as_u16();
+            let bytes = response
+                .into_body()
+                .collect()
+                .await
+                .map_err(|e| StorageError::Backend {
+                    key: String::new(),
+                    message: format!("reading peer response: {e}"),
+                })?
+                .to_bytes();
+            Ok((status, bytes))
+        })
+        .await
+    }
 }

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -72,6 +72,9 @@ max_batch_secs = 30      # ...or when the oldest doc reaches this age
 queue_capacity = 100000  # per-stream in-flight bound before 429s
 memory_budget_mb = 256   # tantivy writer heap per stream worker
 wal_segment_mb = 64      # WAL segment rotation size
+balance_bulk = true      # hand /_bulk batches round-robin to live ingest
+                         # peers (needs cluster.internal_token; keep-alive
+                         # clients otherwise pin all work to one node)
 
 [search]
 cache_max_mb = 4096      # local split-fragment cache budget


### PR DESCRIPTION
Fixes #19.

Bulk ingest was handled entirely by whichever node the client connected to; keep-alive shippers (the reporter runs 7 Vector collectors) pin all split-building work to one or two nodes indefinitely. Client-side balancing can't fix this (per-connection LB still pins; ClusterIP breaks TLS verification against the serving cert).

## What this does

- Ingest nodes now hand whole `/_bulk` bodies **round-robin across live, non-draining ingest peers** (self included in the rotation, so distribution is fair) and relay the peer's verbatim response. The ack comes from the target's WAL — durability semantics are unchanged.
- New internal endpoint `POST /_rsearch/internal/bulk`, authenticated with the shared cluster token exactly like the internal object API (digest-to-digest comparison), mounted outside user auth. A handed-off batch is never re-forwarded, so there are no hop loops.
- **Fallback-safe:** only a peer 2xx is relayed. Peer refusals (draining, saturated), transport errors, or an older peer without the endpoint all fall back to local indexing — availability degrades to today's behavior, never worse. Like shipper retries after a timeout, this is at-least-once.
- Peer list comes from the node registry (heartbeat < 30s, ingest role, not draining), cached 5s; the rotation order is sorted by node id so all nodes walk the same sequence.
- Config: `ingest.balance_bulk` (default `true`), effective only when `cluster.internal_token` is set — clusters without a token keep exactly today's behavior. A node with `balance_bulk = false` still *accepts* handoffs from peers.
- Observability: `bulk_balance` counters (`forwarded`, `forward_fallbacks`, `received`) in `/_rsearch/stats`.
- `PeerClient::post_raw` added for proxy-style calls that must relay non-2xx responses instead of treating them as errors.

## Verification

2-node replicated cluster (factor 2), 10 bulk batches of 100 docs sent **only to node-a**:

| node | docs_enqueued | forwarded | received | fallbacks |
|---|---|---|---|---|
| node-a | 500 | 5 | 0 | 0 |
| node-b | 500 | 0 | 5 | 0 |

All 1000 docs searchable from both nodes; `errors:false` on every batch. `cargo check` clean, unit tests pass.