### PR TITLE
Fix #14: survive host reboots — postgres restart policy + metastore startup retry

### DIFF
--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -62,9 +62,29 @@ async fn main() -> anyhow::Result<()> {
         "starting rsearch"
     );
 
-    let metastore = Metastore::connect(&config.metastore)
-        .await
-        .context("connecting to metastore")?;
+    // An unreachable metastore at startup is retried in-process instead
+    // of exiting: a fatal exit turns any Postgres blip or slow dependency
+    // start into a docker-level crash loop, and after a host reboot the
+    // whole cluster stays down until an operator intervenes (#14). A
+    // genuinely wrong DATABASE_URL surfaces as this same warning
+    // repeating — the error text carries the cause either way.
+    let metastore = {
+        let mut delay = Duration::from_secs(1);
+        loop {
+            match Metastore::connect(&config.metastore).await {
+                Ok(metastore) => break metastore,
+                Err(e) => {
+                    warn!(
+                        error = %e,
+                        retry_in_secs = delay.as_secs(),
+                        "connecting to metastore failed; retrying"
+                    );
+                    tokio::time::sleep(delay).await;
+                    delay = (delay * 2).min(Duration::from_secs(30));
+                }
+            }
+        }
+    };
     let storage: std::sync::Arc<dyn rsearch_storage::Storage> =
         if config.storage.backend == "replicated" {
             if config.cluster.internal_token.is_empty() {

--- a/docker-compose-replicated.yml
+++ b/docker-compose-replicated.yml
@@ -26,6 +26,9 @@ x-rsearch-node: &rsearch-node
 services:
   postgres:
     image: postgres:17-alpine
+    # Same policy as the nodes: without it a docker-daemon restart (host
+    # reboot) leaves the metastore down while every node crash-loops (#14).
+    restart: unless-stopped
     environment:
       POSTGRES_USER: rsearch
       POSTGRES_PASSWORD: rsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ x-rsearch-node: &rsearch-node
 services:
   postgres:
     image: postgres:17-alpine
+    # Same policy as the nodes: without it a docker-daemon restart (host
+    # reboot) leaves the metastore down while every node crash-loops (#14).
+    restart: unless-stopped
     environment:
       POSTGRES_USER: rsearch
       POSTGRES_PASSWORD: rsearch
@@ -39,6 +42,7 @@ services:
 
   minio:
     image: minio/minio:latest
+    restart: unless-stopped
     command: server /data
     environment:
       MINIO_ROOT_USER: minioadmin


### PR DESCRIPTION
Fixes #14.

## Compose
- `postgres` in both `docker-compose.yml` and `docker-compose-replicated.yml` now carries `restart: unless-stopped`, matching the nodes — a docker-daemon restart (host reboot) brings the metastore back instead of leaving every node crash-looping against it. `minio` in the s3 topology gets the same.

## Server
- `Metastore::connect` failures at startup are retried in-process with capped exponential backoff (1s → 30s) instead of being fatal. `depends_on: service_healthy` only helps at initial `compose up`, not after a daemon restart, and a fatal exit turns any Postgres blip into a docker-level crash loop. A genuinely wrong `DATABASE_URL` now surfaces as a repeating warning that carries the underlying error text.

## Verification
- Both compose files validate (`docker compose config -q`).
- A node started against an unreachable Postgres logs `connecting to metastore failed; retrying` and keeps running; previously it exited with `Error: connecting to metastore` within one attempt.
- Background: this exact failure mode kept a 3-node cluster down for 2.4 days after a host reboot (3,207 restarts per node at docker's max backoff).