### PR TITLE
Fix #16: reconcile orphaned local object files with the metastore

### DIFF
--- a/crates/rsearch-metastore/src/locations.rs
+++ b/crates/rsearch-metastore/src/locations.rs
@@ -52,6 +52,23 @@ impl Metastore {
         Ok(result.rows_affected() > 0)
     }
 
+    /// Whether the cluster still tracks `storage_key` at all — any
+    /// placement row *or* split row referencing it counts. Deliberately
+    /// broader than the `if_known` insert guard above: this gates local
+    /// file deletion in the orphan reconcile sweep (#16), where a split
+    /// row without location rows (however it arose) must protect the last
+    /// physical copy rather than let it be swept.
+    pub async fn object_known(&self, storage_key: &str) -> MetastoreResult<bool> {
+        let known: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM object_locations WHERE storage_key = $1)
+                 OR EXISTS (SELECT 1 FROM splits WHERE storage_key = $1)",
+        )
+        .bind(storage_key)
+        .fetch_one(self.pool())
+        .await?;
+        Ok(known)
+    }
+
     /// Remove one node's copy record for an object.
     pub async fn remove_object_location(
         &self,

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -11,6 +11,7 @@ mod internal_api;
 mod loki_api;
 mod metrics;
 mod placement;
+mod reconcile;
 mod routes;
 mod search_api;
 mod state;
@@ -96,42 +97,17 @@ async fn main() -> anyhow::Result<()> {
             }
             let ca = (!config.cluster.peer_ca_file.is_empty())
                 .then_some(config.cluster.peer_ca_file.as_str());
-            // Re-announce local files whose keys the placement table still
-            // knows: a node rejoining after registry expiry has real
-            // copies on disk but may have lost its rows. The if-known
-            // guard means cluster-deleted objects are never resurrected.
-            {
-                let fs = rsearch_storage::FsStorage::new(config.storage.root.clone());
-                let metastore = metastore.clone();
-                let node_id = config.node_id();
-                tokio::spawn(async move {
-                    use rsearch_storage::Storage;
-                    let keys = match fs.list("").await {
-                        Ok(keys) => keys,
-                        Err(e) => {
-                            warn!(error = %e, "rejoin scan: listing local objects failed");
-                            return;
-                        }
-                    };
-                    let mut announced = 0u64;
-                    for key in keys {
-                        let Ok(size) = fs.size(&key).await else { continue };
-                        match metastore
-                            .record_object_location_if_known(&key, &node_id, size as i64)
-                            .await
-                        {
-                            Ok(true) => announced += 1,
-                            Ok(false) => {}
-                            Err(e) => {
-                                warn!(key, error = %e, "rejoin scan: record failed");
-                            }
-                        }
-                    }
-                    if announced > 0 {
-                        info!(announced, "rejoin scan: re-announced local object copies");
-                    }
-                });
-            }
+            // Reconcile local files with the metastore, at startup and
+            // periodically: re-announce copies the placement table still
+            // knows (a node rejoining after registry expiry has real
+            // copies on disk but may have lost its rows) and delete
+            // orphaned files whose splits were GC'd while this node was
+            // unreachable (#16).
+            reconcile::spawn(
+                rsearch_storage::FsStorage::new(config.storage.root.clone()),
+                metastore.clone(),
+                config.node_id(),
+            );
             std::sync::Arc::new(rsearch_storage::ReplicatedStorage::new(
                 rsearch_storage::FsStorage::new(config.storage.root.clone()),
                 std::sync::Arc::new(placement::MetastorePlacement::new(metastore.clone())),

--- a/crates/rsearch-server/src/reconcile.rs
+++ b/crates/rsearch-server/src/reconcile.rs
@@ -1,0 +1,134 @@
+//! Local object reconciliation for the replicated backend (#16).
+//!
+//! A node that was down while the leader GC'd splits comes back holding
+//! files the cluster no longer tracks: the metadata rows were deleted but
+//! the peer DELETE never reached this node, and nothing cleaned the files
+//! up afterwards — they accumulated forever. The reconcile sweep walks
+//! the local object root and, per key:
+//!
+//! - **known placement** → re-announce our copy (the original rejoin-scan
+//!   behavior: a node returning after registry expiry has real copies on
+//!   disk but may have lost its rows);
+//! - **tracked split with no placement rows** → resurrect a placement row
+//!   unguarded, restoring availability (and letting GC delete a
+//!   marked-for-delete split through its normal path);
+//! - **unknown everywhere** → an orphan; delete the local file once it is
+//!   older than a grace window, so an in-flight transfer whose row hasn't
+//!   landed yet is never swept.
+//!
+//! Runs at startup (the rejoin case) and then periodically, which also
+//! catches deletes missed while merely partitioned rather than down.
+
+use std::time::Duration;
+
+use rsearch_metastore::Metastore;
+use rsearch_storage::{FsStorage, Storage};
+use tracing::{info, warn};
+
+/// Never sweep a file younger than this: a freshly transferred object's
+/// placement row lands moments after the file, and peer transfers time
+/// out after 600s — an hour comfortably outlives any in-flight write.
+const ORPHAN_MIN_AGE: Duration = Duration::from_secs(3600);
+/// Sweep cadence after the startup pass.
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(3600);
+
+/// Spawn the reconcile loop: one pass immediately (rejoin), then hourly.
+pub fn spawn(fs: FsStorage, metastore: Metastore, node_id: String) {
+    tokio::spawn(async move {
+        loop {
+            reconcile(&fs, &metastore, &node_id).await;
+            tokio::time::sleep(RECONCILE_INTERVAL).await;
+        }
+    });
+}
+
+async fn reconcile(fs: &FsStorage, metastore: &Metastore, node_id: &str) {
+    let keys = match fs.list("").await {
+        Ok(keys) => keys,
+        Err(e) => {
+            warn!(error = %e, "reconcile: listing local objects failed");
+            return;
+        }
+    };
+    let mut announced = 0u64;
+    let mut swept = 0u64;
+    let mut swept_bytes = 0u64;
+    for key in keys {
+        let Ok(size) = fs.size(&key).await else { continue };
+        match metastore
+            .record_object_location_if_known(&key, node_id, size as i64)
+            .await
+        {
+            Ok(true) => announced += 1,
+            Ok(false) => {
+                if sweep_orphan(fs, metastore, node_id, &key, size).await {
+                    swept += 1;
+                    swept_bytes += size;
+                }
+            }
+            Err(e) => warn!(key, error = %e, "reconcile: record failed"),
+        }
+    }
+    if announced > 0 {
+        info!(announced, "reconcile: re-announced local object copies");
+    }
+    if swept > 0 {
+        info!(swept, swept_bytes, "reconcile: deleted orphaned local objects");
+    }
+}
+
+/// Handle a key with no placement rows anywhere. Returns whether the
+/// local file was deleted.
+async fn sweep_orphan(
+    fs: &FsStorage,
+    metastore: &Metastore,
+    node_id: &str,
+    key: &str,
+    size: u64,
+) -> bool {
+    // The guarded insert refuses when object_locations is empty for the
+    // key; a split row referencing it means the object still matters —
+    // resurrect our placement row so search/repair (or GC, for a
+    // marked-for-delete split) can reach this copy again.
+    match metastore.object_known(key).await {
+        Ok(true) => {
+            match metastore
+                .record_object_location(key, node_id, size as i64)
+                .await
+            {
+                Ok(()) => {
+                    info!(key, "reconcile: restored placement for tracked split");
+                }
+                Err(e) => warn!(key, error = %e, "reconcile: placement restore failed"),
+            }
+            return false;
+        }
+        Ok(false) => {}
+        Err(e) => {
+            warn!(key, error = %e, "reconcile: metastore lookup failed; keeping file");
+            return false;
+        }
+    }
+    // Unknown everywhere: an orphan unless it is too young to judge.
+    match fs.modified(key).await {
+        Ok(modified) => {
+            let age = std::time::SystemTime::now()
+                .duration_since(modified)
+                .unwrap_or(Duration::ZERO);
+            if age < ORPHAN_MIN_AGE {
+                return false;
+            }
+        }
+        Err(_) => return false,
+    }
+    match fs.delete(key).await {
+        Ok(()) => {
+            info!(key, size, "reconcile: deleted orphaned object file");
+            true
+        }
+        Err(e) => {
+            warn!(key, error = %e, "reconcile: orphan delete failed");
+            false
+        }
+    }
+}

--- a/crates/rsearch-storage/src/fs.rs
+++ b/crates/rsearch-storage/src/fs.rs
@@ -147,6 +147,17 @@ fn sweep_temp_files(dir: &Path) {
 }
 
 impl FsStorage {
+    /// Last-modification time of an object file. Used by the local
+    /// reconcile sweep as a deletion grace: a freshly received object may
+    /// not have its placement row yet and must not be treated as an
+    /// orphan.
+    pub async fn modified(&self, key: &str) -> StorageResult<std::time::SystemTime> {
+        let path = self.resolve(key)?;
+        let meta = tokio::fs::metadata(&path)
+            .await
+            .map_err(|e| Self::io_err(key, e))?;
+        meta.modified().map_err(|e| Self::io_err(key, e))
+    }
 
     /// Atomic streamed write for peer transfers: chunks land in a temp
     /// sibling, fsync, rename, parent fsync — same durability discipline


### PR DESCRIPTION
Fixes #16.

## Problem

GC while a holder node is down deletes the metadata rows, but the peer DELETE never reaches the node — after rejoin the files sit on disk forever. Observed: 48 orphaned `.split` files (~2 GB) across two nodes after a multi-day outage, growing every time GC runs while a holder is unreachable.

## Fix

The one-shot startup rejoin scan becomes a **reconcile sweep** (new `reconcile` module): one pass at startup, then hourly — the periodic pass also catches deletes missed while a node was merely partitioned rather than restarted. Per local file:

1. **Placement knows the key** → re-announce our copy (the existing rejoin behavior, unchanged).
2. **A split row references the key but placement lost every row** → restore our placement row (unguarded insert), so search/repair — or GC, for a marked-for-delete split — can reach this copy through the normal paths instead of the last physical copy being swept.
3. **Unknown in both tables** → orphan: delete the local file once it's older than a 1-hour grace window, so an in-flight transfer whose placement row hasn't landed yet is never swept. Metastore lookup errors always keep the file.

Supporting additions: `Metastore::object_known` (checks `object_locations` **or** `splits` — deliberately broader than the `if_known` insert guard, since this gates deletion) and `FsStorage::modified` for the age check.

## Verification

Planted a 2-hour-old orphan and a fresh file in a node's object root and started it against an empty metastore: the old orphan was deleted on the startup pass (`reconcile: deleted orphaned object file`), the fresh file survived the grace window. `cargo check` clean, tests pass.