### PR TITLE
Document mode: index/update/delete by _id for application indices (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,10 +253,24 @@ On a document-mode index:
   rewrites the split without the hidden versions: merges always do, and
   a dedicated job rewrites document-mode splits once an index has
   `control.compact_min_tombstones` (default 1000) or its oldest tombstone
-  is past `control.compact_max_age_secs` (default 1h) — that setting is
-  the bound on how long a deleted document survives in storage, so lower
-  it if an erasure SLA requires. Tombstone rows are purged once no split
-  can still hold a version they hide.
+  is past `control.compact_max_age_secs` (default 1h). A deleted document
+  is therefore physically gone after that age plus the sweep
+  (`control.compact_splits_per_tick`, default 8 per control tick, so a
+  stream with many splits takes several ticks) plus `control.gc_grace_secs`
+  for the old split object — lower those if an erasure SLA requires.
+  Tombstone rows are purged once every split of the stream has applied
+  them and they are older than `control.tombstone_purge_grace_secs`
+  (default 1h); that grace also covers documents still buffered on an
+  ingest node, so **drain an ingest node's WAL before taking it down for
+  longer than `compact_max_age_secs + tombstone_purge_grace_secs`** (a
+  replayed document whose tombstone was purged would reappear).
+- Ordering across nodes: each write gets a sequence from a hybrid logical
+  clock — wall-clock micros pushed past every sequence the node has
+  observed for the ids it writes (their existing tombstone bounds and the
+  stream's highest published sequence) — so a replacement taken by a node
+  whose clock lags still orders after the version it replaces. Keep node
+  clocks NTP-synced anyway; skew only shows up as slightly non-monotonic
+  `_version` values.
 - Log indices are untouched: they reject `delete`/`update` per item with
   a reason that points at the setting, ignore `?refresh`, and carry no
   query-time filtering.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ no garbage collector.
   automatic re-replication; no external object store required
 - **Tantivy index engine** — Lucene-class full-text search and
   ES-compatible aggregations with predictable, GC-free latency
+- **Document mode for application data** — per-index `mode: document`
+  turns on index-replaces / delete-by-`_id` / `_doc` routes /
+  `?refresh=wait_for`, with tombstones applied at query time and made
+  physical by compaction; log indices stay append-only and cost nothing
+  extra (see [Document mode](#document-mode-application-indices))
 
 ## FIPS compliance
 
@@ -104,7 +109,9 @@ curl -XPUT localhost:9200/_rsearch/users/admin \
 
 A reference multi-node topology (2 ingest + 2 search + 1 control over
 Postgres and MinIO) is in `docker-compose.yml`; the kill-a-node test
-suite that exercises it is `tests/cluster/run-cluster-test.sh`.
+suite that exercises it is `tests/cluster/run-cluster-test.sh`, and
+`tests/cluster/run-document-mode-test.sh` walks the document-mode API
+end to end on a single node.
 
 ## HA on block storage (no object store)
 
@@ -186,22 +193,89 @@ and IMDS are never touched.
 
 | Area | Endpoints |
 |------|-----------|
-| Ingest | `POST /_bulk`, `POST /{index}/_bulk` |
+| Ingest | `POST /_bulk`, `POST /{index}/_bulk` (`index`, `create`; plus `update`, `delete` on document-mode indices; `?refresh=true\|wait_for`) |
+| Documents | `PUT/POST/GET/HEAD/DELETE /{index}/_doc/{id}`, `POST /{index}/_doc`, `PUT/POST /{index}/_create/{id}`, `POST /{index}/_update/{id}`, `GET /{index}/_source/{id}`, `POST /{index}/_delete_by_query` (document-mode indices) |
 | Search | `POST /{index}/_search`, `POST /_msearch`, `GET /{index}/_mapping` |
-| Index admin | `PUT /{index}` (mapping), `GET /_cat/indices` |
+| Index admin | `PUT /{index}` (settings + mapping), `GET/HEAD /{index}`, `GET /{index}/_settings`, `GET /_cat/indices` |
 | Cluster | `GET /`, `GET /_cluster/health`, `GET /_cat/nodes` |
 | Streams | `PUT /_rsearch/streams/{name}/retention`, routing rules under `/_rsearch/routing_rules` |
 | Alerts | `PUT/GET/DELETE /_rsearch/alerts[/{name}]` (scheduled query → webhook) |
 | Auth | `POST /_rsearch/login`, users/api_keys under `/_rsearch/` |
 | Observability | `GET /metrics` (Prometheus), `GET /_rsearch/stats` (JSON) |
 
-Query DSL subset: `match_all`, `bool`, `term`, `terms`, `range`,
+Query DSL subset: `match_all`, `bool`, `term`, `terms`, `ids`, `range`,
 `exists`, `match`, `match_phrase`, `query_string`. Aggregations pass
 through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.
+
+### Document mode (application indices)
+
+rSearch is a log engine first: an index is append-only, every write is a
+new document, and the only deletion is retention by time. Applications
+that index *records people edit* need more, so an index can be created
+in **document mode**:
+
+```bash
+curl -XPUT localhost:9200/items -H 'Content-Type: application/json' -d '{
+  "settings": {"index": {"mode": "document"}},
+  "mappings": {"properties": {"title": {"type": "keyword"}}}
+}'
+```
+
+(`mode` defaults to `log`; it can only change while the index is empty.)
+On a document-mode index:
+
+- `_id` is honored and persisted; `index` on an existing `_id` **replaces**
+  it (reads see exactly the newest version), `delete` hides every version,
+  `create` fails with 409 if a live version exists, `update` merges a
+  partial `doc` (`doc_as_upsert` / `upsert` supported, no scripts).
+- The stock ES document routes work unmodified — `PUT/GET/DELETE
+  /{index}/_doc/{id}`, `_create`, `_update`, `_source`,
+  `_delete_by_query` — and are one-item `_bulk` requests underneath, so
+  they share routing, peer handoff and WAL durability.
+- **Visibility**: a write becomes searchable when its split is cut —
+  within `ingest.document_max_batch_secs` (default 5s; log indices use
+  `ingest.max_batch_secs`, default 30s). `?refresh=true` or
+  `?refresh=wait_for` on `_bulk` or any document route cuts the split now
+  and returns once it is published, so a save-then-search flow sees its
+  own write. Deletes are visible immediately on the node that took them
+  and within ~1s elsewhere. `update`/`create`/GET read published splits
+  only, so a read-modify-write chain should set `refresh=wait_for` on
+  each step.
+- Under the hood: deleting or replacing writes a **tombstone** (one row per
+  index + `_id` in the metastore: "hide versions older than this write").
+  Searches apply tombstones inside the query so hits, counts and
+  aggregations agree; the excluded-document set is cached per split and
+  extended incrementally. Tombstones become **physical** when compaction
+  rewrites the split without the hidden versions: merges always do, and
+  a dedicated job rewrites document-mode splits once an index has
+  `control.compact_min_tombstones` (default 1000) or its oldest tombstone
+  is past `control.compact_max_age_secs` (default 1h) — that setting is
+  the bound on how long a deleted document survives in storage, so lower
+  it if an erasure SLA requires. Tombstone rows are purged once no split
+  can still hold a version they hide.
+- Log indices are untouched: they reject `delete`/`update` per item with
+  a reason that points at the setting, ignore `?refresh`, and carry no
+  query-time filtering.
+
+Hits from document-mode (and new log) indices return the real `_id` and
+`_version` (the write sequence); splits written before this feature keep
+their synthetic `split:segment:doc` ids.
+
+### Authentication for applications
+
+API keys are accepted as `Authorization: Bearer <key>` (preferred —
+`Authorization` is what HTTP clients, tracing middleware and proxies
+already redact) or `X-Api-Key: <key>`. A key carries an action set and a
+stream list, so an application can hold a least-privilege key: with
+`{"actions": ["ingest", "search"], "streams": ["items"]}` it can create
+its index (`PUT /items`), write and read documents, and nothing else.
+`PUT /{index}`, the document writes and `_delete_by_query` classify as
+stream-scoped `ingest`; document reads, `GET /{index}` and `_settings`
+as stream-scoped `search`. Everything under `/_rsearch/` stays admin.
 
 ### Loki-compatible API (Grafana Logs Drilldown)
 

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -159,6 +159,20 @@ pub struct ControlConfig {
     /// DELETE /_rsearch/nodes/{id}/drain, and the node silently takes no
     /// writes or repair copies while it lasts.
     pub drain_warn_secs: f64,
+    /// Document-mode compaction trigger: a stream whose tombstone count
+    /// reaches this has its splits rewritten without the hidden versions.
+    pub compact_min_tombstones: i64,
+    /// Document-mode compaction trigger: a stream whose oldest tombstone
+    /// is older than this is compacted regardless of count — the bound on
+    /// how long a deleted document physically survives in storage.
+    pub compact_max_age_secs: f64,
+    /// Max splits rewritten (or marked up to date) per compaction tick.
+    pub compact_splits_per_tick: i64,
+    /// Tombstones are purged from the metastore only once no split can
+    /// still hold a version they hide *and* they are at least this old —
+    /// the age covers documents still buffered on an ingest node whose
+    /// split has not been cut yet.
+    pub tombstone_purge_grace_secs: f64,
 }
 
 impl Default for ControlConfig {
@@ -172,6 +186,10 @@ impl Default for ControlConfig {
             staged_orphan_secs: 3600.0,
             repair_stale_secs: 300.0,
             drain_warn_secs: 3600.0,
+            compact_min_tombstones: 1_000,
+            compact_max_age_secs: 3_600.0,
+            compact_splits_per_tick: 8,
+            tombstone_purge_grace_secs: 3_600.0,
         }
     }
 }

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -360,6 +360,10 @@ pub struct IngestConfig {
     pub max_batch_docs: usize,
     /// Max seconds a batch may age before a split is cut.
     pub max_batch_secs: u64,
+    /// Same bound for document-mode streams, which trade smaller splits
+    /// for a tighter time-to-searchable (a user saves a record and
+    /// searches for it). `?refresh=wait_for` forces an immediate cut.
+    pub document_max_batch_secs: u64,
     /// Bound on the in-flight ingest queue (documents per stream) before
     /// per-item 429s are returned.
     pub queue_capacity: usize,
@@ -380,6 +384,7 @@ impl Default for IngestConfig {
         Self {
             max_batch_docs: 500_000,
             max_batch_secs: 30,
+            document_max_batch_secs: 5,
             queue_capacity: 100_000,
             memory_budget_mb: 256,
             wal_segment_mb: 64,

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -19,6 +19,8 @@ pub struct SplitBuilder {
     doc_count: u64,
     min_ts_millis: i64,
     max_ts_millis: i64,
+    min_seq: i64,
+    max_seq: i64,
 }
 
 /// A finished split: a single bundled file on local disk plus its
@@ -63,6 +65,8 @@ impl SplitBuilder {
             doc_count: 0,
             min_ts_millis: i64::MAX,
             max_ts_millis: i64::MIN,
+            min_seq: i64::MAX,
+            max_seq: i64::MIN,
         })
     }
 
@@ -107,6 +111,8 @@ impl SplitBuilder {
         self.writer.add_document(converted)?;
         self.min_ts_millis = self.min_ts_millis.min(millis);
         self.max_ts_millis = self.max_ts_millis.max(millis);
+        self.min_seq = self.min_seq.min(identity.seq);
+        self.max_seq = self.max_seq.max(identity.seq);
         self.doc_count += 1;
         Ok(())
     }
@@ -133,6 +139,8 @@ impl SplitBuilder {
             time_end_millis: self.max_ts_millis,
             mapping: self.converter.schema().mapping.to_json(),
             schema_version: self.converter.schema().schema_version,
+            seq_min: self.converter.schema().seq.map(|_| self.min_seq),
+            seq_max: self.converter.schema().seq.map(|_| self.max_seq),
         };
 
         let file_path = self.work_dir.path().join(format!("{}.split", self.split_id));

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use tantivy::{Index, IndexWriter, TantivyDocument};
 
-use crate::document::DocumentConverter;
+use crate::document::{DocIdentity, DocumentConverter};
 use crate::error::{IndexError, IndexResult};
 use crate::mapping::MappedSchema;
 use crate::split_file::{self, SplitMeta};
@@ -76,28 +76,31 @@ impl SplitBuilder {
         self.doc_count
     }
 
-    /// Convert and buffer one document (serializes `_source` from `doc`).
+    /// Convert and buffer one document (serializes `_source` from `doc`)
+    /// under a fresh generated id at sequence 0.
     pub fn add_json(
         &mut self,
         doc: serde_json::Value,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<()> {
-        self.add_json_with_source(doc, None, fallback_timestamp)
+        let identity = DocIdentity::generated();
+        self.add_document(doc, None, &identity, fallback_timestamp)
     }
 
-    /// Convert and buffer one document, storing `source` verbatim as
-    /// `_source` (the client's original line) instead of re-serializing.
-    /// The document is consumed — its unmapped fields move into `_dynamic`
-    /// without a deep clone.
-    pub fn add_json_with_source(
+    /// Convert and buffer one document with an explicit identity, storing
+    /// `source` verbatim as `_source` (the client's original line) when
+    /// given instead of re-serializing. The document is consumed — its
+    /// unmapped fields move into `_dynamic` without a deep clone.
+    pub fn add_document(
         &mut self,
         doc: serde_json::Value,
         source: Option<&str>,
+        identity: &DocIdentity,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<()> {
         let (converted, ts): (TantivyDocument, _) =
             self.converter
-                .convert_with_source(doc, source, fallback_timestamp)?;
+                .convert_with_source(doc, source, identity, fallback_timestamp)?;
         let millis = ts.into_timestamp_millis();
         // Update the advertised time range only after the doc is accepted,
         // so a rejected add can't widen the split's range (L6).
@@ -129,6 +132,7 @@ impl SplitBuilder {
             time_start_millis: self.min_ts_millis,
             time_end_millis: self.max_ts_millis,
             mapping: self.converter.schema().mapping.to_json(),
+            schema_version: self.converter.schema().schema_version,
         };
 
         let file_path = self.work_dir.path().join(format!("{}.split", self.split_id));

--- a/crates/rsearch-index/src/document.rs
+++ b/crates/rsearch-index/src/document.rs
@@ -7,6 +7,29 @@ use tantivy::time::format_description::well_known::Rfc3339;
 use crate::error::{IndexError, IndexResult};
 use crate::mapping::{FieldType, MappedSchema};
 
+/// A document's identity within its stream: the `_id` (client-supplied or
+/// generated) and the write sequence stamp that orders versions of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DocIdentity {
+    /// The document id (`_id`).
+    pub id: String,
+    /// Node-local monotonic write stamp (micros since epoch); `0` for
+    /// documents whose write predates sequence tracking.
+    pub seq: i64,
+}
+
+impl DocIdentity {
+    /// Identity with the given id and sequence.
+    pub fn new(id: impl Into<String>, seq: i64) -> Self {
+        Self { id: id.into(), seq }
+    }
+
+    /// A fresh UUID id at sequence 0.
+    pub fn generated() -> Self {
+        Self::new(uuid::Uuid::new_v4().simple().to_string(), 0)
+    }
+}
+
 /// Extract a document timestamp from `@timestamp` or `timestamp` fields.
 /// Accepts RFC 3339 strings, epoch seconds, or epoch milliseconds
 /// (numbers >= 1e12 are treated as milliseconds).
@@ -82,12 +105,15 @@ impl DocumentConverter {
     }
 
     /// Convert one document, deriving the stored `_source` from the doc.
+    /// Identity is a fresh generated id at sequence 0 (tests, legacy
+    /// re-index paths).
     pub fn convert(
         &self,
         doc: serde_json::Value,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<(TantivyDocument, tantivy::DateTime)> {
-        self.convert_with_source(doc, None, fallback_timestamp)
+        let id = DocIdentity::generated();
+        self.convert_with_source(doc, None, &id, fallback_timestamp)
     }
 
     /// Convert one document. `source` is the exact bytes to store as
@@ -103,6 +129,7 @@ impl DocumentConverter {
         &self,
         doc: serde_json::Value,
         source: Option<&str>,
+        identity: &DocIdentity,
         fallback_timestamp: tantivy::DateTime,
     ) -> IndexResult<(TantivyDocument, tantivy::DateTime)> {
         let timestamp = extract_timestamp(&doc).unwrap_or(fallback_timestamp);
@@ -118,6 +145,10 @@ impl DocumentConverter {
 
         let mut out = TantivyDocument::new();
         out.add_date(self.schema.timestamp, timestamp);
+        if let (Some(id_field), Some(seq_field)) = (self.schema.id, self.schema.seq) {
+            out.add_text(id_field, &identity.id);
+            out.add_i64(seq_field, identity.seq);
+        }
         match (source, serialized) {
             (Some(source), _) => out.add_text(self.schema.source, source),
             (None, Some(serialized)) => out.add_text(self.schema.source, serialized),
@@ -317,7 +348,7 @@ mod tests {
                 fallback(),
             )
             .unwrap();
-        // 2 service + 3 status + _source + _timestamp
-        assert_eq!(doc.field_values().count(), 7);
+        // 2 service + 3 status + _source + _timestamp + _id + _seq
+        assert_eq!(doc.field_values().count(), 9);
     }
 }

--- a/crates/rsearch-index/src/exclusions.rs
+++ b/crates/rsearch-index/src/exclusions.rs
@@ -8,9 +8,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use tantivy::index::SegmentId;
 use tantivy::query::{ConstScorer, EnableScoring, Explanation, Query, Scorer, Weight};
 use tantivy::schema::{IndexRecordOption, Term};
-use tantivy::index::SegmentId;
 use tantivy::{DocId, DocSet, Score, SegmentReader, TERMINATED};
 
 use crate::error::IndexResult;
@@ -89,7 +89,10 @@ impl ExclusionSet {
         let mut per_segment = Vec::with_capacity(self.per_segment.len());
         let mut total = 0;
         for (ord, existing) in self.per_segment.iter().enumerate() {
-            let added = additions.get_mut(ord).map(std::mem::take).unwrap_or_default();
+            let added = additions
+                .get_mut(ord)
+                .map(std::mem::take)
+                .unwrap_or_default();
             let docs: Arc<[DocId]> = if added.is_empty() {
                 existing.clone()
             } else {
@@ -349,9 +352,21 @@ mod tests {
             // cached set extends by the tail only.
             let set = r
                 .apply_tombstones(&[
-                    Tombstone { seq: 1, doc_id: "alpha".into(), before_seq: 30 },
-                    Tombstone { seq: 2, doc_id: "beta".into(), before_seq: 1_000 },
-                    Tombstone { seq: 3, doc_id: "alpha".into(), before_seq: 1_000 },
+                    Tombstone {
+                        seq: 1,
+                        doc_id: "alpha".into(),
+                        before_seq: 30,
+                    },
+                    Tombstone {
+                        seq: 2,
+                        doc_id: "beta".into(),
+                        before_seq: 1_000,
+                    },
+                    Tombstone {
+                        seq: 3,
+                        doc_id: "alpha".into(),
+                        before_seq: 1_000,
+                    },
                 ])
                 .unwrap();
             assert_eq!(set.len(), 3);
@@ -362,8 +377,16 @@ mod tests {
             // without any lookup; unknown ids are harmless.
             let set = r
                 .apply_tombstones(&[
-                    Tombstone { seq: 4, doc_id: "gamma".into(), before_seq: 10 },
-                    Tombstone { seq: 5, doc_id: "nobody".into(), before_seq: 1_000 },
+                    Tombstone {
+                        seq: 4,
+                        doc_id: "gamma".into(),
+                        before_seq: 10,
+                    },
+                    Tombstone {
+                        seq: 5,
+                        doc_id: "nobody".into(),
+                        before_seq: 1_000,
+                    },
                 ])
                 .unwrap();
             assert_eq!(set.len(), 3);

--- a/crates/rsearch-index/src/exclusions.rs
+++ b/crates/rsearch-index/src/exclusions.rs
@@ -1,0 +1,377 @@
+//! Tombstone application. A tombstone says "hide every version of `_id`
+//! whose `_seq` is below `before_seq`". Resolving that against an
+//! immutable split yields a fixed set of (segment, doc) addresses, so the
+//! set is computed once per split and extended incrementally as newer
+//! tombstones arrive — Lucene's live-docs bitset, kept in cache form
+//! because splits are shared read-only objects.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tantivy::query::{ConstScorer, EnableScoring, Explanation, Query, Scorer, Weight};
+use tantivy::schema::{IndexRecordOption, Term};
+use tantivy::index::SegmentId;
+use tantivy::{DocId, DocSet, Score, SegmentReader, TERMINATED};
+
+use crate::error::IndexResult;
+use crate::mapping::SEQ_FIELD;
+use crate::reader::SplitReader;
+
+/// One tombstone, as stored in the metastore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tombstone {
+    /// Monotonic tombstone ordinal; application state is tracked by it.
+    pub seq: i64,
+    /// The `_id` whose older versions are hidden.
+    pub doc_id: String,
+    /// Versions with `_seq` strictly below this are hidden.
+    pub before_seq: i64,
+}
+
+/// The documents of one split hidden by every tombstone applied so far.
+#[derive(Debug)]
+pub struct ExclusionSet {
+    /// Highest tombstone `seq` folded into this set.
+    pub applied_through: i64,
+    /// Per segment ordinal: sorted, de-duplicated excluded doc ids.
+    per_segment: Vec<Arc<[DocId]>>,
+    /// Segment id → ordinal (a `SegmentReader` knows its id, not its
+    /// ordinal, when a `Weight` builds a scorer for it).
+    ordinals: HashMap<SegmentId, usize>,
+    total: usize,
+}
+
+impl ExclusionSet {
+    /// An empty set for a split whose segments are `segment_ids`, in
+    /// ordinal order.
+    pub fn empty(segment_ids: Vec<SegmentId>) -> Self {
+        Self {
+            applied_through: 0,
+            per_segment: vec![Arc::from(Vec::new()); segment_ids.len()],
+            ordinals: segment_ids
+                .into_iter()
+                .enumerate()
+                .map(|(ord, id)| (id, ord))
+                .collect(),
+            total: 0,
+        }
+    }
+
+    /// Excluded docs of the segment with the given id (empty if none).
+    fn for_segment(&self, id: SegmentId) -> Arc<[DocId]> {
+        self.ordinals
+            .get(&id)
+            .and_then(|ord| self.per_segment.get(*ord))
+            .cloned()
+            .unwrap_or_else(|| Arc::from(Vec::new()))
+    }
+
+    /// Number of excluded documents across all segments.
+    pub fn len(&self) -> usize {
+        self.total
+    }
+
+    /// True when nothing is excluded.
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
+
+    /// Whether (segment, doc) is excluded.
+    pub fn contains(&self, segment_ord: u32, doc: DocId) -> bool {
+        self.per_segment
+            .get(segment_ord as usize)
+            .map(|docs| docs.binary_search(&doc).is_ok())
+            .unwrap_or(false)
+    }
+
+    /// Fold newly excluded docs (unsorted, may repeat) into a new set.
+    fn extended(&self, mut additions: Vec<Vec<DocId>>, applied_through: i64) -> Self {
+        let mut per_segment = Vec::with_capacity(self.per_segment.len());
+        let mut total = 0;
+        for (ord, existing) in self.per_segment.iter().enumerate() {
+            let added = additions.get_mut(ord).map(std::mem::take).unwrap_or_default();
+            let docs: Arc<[DocId]> = if added.is_empty() {
+                existing.clone()
+            } else {
+                let mut merged: Vec<DocId> = existing.iter().copied().chain(added).collect();
+                merged.sort_unstable();
+                merged.dedup();
+                Arc::from(merged)
+            };
+            total += docs.len();
+            per_segment.push(docs);
+        }
+        Self {
+            applied_through,
+            per_segment,
+            ordinals: self.ordinals.clone(),
+            total,
+        }
+    }
+}
+
+impl SplitReader {
+    /// Fold `tombstones` (ascending by `seq`) into this split's cached
+    /// exclusion set and return the result. Tombstones at or below the
+    /// already-applied seq are skipped, so callers pass their whole cached
+    /// list each time and only the tail costs anything. Call from a
+    /// blocking context (term lookups may read from storage).
+    pub fn apply_tombstones(&self, tombstones: &[Tombstone]) -> IndexResult<Arc<ExclusionSet>> {
+        // Serialize appliers: concurrent queries on one split wait for the
+        // first rather than each repeating the term lookups.
+        let mut slot = self.exclusions.lock().unwrap();
+        let current = slot.clone();
+        let start = tombstones.partition_point(|t| t.seq <= current.applied_through);
+        let pending = &tombstones[start..];
+        let Some(last) = pending.last() else {
+            return Ok(current);
+        };
+        let applied_through = last.seq;
+        let id_field = match self.mapped_schema().id {
+            Some(field) => field,
+            None => {
+                // Legacy split: no ids, so tombstones can never apply.
+                let next = Arc::new(current.extended(Vec::new(), applied_through));
+                *slot = next.clone();
+                return Ok(next);
+            }
+        };
+        // Nothing in the split is older than a tombstone's bound when the
+        // split's lowest _seq is already at or past it.
+        let seq_min = self.meta.split.seq_min;
+        let searcher = self.searcher()?;
+        let segments = searcher.segment_readers();
+        let mut additions: Vec<Vec<DocId>> = vec![Vec::new(); segments.len()];
+        for (ord, segment) in segments.iter().enumerate() {
+            let inverted = segment.inverted_index(id_field)?;
+            let seq_column = segment.fast_fields().i64(SEQ_FIELD)?;
+            for tombstone in pending {
+                if seq_min.is_some_and(|min| tombstone.before_seq <= min) {
+                    continue;
+                }
+                let term = Term::from_field_text(id_field, &tombstone.doc_id);
+                let Some(mut postings) = inverted.read_postings(&term, IndexRecordOption::Basic)?
+                else {
+                    continue;
+                };
+                let mut doc = postings.doc();
+                while doc != TERMINATED {
+                    if seq_column
+                        .first(doc)
+                        .is_some_and(|seq| seq < tombstone.before_seq)
+                    {
+                        additions[ord].push(doc);
+                    }
+                    doc = postings.advance();
+                }
+            }
+        }
+        let next = Arc::new(current.extended(additions, applied_through));
+        *slot = next.clone();
+        Ok(next)
+    }
+
+    /// The exclusion set as last computed (without applying anything).
+    pub fn current_exclusions(&self) -> Arc<ExclusionSet> {
+        self.exclusions.lock().unwrap().clone()
+    }
+}
+
+/// Matches exactly the documents in an [`ExclusionSet`] — used as a
+/// `must_not` clause so counts, hits, and aggregations all skip them.
+#[derive(Debug, Clone)]
+pub struct ExcludeDocsQuery {
+    set: Arc<ExclusionSet>,
+}
+
+impl ExcludeDocsQuery {
+    /// A query over the given set.
+    pub fn new(set: Arc<ExclusionSet>) -> Self {
+        Self { set }
+    }
+}
+
+impl Query for ExcludeDocsQuery {
+    fn weight(&self, _enable_scoring: EnableScoring<'_>) -> tantivy::Result<Box<dyn Weight>> {
+        Ok(Box::new(ExcludeDocsWeight {
+            set: self.set.clone(),
+        }))
+    }
+}
+
+struct ExcludeDocsWeight {
+    set: Arc<ExclusionSet>,
+}
+
+impl Weight for ExcludeDocsWeight {
+    fn scorer(&self, reader: &SegmentReader, boost: Score) -> tantivy::Result<Box<dyn Scorer>> {
+        let docs = self.set.for_segment(reader.segment_id());
+        Ok(Box::new(ConstScorer::new(SortedDocSet::new(docs), boost)))
+    }
+
+    fn explain(&self, reader: &SegmentReader, doc: DocId) -> tantivy::Result<Explanation> {
+        let docs = self.set.for_segment(reader.segment_id());
+        if docs.binary_search(&doc).is_ok() {
+            Ok(Explanation::new("tombstoned document", 1.0))
+        } else {
+            Err(tantivy::TantivyError::InvalidArgument(
+                "document is not excluded".to_string(),
+            ))
+        }
+    }
+}
+
+/// A `DocSet` over a sorted, de-duplicated slice of doc ids.
+struct SortedDocSet {
+    docs: Arc<[DocId]>,
+    cursor: usize,
+}
+
+impl SortedDocSet {
+    fn new(docs: Arc<[DocId]>) -> Self {
+        Self { docs, cursor: 0 }
+    }
+}
+
+impl DocSet for SortedDocSet {
+    fn advance(&mut self) -> DocId {
+        self.cursor = self.cursor.saturating_add(1).min(self.docs.len());
+        self.doc()
+    }
+
+    fn seek(&mut self, target: DocId) -> DocId {
+        // Docs are sorted: jump to the first id >= target.
+        let rest = &self.docs[self.cursor.min(self.docs.len())..];
+        self.cursor += rest.partition_point(|&d| d < target);
+        self.doc()
+    }
+
+    fn doc(&self) -> DocId {
+        self.docs.get(self.cursor).copied().unwrap_or(TERMINATED)
+    }
+
+    fn size_hint(&self) -> u32 {
+        self.docs.len().saturating_sub(self.cursor) as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::SplitBuilder;
+    use crate::cache::SplitCache;
+    use crate::document::DocIdentity;
+    use crate::mapping::{IndexMapping, MappedSchema};
+    use rsearch_storage::{FsStorage, Storage};
+    use tantivy::collector::Count;
+    use tantivy::query::{AllQuery, BooleanQuery, Occur, TermQuery};
+
+    /// alpha@10, beta@20, alpha@30, gamma@40 (two segments worth of adds
+    /// are irrelevant — one commit, one segment).
+    async fn open_split() -> (Arc<SplitReader>, tempfile::TempDir, tempfile::TempDir) {
+        let store_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        let storage: Arc<dyn Storage> = Arc::new(FsStorage::new(store_dir.path()));
+        let schema = MappedSchema::build(IndexMapping::default());
+        let mut builder = SplitBuilder::new("docs", schema, scratch.path(), 20 << 20).unwrap();
+        for (id, seq) in [("alpha", 10), ("beta", 20), ("alpha", 30), ("gamma", 40)] {
+            builder
+                .add_document(
+                    serde_json::json!({"id": id}),
+                    None,
+                    &DocIdentity::new(id, seq),
+                    tantivy::DateTime::from_timestamp_millis(1_753_300_000_000),
+                )
+                .unwrap();
+        }
+        let packaged = builder.finish().unwrap();
+        assert_eq!(packaged.meta.seq_min, Some(10));
+        assert_eq!(packaged.meta.seq_max, Some(40));
+        let key = format!("splits/{}.split", packaged.meta.split_id);
+        storage.put_file(&key, &packaged.file_path).await.unwrap();
+        let cache = Arc::new(SplitCache::new(cache_dir.path(), 1 << 30).unwrap());
+        let reader = Arc::new(SplitReader::open(storage, &key, cache).await.unwrap());
+        (reader, store_dir, cache_dir)
+    }
+
+    fn count(reader: &SplitReader, set: &Arc<ExclusionSet>, query: Box<dyn Query>) -> usize {
+        let searcher = reader.searcher().unwrap();
+        let wrapped = BooleanQuery::new(vec![
+            (Occur::Must, query),
+            (Occur::MustNot, Box::new(ExcludeDocsQuery::new(set.clone()))),
+        ]);
+        searcher.search(&wrapped, &Count).unwrap()
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn tombstones_hide_older_versions_incrementally() {
+        let (reader, _s, _c) = open_split().await;
+        let r = reader.clone();
+        tokio::task::spawn_blocking(move || {
+            let id_field = r.mapped_schema().id.unwrap();
+            let alpha = || -> Box<dyn Query> {
+                Box::new(TermQuery::new(
+                    Term::from_field_text(id_field, "alpha"),
+                    IndexRecordOption::Basic,
+                ))
+            };
+
+            // Nothing applied: everything visible.
+            let empty = r.current_exclusions();
+            assert!(empty.is_empty());
+            assert_eq!(count(&r, &empty, Box::new(AllQuery)), 4);
+
+            // "alpha replaced at seq 30": hides alpha@10 only.
+            let set = r
+                .apply_tombstones(&[Tombstone {
+                    seq: 1,
+                    doc_id: "alpha".into(),
+                    before_seq: 30,
+                }])
+                .unwrap();
+            assert_eq!(set.len(), 1);
+            assert_eq!(set.applied_through, 1);
+            assert_eq!(count(&r, &set, Box::new(AllQuery)), 3);
+            assert_eq!(count(&r, &set, alpha()), 1);
+
+            // Re-applying the same list is a no-op (already past seq 1).
+            let again = r
+                .apply_tombstones(&[Tombstone {
+                    seq: 1,
+                    doc_id: "alpha".into(),
+                    before_seq: 30,
+                }])
+                .unwrap();
+            assert!(Arc::ptr_eq(&set, &again));
+
+            // Delete beta (before everything) and alpha entirely: the
+            // cached set extends by the tail only.
+            let set = r
+                .apply_tombstones(&[
+                    Tombstone { seq: 1, doc_id: "alpha".into(), before_seq: 30 },
+                    Tombstone { seq: 2, doc_id: "beta".into(), before_seq: 1_000 },
+                    Tombstone { seq: 3, doc_id: "alpha".into(), before_seq: 1_000 },
+                ])
+                .unwrap();
+            assert_eq!(set.len(), 3);
+            assert_eq!(set.applied_through, 3);
+            assert_eq!(count(&r, &set, Box::new(AllQuery)), 1);
+            assert_eq!(count(&r, &set, alpha()), 0);
+            // A tombstone at or below the split's lowest _seq is skipped
+            // without any lookup; unknown ids are harmless.
+            let set = r
+                .apply_tombstones(&[
+                    Tombstone { seq: 4, doc_id: "gamma".into(), before_seq: 10 },
+                    Tombstone { seq: 5, doc_id: "nobody".into(), before_seq: 1_000 },
+                ])
+                .unwrap();
+            assert_eq!(set.len(), 3);
+            assert_eq!(set.applied_through, 5);
+            assert!(set.contains(0, 0));
+            assert!(!set.contains(0, 3));
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/crates/rsearch-index/src/exclusions.rs
+++ b/crates/rsearch-index/src/exclusions.rs
@@ -121,8 +121,12 @@ impl SplitReader {
     /// blocking context (term lookups may read from storage).
     pub fn apply_tombstones(&self, tombstones: &[Tombstone]) -> IndexResult<Arc<ExclusionSet>> {
         // Serialize appliers: concurrent queries on one split wait for the
-        // first rather than each repeating the term lookups.
-        let mut slot = self.exclusions.lock().unwrap();
+        // first rather than each repeating the term lookups. A poisoned
+        // lock (a panic mid-apply) just yields the last good set.
+        let mut slot = self
+            .exclusions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         let current = slot.clone();
         let start = tombstones.partition_point(|t| t.seq <= current.applied_through);
         let pending = &tombstones[start..];
@@ -174,9 +178,24 @@ impl SplitReader {
         Ok(next)
     }
 
-    /// The exclusion set as last computed (without applying anything).
-    pub fn current_exclusions(&self) -> Arc<ExclusionSet> {
-        self.exclusions.lock().unwrap().clone()
+    /// Start the exclusion bookkeeping at `applied_through`: tombstones at
+    /// or below it are known to hide nothing in this split (it was built —
+    /// by compaction or a merge — with them applied), so they are never
+    /// looked up. Only moves forward, and only while nothing has been
+    /// applied yet (the cached set would otherwise be incomplete).
+    pub fn seed_applied_through(&self, applied_through: i64) {
+        let mut slot = self
+            .exclusions
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot.applied_through == 0 && slot.is_empty() && applied_through > 0 {
+            *slot = Arc::new(ExclusionSet {
+                applied_through,
+                per_segment: slot.per_segment.clone(),
+                ordinals: slot.ordinals.clone(),
+                total: 0,
+            });
+        }
     }
 }
 
@@ -321,7 +340,7 @@ mod tests {
             };
 
             // Nothing applied: everything visible.
-            let empty = r.current_exclusions();
+            let empty = r.apply_tombstones(&[]).unwrap();
             assert!(empty.is_empty());
             assert_eq!(count(&r, &empty, Box::new(AllQuery)), 4);
 
@@ -393,6 +412,37 @@ mod tests {
             assert_eq!(set.applied_through, 5);
             assert!(set.contains(0, 0));
             assert!(!set.contains(0, 3));
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn seeded_reader_skips_already_applied_tombstones() {
+        let (reader, _s, _c) = open_split().await;
+        tokio::task::spawn_blocking(move || {
+            // The split was (notionally) rebuilt with tombstones through
+            // seq 5 applied: those are never looked up, later ones are.
+            reader.seed_applied_through(5);
+            let set = reader
+                .apply_tombstones(&[
+                    Tombstone {
+                        seq: 3,
+                        doc_id: "alpha".into(),
+                        before_seq: 1_000,
+                    },
+                    Tombstone {
+                        seq: 7,
+                        doc_id: "beta".into(),
+                        before_seq: 1_000,
+                    },
+                ])
+                .unwrap();
+            assert_eq!(set.applied_through, 7);
+            assert_eq!(set.len(), 1, "only beta (seq 7) was applied");
+            // Seeding after application is a no-op.
+            reader.seed_applied_through(100);
+            assert_eq!(reader.apply_tombstones(&[]).unwrap().applied_through, 7);
         })
         .await
         .unwrap();

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -6,6 +6,7 @@ mod builder;
 mod cache;
 mod document;
 mod error;
+mod exclusions;
 mod mapping;
 mod reader;
 mod split_file;
@@ -16,6 +17,7 @@ pub use cache::SplitCache;
 pub use reader::{ReadDoc, SplitReader};
 pub use document::{DocIdentity, DocumentConverter, epoch_to_millis, extract_timestamp};
 pub use error::{IndexError, IndexResult};
+pub use exclusions::{ExcludeDocsQuery, ExclusionSet, Tombstone};
 pub use mapping::{
     CURRENT_SCHEMA_VERSION, DYNAMIC_FIELD, FieldType, ID_FIELD, IndexMapping, MappedSchema,
     SEQ_FIELD, SOURCE_FIELD, TIMESTAMP_FIELD,

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -13,8 +13,11 @@ mod split_file;
 pub use builder::{PackagedSplit, SplitBuilder};
 pub use tantivy::DateTime;
 pub use cache::SplitCache;
-pub use reader::SplitReader;
-pub use document::{DocumentConverter, epoch_to_millis, extract_timestamp};
+pub use reader::{ReadDoc, SplitReader};
+pub use document::{DocIdentity, DocumentConverter, epoch_to_millis, extract_timestamp};
 pub use error::{IndexError, IndexResult};
-pub use mapping::{FieldType, IndexMapping, MappedSchema};
+pub use mapping::{
+    CURRENT_SCHEMA_VERSION, DYNAMIC_FIELD, FieldType, ID_FIELD, IndexMapping, MappedSchema,
+    SEQ_FIELD, SOURCE_FIELD, TIMESTAMP_FIELD,
+};
 pub use split_file::{BundleMeta, FOOTER_TAIL_LEN, FileSpan, SplitMeta, parse_footer_tail, parse_meta};

--- a/crates/rsearch-index/src/mapping.rs
+++ b/crates/rsearch-index/src/mapping.rs
@@ -7,10 +7,23 @@ use tantivy::schema::{
 
 use crate::error::{IndexError, IndexResult};
 
-/// Reserved fields present in every rsearch schema.
+/// Reserved stored `_source` field (the client's original document).
 pub const SOURCE_FIELD: &str = "_source";
+/// Reserved indexed+fast `_timestamp` field every document is sorted by.
 pub const TIMESTAMP_FIELD: &str = "_timestamp";
+/// Reserved JSON field unmapped keys are indexed under.
 pub const DYNAMIC_FIELD: &str = "_dynamic";
+/// Reserved document-id field (the client's `_id` or a generated UUID).
+/// Present in splits with `schema_version >= 1`.
+pub const ID_FIELD: &str = "_id";
+/// Reserved write-sequence field: a node-local monotonic stamp (micros
+/// since epoch) taken when the write was accepted. Orders versions of the
+/// same `_id` and scopes tombstones. Present with `schema_version >= 1`.
+pub const SEQ_FIELD: &str = "_seq";
+/// Schema version written into new splits. `0` (or absent in the footer)
+/// is the legacy layout without `_id`/`_seq`; `1` adds them after the
+/// mapped fields so legacy field ordinals are unchanged.
+pub const CURRENT_SCHEMA_VERSION: u32 = 1;
 
 /// Supported field types — the ES mapping subset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -118,12 +131,25 @@ pub struct MappedSchema {
     pub fields: BTreeMap<String, (Field, FieldType)>,
     /// The mapping this schema was built from.
     pub mapping: IndexMapping,
+    /// Handle to the stored `_id` field; None for legacy (version 0)
+    /// schemas, which have no document ids.
+    pub id: Option<Field>,
+    /// Handle to the `_seq` fast field; None for legacy schemas.
+    pub seq: Option<Field>,
+    /// The layout version this schema follows.
+    pub schema_version: u32,
 }
 
 impl MappedSchema {
-    /// Build the Tantivy schema: reserved fields plus one field per
-    /// mapping entry, typed per [`FieldType`].
+    /// Build the current-version Tantivy schema: reserved fields plus one
+    /// field per mapping entry, typed per [`FieldType`].
     pub fn build(mapping: IndexMapping) -> Self {
+        Self::build_versioned(mapping, CURRENT_SCHEMA_VERSION)
+    }
+
+    /// Build the schema for a given layout version — used to interpret a
+    /// split exactly as it was written (field ordinals must match).
+    pub fn build_versioned(mapping: IndexMapping, schema_version: u32) -> Self {
         let mut builder = Schema::builder();
         let source = builder.add_text_field(SOURCE_FIELD, STORED);
         let timestamp = builder.add_date_field(
@@ -154,6 +180,16 @@ impl MappedSchema {
             };
             fields.insert(name.clone(), (field, *ty));
         }
+        // Appended last so a version-0 split's mapped-field ordinals are
+        // identical to a version-1 split built from the same mapping.
+        let (id, seq) = if schema_version >= 1 {
+            (
+                Some(builder.add_text_field(ID_FIELD, STRING | STORED)),
+                Some(builder.add_i64_field(SEQ_FIELD, INDEXED | FAST)),
+            )
+        } else {
+            (None, None)
+        };
 
         Self {
             schema: builder.build(),
@@ -162,6 +198,9 @@ impl MappedSchema {
             dynamic,
             fields,
             mapping,
+            id,
+            seq,
+            schema_version,
         }
     }
 }
@@ -211,7 +250,25 @@ mod tests {
         assert!(schema.schema.get_field(SOURCE_FIELD).is_ok());
         assert!(schema.schema.get_field(TIMESTAMP_FIELD).is_ok());
         assert!(schema.schema.get_field(DYNAMIC_FIELD).is_ok());
+        assert!(schema.schema.get_field(ID_FIELD).is_ok());
+        assert!(schema.schema.get_field(SEQ_FIELD).is_ok());
         assert!(schema.fields.is_empty());
+        assert_eq!(schema.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn legacy_schema_keeps_mapped_field_ordinals() {
+        let mapping = IndexMapping::from_json(&serde_json::json!({
+            "properties": {"a": {"type": "keyword"}, "b": {"type": "long"}}
+        }))
+        .unwrap();
+        let legacy = MappedSchema::build_versioned(mapping.clone(), 0);
+        let current = MappedSchema::build(mapping);
+        assert!(legacy.id.is_none() && legacy.seq.is_none());
+        assert!(legacy.schema.get_field(ID_FIELD).is_err());
+        for name in ["a", "b"] {
+            assert_eq!(legacy.fields[name].0, current.fields[name].0);
+        }
     }
 
     #[test]

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -12,7 +12,21 @@ use rsearch_storage::Storage;
 
 use crate::cache::SplitCache;
 use crate::error::{IndexError, IndexResult};
+use crate::mapping::{ID_FIELD, IndexMapping, MappedSchema, SEQ_FIELD, SOURCE_FIELD, TIMESTAMP_FIELD};
 use crate::split_file::{BundleMeta, FOOTER_TAIL_LEN, parse_footer_tail, parse_meta};
+
+/// One document read back out of a split (merge / compaction re-index).
+#[derive(Debug)]
+pub struct ReadDoc {
+    /// Parsed `_source`.
+    pub json: serde_json::Value,
+    /// The document's `_timestamp`, epoch millis.
+    pub timestamp_millis: i64,
+    /// Stored `_id`; None in legacy splits (no id field).
+    pub id: Option<String>,
+    /// `_seq` write stamp; 0 in legacy splits.
+    pub seq: i64,
+}
 
 /// An opened split: footer metadata plus a lazily-fetching Tantivy index.
 /// Opening reads only the footer; internal files are range-read from
@@ -24,6 +38,9 @@ pub struct SplitReader {
     /// Built once and reused: splits are immutable, so re-opening every
     /// segment's readers per query is pure waste.
     reader: tantivy::IndexReader,
+    /// The mapped schema this split was written with (its own mapping and
+    /// layout version), so queries resolve fields by the split's ordinals.
+    schema: Arc<MappedSchema>,
 }
 
 impl SplitReader {
@@ -85,16 +102,29 @@ impl SplitReader {
         })
         .await
         .map_err(|e| IndexError::InvalidDocument(format!("open task failed: {e}")))??;
+        let mapping = IndexMapping::from_json(&meta.split.mapping).unwrap_or_default();
+        let schema = Arc::new(MappedSchema::build_versioned(mapping, meta.split.schema_version));
         Ok(Self {
             meta,
             index,
             reader,
+            schema,
         })
     }
 
     /// The underlying lazily-fetching Tantivy index.
     pub fn index(&self) -> &Index {
         &self.index
+    }
+
+    /// The schema this split was built with (own mapping + layout version).
+    pub fn mapped_schema(&self) -> &Arc<MappedSchema> {
+        &self.schema
+    }
+
+    /// Whether documents in this split carry `_id`/`_seq`.
+    pub fn has_doc_ids(&self) -> bool {
+        self.schema.id.is_some()
     }
 
     /// A searcher over this immutable split, reusing the reader built at
@@ -104,26 +134,34 @@ impl SplitReader {
         Ok(self.reader.searcher())
     }
 
-    /// Visit every document as (parsed source JSON, timestamp millis) —
-    /// used by the merge job to re-index small splits. Call from a
-    /// blocking context. Streams the doc store one document at a time so
+    /// Visit every document — used by the merge/compaction jobs to
+    /// re-index splits. `skip(segment_ord, doc_id)` lets the caller drop
+    /// documents (tombstoned ones) without reading their source. Call from
+    /// a blocking context. Streams the doc store one document at a time so
     /// re-indexing a whole merge group holds O(one doc) in memory, not the
     /// entire group's parsed corpus.
     pub fn for_each_doc(
         &self,
-        mut visit: impl FnMut(serde_json::Value, i64) -> IndexResult<()>,
+        mut skip: impl FnMut(u32, tantivy::DocId) -> bool,
+        mut visit: impl FnMut(ReadDoc) -> IndexResult<()>,
     ) -> IndexResult<()> {
         let searcher = self.searcher()?;
         let schema = self.index.schema();
         let source_field = schema
-            .get_field(crate::mapping::SOURCE_FIELD)
+            .get_field(SOURCE_FIELD)
             .map_err(|_| IndexError::InvalidDocument("split lacks _source".into()))?;
-        for segment_reader in searcher.segment_readers() {
+        let id_field = schema.get_field(ID_FIELD).ok();
+        for (segment_ord, segment_reader) in searcher.segment_readers().iter().enumerate() {
             let store = segment_reader.get_store_reader(10)?;
-            let ts_column = segment_reader
-                .fast_fields()
-                .date(crate::mapping::TIMESTAMP_FIELD)?;
+            let ts_column = segment_reader.fast_fields().date(TIMESTAMP_FIELD)?;
+            let seq_column = match id_field {
+                Some(_) => Some(segment_reader.fast_fields().i64(SEQ_FIELD)?),
+                None => None,
+            };
             for doc_id in segment_reader.doc_ids_alive() {
+                if skip(segment_ord as u32, doc_id) {
+                    continue;
+                }
                 let doc: tantivy::TantivyDocument = store.get(doc_id)?;
                 let source = doc
                     .get_first(source_field)
@@ -134,11 +172,25 @@ impl SplitReader {
                 let json: serde_json::Value = serde_json::from_str(source).map_err(|e| {
                     IndexError::InvalidDocument(format!("corrupt _source: {e}"))
                 })?;
-                let ts = ts_column
+                let timestamp_millis = ts_column
                     .first(doc_id)
                     .map(|dt| dt.into_timestamp_millis())
                     .unwrap_or_default();
-                visit(json, ts)?;
+                let id = id_field.and_then(|f| {
+                    doc.get_first(f)
+                        .and_then(|v| tantivy::schema::Value::as_str(&v))
+                        .map(str::to_string)
+                });
+                let seq = seq_column
+                    .as_ref()
+                    .and_then(|c| c.first(doc_id))
+                    .unwrap_or(0);
+                visit(ReadDoc {
+                    json,
+                    timestamp_millis,
+                    id,
+                    seq,
+                })?;
             }
         }
         Ok(())
@@ -383,6 +435,72 @@ mod tests {
             "cache {} should be smaller than split {}",
             cache.total_bytes(),
             split_size
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn identity_round_trips_through_split() {
+        use crate::document::DocIdentity;
+        use tantivy::query::TermQuery;
+        use tantivy::schema::{IndexRecordOption, Term};
+
+        let store_dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        let scratch = tempfile::tempdir().unwrap();
+        let storage: Arc<dyn Storage> = Arc::new(FsStorage::new(store_dir.path()));
+
+        let schema = MappedSchema::build(IndexMapping::default());
+        let mut builder = SplitBuilder::new("docs", schema, scratch.path(), 20 << 20).unwrap();
+        for (id, seq) in [("alpha", 10), ("beta", 20), ("alpha", 30)] {
+            builder
+                .add_document(
+                    serde_json::json!({"id": id, "seq": seq}),
+                    None,
+                    &DocIdentity::new(id, seq),
+                    tantivy::DateTime::from_timestamp_millis(1_753_300_000_000),
+                )
+                .unwrap();
+        }
+        let packaged = builder.finish().unwrap();
+        assert_eq!(packaged.meta.schema_version, crate::mapping::CURRENT_SCHEMA_VERSION);
+        let key = format!("splits/{}.split", packaged.meta.split_id);
+        storage.put_file(&key, &packaged.file_path).await.unwrap();
+
+        let cache = Arc::new(SplitCache::new(cache_dir.path(), 1 << 30).unwrap());
+        let reader = Arc::new(SplitReader::open(storage, &key, cache).await.unwrap());
+        assert!(reader.has_doc_ids());
+
+        let r = reader.clone();
+        let (alpha_count, seen) = tokio::task::spawn_blocking(move || {
+            let searcher = r.searcher().unwrap();
+            let id_field = r.mapped_schema().id.unwrap();
+            let query = TermQuery::new(
+                Term::from_field_text(id_field, "alpha"),
+                IndexRecordOption::Basic,
+            );
+            let alpha_count = searcher.search(&query, &Count).unwrap();
+            let mut seen = Vec::new();
+            r.for_each_doc(
+                |_, _| false,
+                |doc| {
+                    seen.push((doc.id.unwrap(), doc.seq));
+                    Ok(())
+                },
+            )
+            .unwrap();
+            seen.sort();
+            (alpha_count, seen)
+        })
+        .await
+        .unwrap();
+        assert_eq!(alpha_count, 2);
+        assert_eq!(
+            seen,
+            vec![
+                ("alpha".to_string(), 10),
+                ("alpha".to_string(), 30),
+                ("beta".to_string(), 20)
+            ]
         );
     }
 }

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -133,10 +133,6 @@ impl SplitReader {
         &self.schema
     }
 
-    /// Whether documents in this split carry `_id`/`_seq`.
-    pub fn has_doc_ids(&self) -> bool {
-        self.schema.id.is_some()
-    }
 
     /// A searcher over this immutable split, reusing the reader built at
     /// open time (segment readers are pooled, not re-opened). Call from a
@@ -479,7 +475,7 @@ mod tests {
 
         let cache = Arc::new(SplitCache::new(cache_dir.path(), 1 << 30).unwrap());
         let reader = Arc::new(SplitReader::open(storage, &key, cache).await.unwrap());
-        assert!(reader.has_doc_ids());
+        assert!(reader.mapped_schema().id.is_some());
 
         let r = reader.clone();
         let (alpha_count, seen) = tokio::task::spawn_blocking(move || {

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -41,6 +41,8 @@ pub struct SplitReader {
     /// The mapped schema this split was written with (its own mapping and
     /// layout version), so queries resolve fields by the split's ordinals.
     schema: Arc<MappedSchema>,
+    /// Tombstone exclusions applied so far (see `apply_tombstones`).
+    pub(crate) exclusions: std::sync::Mutex<Arc<crate::exclusions::ExclusionSet>>,
 }
 
 impl SplitReader {
@@ -104,11 +106,20 @@ impl SplitReader {
         .map_err(|e| IndexError::InvalidDocument(format!("open task failed: {e}")))??;
         let mapping = IndexMapping::from_json(&meta.split.mapping).unwrap_or_default();
         let schema = Arc::new(MappedSchema::build_versioned(mapping, meta.split.schema_version));
+        let segment_ids: Vec<tantivy::index::SegmentId> = reader
+            .searcher()
+            .segment_readers()
+            .iter()
+            .map(|s| s.segment_id())
+            .collect();
         Ok(Self {
             meta,
             index,
             reader,
             schema,
+            exclusions: std::sync::Mutex::new(Arc::new(
+                crate::exclusions::ExclusionSet::empty(segment_ids),
+            )),
         })
     }
 

--- a/crates/rsearch-index/src/split_file.rs
+++ b/crates/rsearch-index/src/split_file.rs
@@ -44,6 +44,10 @@ pub struct SplitMeta {
     pub time_end_millis: i64,
     /// The index mapping the split was built with (ES mapping shape).
     pub mapping: serde_json::Value,
+    /// Schema layout version (see `mapping::CURRENT_SCHEMA_VERSION`);
+    /// absent in footers written before `_id`/`_seq` existed.
+    #[serde(default)]
+    pub schema_version: u32,
 }
 
 /// Full footer contents: bundled file map + split metadata.

--- a/crates/rsearch-index/src/split_file.rs
+++ b/crates/rsearch-index/src/split_file.rs
@@ -48,6 +48,12 @@ pub struct SplitMeta {
     /// absent in footers written before `_id`/`_seq` existed.
     #[serde(default)]
     pub schema_version: u32,
+    /// Lowest `_seq` in the split; None when documents carry no ids.
+    #[serde(default)]
+    pub seq_min: Option<i64>,
+    /// Highest `_seq` in the split; None when documents carry no ids.
+    #[serde(default)]
+    pub seq_max: Option<i64>,
 }
 
 /// Full footer contents: bundled file map + split metadata.

--- a/crates/rsearch-ingest/src/bulk.rs
+++ b/crates/rsearch-ingest/src/bulk.rs
@@ -116,12 +116,14 @@ pub fn parse_bulk_body(
             .or(default_index)
             .unwrap_or("")
             .to_string();
-        let explicit_id = meta.get("_id").and_then(|v| v.as_str()).is_some();
-        let doc_id = meta
-            .get("_id")
-            .and_then(|v| v.as_str())
-            .map(str::to_string)
-            .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
+        // ES coerces numeric ids to strings ({"_id": 42} == {"_id": "42"}).
+        let explicit = match meta.get("_id") {
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Number(n)) => Some(n.to_string()),
+            _ => None,
+        };
+        let explicit_id = explicit.is_some();
+        let doc_id = explicit.unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
 
         let Some(action) = BulkAction::parse(action_name) else {
             return Err(format!(
@@ -247,6 +249,20 @@ mod tests {
         assert_eq!(update.doc["doc"]["x"], 1);
         assert_eq!(out.items[2].1.action, BulkAction::Index);
         assert!(!out.items[2].1.explicit_id);
+    }
+
+    #[test]
+    fn numeric_ids_are_coerced_to_strings() {
+        let body = concat!(
+            "{\"index\":{\"_index\":\"recs\",\"_id\":42}}\n",
+            "{\"v\":1}\n",
+            "{\"delete\":{\"_index\":\"recs\",\"_id\":7}}\n",
+        );
+        let out = parse_bulk_body(body, None).unwrap();
+        assert!(out.rejections.is_empty());
+        assert_eq!(out.items[0].1.doc_id, "42");
+        assert!(out.items[0].1.explicit_id);
+        assert_eq!(out.items[1].1.doc_id, "7");
     }
 
     #[test]

--- a/crates/rsearch-ingest/src/bulk.rs
+++ b/crates/rsearch-ingest/src/bulk.rs
@@ -1,17 +1,26 @@
 //! `_bulk` NDJSON parsing: alternating action and document lines, per the
-//! ES/OpenSearch wire format. Log ingestion supports `index` and `create`
-//! actions; `delete`/`update` are rejected per item (immutable log store).
+//! ES/OpenSearch wire format. All four actions parse; whether `delete`
+//! and `update` are *accepted* depends on the target stream's mode (log
+//! streams reject them per item, document streams honor them) — that is
+//! the handler's call, so the parser stays mode-agnostic.
 
 use serde_json::Value;
 
-/// Accepted bulk action kinds (both index the document; the immutable
-/// log store makes no update-vs-create distinction).
+/// Bulk action kinds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BulkAction {
-    /// An `{"index": …}` action line.
+    /// An `{"index": …}` action line: write the document (document-mode
+    /// streams replace an existing `_id`).
     Index,
-    /// A `{"create": …}` action line.
+    /// A `{"create": …}` action line: write only if the `_id` is absent
+    /// (document mode); indistinguishable from `index` on log streams.
     Create,
+    /// An `{"update": …}` action line followed by `{"doc": …}`: partial
+    /// update of an existing document (document mode only).
+    Update,
+    /// A `{"delete": …}` action line (no document line): hide every
+    /// version of the `_id` (document mode only).
+    Delete,
 }
 
 impl BulkAction {
@@ -20,23 +29,46 @@ impl BulkAction {
         match self {
             BulkAction::Index => "index",
             BulkAction::Create => "create",
+            BulkAction::Update => "update",
+            BulkAction::Delete => "delete",
+        }
+    }
+
+    /// Whether the action needs a following document line.
+    fn has_doc_line(&self) -> bool {
+        !matches!(self, BulkAction::Delete)
+    }
+
+    fn parse(name: &str) -> Option<Self> {
+        match name {
+            "index" => Some(BulkAction::Index),
+            "create" => Some(BulkAction::Create),
+            "update" => Some(BulkAction::Update),
+            "delete" => Some(BulkAction::Delete),
+            _ => None,
         }
     }
 }
 
-/// One accepted document.
+/// One parsed action.
 #[derive(Debug)]
 pub struct BulkItem {
-    /// The action kind that carried the document.
+    /// The action kind.
     pub action: BulkAction,
     /// Target stream: the action line's `_index`, or the URL default.
     pub stream: String,
-    /// Document id: the action line's `_id`, or a generated UUID.
+    /// Document id: the action line's `_id`, or a generated UUID for
+    /// `index`/`create` without one (`update`/`delete` require it).
     pub doc_id: String,
-    /// The parsed document body.
+    /// Whether the client supplied the `_id` (vs. generated here).
+    pub explicit_id: bool,
+    /// The parsed body: the document for `index`/`create`, the update
+    /// body (`{"doc": …, "doc_as_upsert": …}`) for `update`, `Null` for
+    /// `delete`.
     pub doc: Value,
-    /// The client's original document line, stored verbatim as `_source`
-    /// and written to the WAL — avoids re-serializing the parsed value.
+    /// The client's original body line (empty for `delete`), stored
+    /// verbatim as `_source` and written to the WAL for `index`/`create` —
+    /// avoids re-serializing the parsed value.
     pub raw: std::sync::Arc<str>,
 }
 
@@ -84,93 +116,72 @@ pub fn parse_bulk_body(
             .or(default_index)
             .unwrap_or("")
             .to_string();
+        let explicit_id = meta.get("_id").and_then(|v| v.as_str()).is_some();
         let doc_id = meta
             .get("_id")
             .and_then(|v| v.as_str())
             .map(str::to_string)
             .unwrap_or_else(|| uuid::Uuid::new_v4().simple().to_string());
 
-        match action_name {
-            "index" | "create" => {
-                let action = if action_name == "index" {
-                    BulkAction::Index
+        let Some(action) = BulkAction::parse(action_name) else {
+            return Err(format!(
+                "unknown bulk action '{action_name}' at action {}",
+                position + 1
+            ));
+        };
+        let reject = |outcome: &mut BulkParseOutcome, reason: String| {
+            outcome
+                .rejections
+                .push((position, action_name.to_string(), index.clone(), reason));
+        };
+        if !action.has_doc_line() {
+            if index.is_empty() {
+                reject(&mut outcome, "no index specified in action or URL".to_string());
+            } else if !explicit_id {
+                reject(&mut outcome, format!("{action_name} requires an _id"));
+            } else {
+                outcome.items.push((
+                    position,
+                    BulkItem {
+                        action,
+                        stream: index,
+                        doc_id,
+                        explicit_id,
+                        doc: Value::Null,
+                        raw: std::sync::Arc::from(""),
+                    },
+                ));
+            }
+            position += 1;
+            continue;
+        }
+        let Some(doc_line) = lines.next() else {
+            reject(&mut outcome, "missing document line".to_string());
+            position += 1; // count this partial action...
+            break; // ...then the post-loop `total = position` is correct
+        };
+        match serde_json::from_str::<Value>(doc_line) {
+            Ok(doc) if doc.is_object() => {
+                if index.is_empty() {
+                    reject(&mut outcome, "no index specified in action or URL".to_string());
+                } else if action == BulkAction::Update && !explicit_id {
+                    reject(&mut outcome, "update requires an _id".to_string());
                 } else {
-                    BulkAction::Create
-                };
-                let Some(doc_line) = lines.next() else {
-                    outcome.rejections.push((
+                    outcome.items.push((
                         position,
-                        action_name.to_string(),
-                        index,
-                        "missing document line".to_string(),
+                        BulkItem {
+                            action,
+                            stream: index,
+                            doc_id,
+                            explicit_id,
+                            doc,
+                            raw: std::sync::Arc::from(doc_line),
+                        },
                     ));
-                    position += 1; // count this partial action...
-                    break; // ...then the post-loop `total = position` is correct
-                };
-                match serde_json::from_str::<Value>(doc_line) {
-                    Ok(doc) if doc.is_object() => {
-                        if index.is_empty() {
-                            outcome.rejections.push((
-                                position,
-                                action_name.to_string(),
-                                index,
-                                "no index specified in action or URL".to_string(),
-                            ));
-                        } else {
-                            outcome.items.push((
-                                position,
-                                BulkItem {
-                                    action,
-                                    stream: index,
-                                    doc_id,
-                                    doc,
-                                    raw: std::sync::Arc::from(doc_line),
-                                },
-                            ));
-                        }
-                    }
-                    Ok(_) => {
-                        outcome.rejections.push((
-                            position,
-                            action_name.to_string(),
-                            index,
-                            "document must be a JSON object".to_string(),
-                        ));
-                    }
-                    Err(e) => {
-                        outcome.rejections.push((
-                            position,
-                            action_name.to_string(),
-                            index,
-                            format!("document is not valid JSON: {e}"),
-                        ));
-                    }
                 }
             }
-            "delete" => {
-                outcome.rejections.push((
-                    position,
-                    "delete".to_string(),
-                    index,
-                    "delete is not supported on an immutable log store".to_string(),
-                ));
-            }
-            "update" => {
-                // Update actions carry a following doc line — consume it.
-                let _ = lines.next();
-                outcome.rejections.push((
-                    position,
-                    "update".to_string(),
-                    index,
-                    "update is not supported on an immutable log store".to_string(),
-                ));
-            }
-            other => {
-                return Err(format!(
-                    "unknown bulk action '{other}' at action {}",
-                    position + 1
-                ));
-            }
+            Ok(_) => reject(&mut outcome, "document must be a JSON object".to_string()),
+            Err(e) => reject(&mut outcome, format!("document is not valid JSON: {e}")),
         }
         position += 1;
     }
@@ -213,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_delete_update_and_bad_docs_per_item() {
+    fn parses_delete_and_update_and_rejects_bad_docs_per_item() {
         let body = concat!(
             "{\"delete\":{\"_index\":\"logs\",\"_id\":\"1\"}}\n",
             "{\"index\":{\"_index\":\"logs\"}}\n",
@@ -225,10 +236,34 @@ mod tests {
         );
         let out = parse_bulk_body(body, None).unwrap();
         assert_eq!(out.total, 4);
+        assert_eq!(out.items.len(), 3);
+        assert_eq!(out.rejections.len(), 1);
+        assert_eq!(out.rejections[0].0, 1);
+        let (pos, delete) = &out.items[0];
+        assert_eq!((*pos, delete.action), (0, BulkAction::Delete));
+        assert!(delete.explicit_id && delete.doc.is_null() && delete.raw.is_empty());
+        let (pos, update) = &out.items[1];
+        assert_eq!((*pos, update.action), (2, BulkAction::Update));
+        assert_eq!(update.doc["doc"]["x"], 1);
+        assert_eq!(out.items[2].1.action, BulkAction::Index);
+        assert!(!out.items[2].1.explicit_id);
+    }
+
+    #[test]
+    fn delete_and_update_require_an_id() {
+        let body = concat!(
+            "{\"delete\":{\"_index\":\"logs\"}}\n",
+            "{\"update\":{\"_index\":\"logs\"}}\n",
+            "{\"doc\":{}}\n",
+            "{\"index\":{\"_index\":\"logs\"}}\n",
+            "{\"ok\":true}\n",
+        );
+        let out = parse_bulk_body(body, None).unwrap();
+        assert_eq!(out.total, 3);
         assert_eq!(out.items.len(), 1);
-        assert_eq!(out.rejections.len(), 3);
-        assert_eq!(out.rejections[0].1, "delete");
-        assert_eq!(out.rejections[2].1, "update");
+        assert_eq!(out.rejections.len(), 2);
+        assert!(out.rejections[0].3.contains("requires an _id"));
+        assert!(out.rejections[1].3.contains("requires an _id"));
     }
 
     #[test]

--- a/crates/rsearch-ingest/src/lib.rs
+++ b/crates/rsearch-ingest/src/lib.rs
@@ -15,5 +15,5 @@ pub use inputs::spawn_inputs;
 pub use syslog::parse_syslog;
 pub use bulk::{BulkAction, BulkItem, BulkParseOutcome, parse_bulk_body};
 pub use error::{IngestError, IngestResult};
-pub use pipeline::{IngestPipeline, PipelineConfig, SeqClock};
+pub use pipeline::{IngestPipeline, PipelineConfig, SeqClock, StreamInfo};
 pub use wal::{Wal, WalItem, WalPos, WalRecord, WalReplay};

--- a/crates/rsearch-ingest/src/lib.rs
+++ b/crates/rsearch-ingest/src/lib.rs
@@ -15,5 +15,5 @@ pub use inputs::spawn_inputs;
 pub use syslog::parse_syslog;
 pub use bulk::{BulkAction, BulkItem, BulkParseOutcome, parse_bulk_body};
 pub use error::{IngestError, IngestResult};
-pub use pipeline::{IngestPipeline, PipelineConfig};
-pub use wal::{Wal, WalPos, WalRecord, WalReplay};
+pub use pipeline::{IngestPipeline, PipelineConfig, SeqClock};
+pub use wal::{Wal, WalItem, WalPos, WalRecord, WalReplay};

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -35,17 +35,24 @@ pub struct StreamInfo {
 /// its own entry immediately.
 const STREAM_INFO_TTL: Duration = Duration::from_secs(10);
 
-/// Node-local monotonic write-sequence source: micros since epoch, forced
-/// strictly increasing across calls so two writes to the same `_id` on
-/// one node always order, even within the same microsecond. Across nodes
-/// ordering relies on wall clocks (NTP) — the same assumption retention
-/// already makes.
+/// Write-sequence source: a hybrid logical clock. Stamps are micros
+/// since epoch, forced strictly increasing across calls on one node, and
+/// pushed past every sequence this node has *observed* from the cluster
+/// (tombstone bounds of the ids being written, the stream's highest
+/// published `_seq`) — so a replacement written on a node whose wall
+/// clock lags the previous writer's still orders after it. Wall clocks
+/// only set the pace; causality comes from the observations.
 #[derive(Default)]
 pub struct SeqClock {
     last: std::sync::atomic::AtomicI64,
 }
 
 impl SeqClock {
+    /// Fold a sequence seen elsewhere into the clock: later stamps exceed it.
+    pub fn observe(&self, seen: i64) {
+        self.last.fetch_max(seen, Ordering::AcqRel);
+    }
+
     /// Next sequence stamp.
     pub fn next(&self) -> i64 {
         let now = SystemTime::now()
@@ -260,6 +267,7 @@ impl IngestPipeline {
                     stream,
                     id: id.clone(),
                     seq,
+                    tombstone: false,
                     doc: source.clone(),
                 });
             }
@@ -320,6 +328,14 @@ impl IngestPipeline {
             id: record.id,
             mode: record.mode(),
         };
+        if info.mode == StreamMode::Document {
+            // Order this node's next writes after everything already
+            // published for the stream (cheap lower bound; the per-id
+            // tombstone bounds the bulk handler observes are exact).
+            if let Some(max) = self.inner.metastore.stream_max_seq(info.id).await? {
+                self.inner.seq.observe(max);
+            }
+        }
         let mut cache = self.inner.stream_info.write().unwrap();
         // Bounded: stream names are client-controlled.
         if cache.len() > 10_000 {
@@ -327,6 +343,21 @@ impl IngestPipeline {
         }
         cache.insert(name.to_string(), (info, std::time::Instant::now()));
         Ok(info)
+    }
+
+    /// Like [`IngestPipeline::stream_info`] but never creates the stream:
+    /// `Ok(None)` when it does not exist.
+    pub async fn stream_info_if_exists(&self, name: &str) -> IngestResult<Option<StreamInfo>> {
+        if let Some((info, at)) = self.inner.stream_info.read().unwrap().get(name)
+            && at.elapsed() < STREAM_INFO_TTL
+        {
+            return Ok(Some(*info));
+        }
+        match self.inner.metastore.get_stream(name).await {
+            Ok(_) => self.stream_info(name).await.map(Some),
+            Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Drop a cached [`StreamInfo`] (after this node changed the stream's
@@ -340,6 +371,12 @@ impl IngestPipeline {
     /// persisted and replayed.
     pub fn next_seq(&self) -> i64 {
         self.inner.seq.next()
+    }
+
+    /// Push the sequence clock past a sequence observed elsewhere (see
+    /// [`SeqClock::observe`]).
+    pub fn observe_seq(&self, seen: i64) {
+        self.inner.seq.observe(seen);
     }
 
     /// Enqueue a WAL-durable document for indexing. `source` is the exact
@@ -398,9 +435,29 @@ impl IngestPipeline {
     /// not be dropped for backpressure.
     pub async fn replay(&self, records: WalReplay) -> IngestResult<usize> {
         let mut count = 0usize;
+        // Records flagged as replacements re-issue their tombstone before
+        // the document is re-indexed (upserts only raise, so doing it
+        // twice is harmless; skipping it would resurrect the old version).
+        let mut pending_tombstones: Vec<rsearch_metastore::NewTombstone> = Vec::new();
         for record in records {
             let record = record.map_err(IngestError::Wal)?;
             count += 1;
+            if record.tombstone {
+                let info = self.stream_info(&record.stream).await?;
+                pending_tombstones.push(rsearch_metastore::NewTombstone {
+                    stream_id: info.id,
+                    doc_id: record.id.clone(),
+                    before_seq: record.seq,
+                });
+                self.inner.seq.observe(record.seq);
+                if pending_tombstones.len() >= 1_000 {
+                    self.inner
+                        .metastore
+                        .upsert_tombstones(&pending_tombstones)
+                        .await?;
+                    pending_tombstones.clear();
+                }
+            }
             // Validate the payload is parseable JSON; the WAL payload IS
             // the source bytes, so we don't keep the parsed value.
             if serde_json::from_slice::<serde::de::IgnoredAny>(&record.doc).is_err() {
@@ -432,6 +489,12 @@ impl IngestPipeline {
                 self.inner.wal.confirm(&[record.pos]);
                 warn!(stream = %record.stream, "worker gone during replay; record dropped");
             }
+        }
+        if !pending_tombstones.is_empty() {
+            self.inner
+                .metastore
+                .upsert_tombstones(&pending_tombstones)
+                .await?;
         }
         if count > 0 {
             info!(count, "replayed WAL records into pipeline");
@@ -796,4 +859,26 @@ async fn flush_inner(
         return Err((IngestError::Metastore(e), batch));
     }
     Ok(Some((packaged.meta.split_id, indexed)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SeqClock;
+
+    #[test]
+    fn seq_clock_is_monotonic_and_observes() {
+        let clock = SeqClock::default();
+        let a = clock.next();
+        let b = clock.next();
+        assert!(b > a);
+        // Observing a sequence from the future (a peer whose clock is
+        // ahead) pushes the next stamp past it.
+        let far = a + 10_000_000_000;
+        clock.observe(far);
+        assert!(clock.next() > far);
+        // Observing the past changes nothing.
+        let c = clock.next();
+        clock.observe(a);
+        assert!(clock.next() > c);
+    }
 }

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -54,6 +54,8 @@ pub struct PipelineConfig {
     /// Flush a non-empty batch after this many seconds regardless of
     /// size (bounds time-to-searchable).
     pub max_batch_secs: u64,
+    /// The same bound for document-mode streams.
+    pub document_max_batch_secs: u64,
     /// Per-stream bounded queue depth in documents; a full queue
     /// rejects with [`IngestError::Saturated`].
     pub queue_capacity: usize,
@@ -401,6 +403,7 @@ impl IngestPipeline {
             self.inner.clone(),
             stream.to_string(),
             record.id,
+            record.is_document_mode(),
             schema,
             rx,
         ));
@@ -423,11 +426,17 @@ async fn stream_worker(
     inner: Arc<PipelineInner>,
     stream: String,
     stream_id: i64,
+    document_mode: bool,
     schema: MappedSchema,
     mut rx: mpsc::Receiver<WorkItem>,
 ) {
     let max_docs = inner.config.max_batch_docs.max(1);
-    let max_age = Duration::from_secs(inner.config.max_batch_secs.max(1));
+    let age_secs = if document_mode {
+        inner.config.document_max_batch_secs
+    } else {
+        inner.config.max_batch_secs
+    };
+    let max_age = Duration::from_secs(age_secs.max(1));
     let idle_exit = Duration::from_secs(WORKER_IDLE_EXIT_SECS);
     let mut buffer: Vec<WorkItem> = Vec::new();
     let mut deadline = tokio::time::Instant::now() + idle_exit;

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -12,12 +12,39 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
-use rsearch_index::{IndexMapping, MappedSchema, SplitBuilder};
+use rsearch_index::{DocIdentity, IndexMapping, MappedSchema, SplitBuilder};
 use rsearch_metastore::Metastore;
 use rsearch_storage::Storage;
 
 use crate::error::{IngestError, IngestResult};
-use crate::wal::{Wal, WalPos, WalReplay};
+use crate::wal::{Wal, WalItem, WalPos, WalReplay};
+
+/// Node-local monotonic write-sequence source: micros since epoch, forced
+/// strictly increasing across calls so two writes to the same `_id` on
+/// one node always order, even within the same microsecond. Across nodes
+/// ordering relies on wall clocks (NTP) — the same assumption retention
+/// already makes.
+#[derive(Default)]
+pub struct SeqClock {
+    last: std::sync::atomic::AtomicI64,
+}
+
+impl SeqClock {
+    /// Next sequence stamp.
+    pub fn next(&self) -> i64 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_micros() as i64)
+            .unwrap_or(0);
+        // fetch_update: `last = max(last + 1, now)` atomically.
+        self.last
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |last| {
+                Some(now.max(last.saturating_add(1)))
+            })
+            .map(|prev| now.max(prev.saturating_add(1)))
+            .unwrap_or(now)
+    }
+}
 
 /// Tuning knobs for the ingest pipeline.
 #[derive(Clone)]
@@ -44,6 +71,8 @@ struct WorkItem {
     /// re-parses on the blocking thread. Keeps ingest RSS low, which is
     /// the whole point of the engine.
     source: Arc<str>,
+    /// Document identity (`_id`, `_seq`).
+    identity: DocIdentity,
     pos: WalPos,
 }
 
@@ -80,6 +109,8 @@ struct PipelineInner {
     metrics: IngestMetrics,
     /// Routing rules, refreshed periodically from the metastore.
     rules: std::sync::RwLock<Arc<Vec<rsearch_metastore::RoutingRuleRecord>>>,
+    /// Write-sequence source shared by every ingest entry point.
+    seq: SeqClock,
 }
 
 /// Cloneable handle to the shared ingest pipeline: routes documents,
@@ -116,6 +147,7 @@ impl IngestPipeline {
                 worker_create: tokio::sync::Mutex::new(()),
                 metrics: IngestMetrics::default(),
                 rules: std::sync::RwLock::new(Arc::new(Vec::new())),
+                seq: SeqClock::default(),
             }),
         };
         // Keep the routing-rule cache warm.
@@ -190,22 +222,29 @@ impl IngestPipeline {
     ) -> IngestResult<(usize, usize)> {
         // Programmatic inputs have no original line, so serialize once and
         // share the Arc across every route.
-        let mut pairs: Vec<(String, Arc<str>)> = Vec::new();
+        let mut items: Vec<WalItem> = Vec::new();
         for doc in docs {
             let source: Arc<str> = Arc::from(doc.to_string());
+            let id = uuid::Uuid::new_v4().simple().to_string();
+            let seq = self.next_seq();
             for stream in self.expand_routes(default_stream, &doc) {
-                pairs.push((stream, source.clone()));
+                items.push(WalItem {
+                    stream,
+                    id: id.clone(),
+                    seq,
+                    doc: source.clone(),
+                });
             }
         }
-        if pairs.is_empty() {
+        if items.is_empty() {
             return Ok((0, 0));
         }
-        // The pairs move into the blocking task and back so the WAL append
+        // The items move into the blocking task and back so the WAL append
         // works on the existing strings — no per-document byte copies.
         let wal = self.inner.wal.clone();
-        let (pairs, positions) = tokio::task::spawn_blocking(move || {
-            let positions = wal.append_batch(&pairs);
-            (pairs, positions)
+        let (items, positions) = tokio::task::spawn_blocking(move || {
+            let positions = wal.append_batch(&items);
+            (items, positions)
         })
         .await
         .map_err(|e| IngestError::Wal(std::io::Error::other(e.to_string())))?;
@@ -213,8 +252,9 @@ impl IngestPipeline {
 
         let mut accepted = 0;
         let mut dropped = 0;
-        for ((stream, source), pos) in pairs.into_iter().zip(positions) {
-            match self.enqueue(&stream, source, pos).await {
+        for (item, pos) in items.into_iter().zip(positions) {
+            let identity = DocIdentity::new(item.id, item.seq);
+            match self.enqueue(&item.stream, item.doc, identity, pos).await {
                 Ok(()) => accepted += 1,
                 Err(_) => {
                     self.inner.wal.confirm(&[pos]);
@@ -238,15 +278,32 @@ impl IngestPipeline {
         &self.inner.wal
     }
 
+    /// Next write-sequence stamp (`_seq`) for a document accepted by this
+    /// node. Take it before the WAL append so the stamp is what gets
+    /// persisted and replayed.
+    pub fn next_seq(&self) -> i64 {
+        self.inner.seq.next()
+    }
+
     /// Enqueue a WAL-durable document for indexing. `source` is the exact
     /// document bytes — stored as `_source` and re-parsed by the indexer.
     /// Fails with [`IngestError::Saturated`] when the stream's queue is
     /// full — the caller reports a per-item 429 and confirms the WAL
     /// position.
-    pub async fn enqueue(&self, stream: &str, source: Arc<str>, pos: WalPos) -> IngestResult<()> {
+    pub async fn enqueue(
+        &self,
+        stream: &str,
+        source: Arc<str>,
+        identity: DocIdentity,
+        pos: WalPos,
+    ) -> IngestResult<()> {
         let tx = self.worker_for(stream).await?;
         let size = source.len() as u64;
-        match tx.try_send(WorkItem { source, pos }) {
+        match tx.try_send(WorkItem {
+            source,
+            identity,
+            pos,
+        }) {
             Ok(()) => {
                 self.note_enqueued(size);
                 Ok(())
@@ -305,6 +362,7 @@ impl IngestPipeline {
             if tx
                 .send(WorkItem {
                     source,
+                    identity: DocIdentity::new(record.id, record.seq),
                     pos: record.pos,
                 })
                 .await
@@ -553,7 +611,7 @@ async fn flush_inner(
                 // retry starts from a fresh one, so a builder corrupted
                 // by an unwound panic can at worst fail this attempt.
                 let added = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    builder.add_json_with_source(doc, Some(&item.source), fallback)
+                    builder.add_document(doc, Some(&item.source), &item.identity, fallback)
                 }));
                 match added {
                     Ok(Ok(())) => {}

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -83,6 +83,13 @@ pub struct PipelineConfig {
     pub node_id: String,
 }
 
+/// What a stream worker receives: documents to index, or a request to cut
+/// the current batch now (`?refresh=wait_for`) and say when it's published.
+enum WorkerMsg {
+    Doc(WorkItem),
+    Flush(tokio::sync::oneshot::Sender<()>),
+}
+
 struct WorkItem {
     /// Original document bytes. The queue holds only these (not a parsed
     /// Value, which is several times larger in memory) — the indexer
@@ -119,7 +126,7 @@ struct PipelineInner {
     /// Stream → worker sender. Read-locked (sync, never across an await)
     /// on the per-document hot path; the write lock is only ever taken to
     /// insert a newly created worker.
-    workers: std::sync::RwLock<HashMap<String, mpsc::Sender<WorkItem>>>,
+    workers: std::sync::RwLock<HashMap<String, mpsc::Sender<WorkerMsg>>>,
     /// Single-flights first-time worker creation so the metastore resolve
     /// never runs under `workers` — enqueues to existing streams are not
     /// blocked while a new stream's row is being created.
@@ -349,11 +356,11 @@ impl IngestPipeline {
     ) -> IngestResult<()> {
         let tx = self.worker_for(stream).await?;
         let size = source.len() as u64;
-        match tx.try_send(WorkItem {
+        match tx.try_send(WorkerMsg::Doc(WorkItem {
             source,
             identity,
             pos,
-        }) {
+        })) {
             Ok(()) => {
                 self.note_enqueued(size);
                 Ok(())
@@ -410,11 +417,11 @@ impl IngestPipeline {
             let tx = self.worker_for(&record.stream).await?;
             self.inner.metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
             if tx
-                .send(WorkItem {
+                .send(WorkerMsg::Doc(WorkItem {
                     source,
                     identity: DocIdentity::new(record.id, record.seq),
                     pos: record.pos,
-                })
+                }))
                 .await
                 .is_err()
             {
@@ -432,7 +439,29 @@ impl IngestPipeline {
         Ok(count)
     }
 
-    async fn worker_for(&self, stream: &str) -> IngestResult<mpsc::Sender<WorkItem>> {
+    /// Cut the stream's current batch into a split now and resolve once it
+    /// is published (or immediately when nothing is buffered on this
+    /// node). Backs `?refresh=true|wait_for`. Only this node's buffer is
+    /// flushed — with bulk handoff the flag travels to the node that
+    /// indexed the batch, which is the one whose buffer matters.
+    pub async fn flush_stream(&self, stream: &str) -> IngestResult<()> {
+        let tx = match self.inner.workers.read().unwrap().get(stream) {
+            Some(tx) => tx.clone(),
+            // No worker: nothing buffered here.
+            None => return Ok(()),
+        };
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel();
+        if tx.send(WorkerMsg::Flush(done_tx)).await.is_err() {
+            // Worker retired between the lookup and the send; its buffer
+            // was flushed on the way out.
+            return Ok(());
+        }
+        // A dropped sender means the worker exited after flushing.
+        let _ = done_rx.await;
+        Ok(())
+    }
+
+    async fn worker_for(&self, stream: &str) -> IngestResult<mpsc::Sender<WorkerMsg>> {
         if let Some(tx) = self.inner.workers.read().unwrap().get(stream) {
             return Ok(tx.clone());
         }
@@ -476,7 +505,7 @@ async fn stream_worker(
     stream_id: i64,
     document_mode: bool,
     schema: MappedSchema,
-    mut rx: mpsc::Receiver<WorkItem>,
+    mut rx: mpsc::Receiver<WorkerMsg>,
 ) {
     let max_docs = inner.config.max_batch_docs.max(1);
     let age_secs = if document_mode {
@@ -487,6 +516,8 @@ async fn stream_worker(
     let max_age = Duration::from_secs(age_secs.max(1));
     let idle_exit = Duration::from_secs(WORKER_IDLE_EXIT_SECS);
     let mut buffer: Vec<WorkItem> = Vec::new();
+    // Refresh waiters, answered after the next flush completes.
+    let mut waiters: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
     let mut deadline = tokio::time::Instant::now() + idle_exit;
     // Re-resolved before each flush so a mapping change (PUT /{index})
     // takes effect on the next split, not only after a restart (L7).
@@ -495,13 +526,23 @@ async fn stream_worker(
 
     loop {
         let flush_now = tokio::select! {
-            item = rx.recv() => match item {
-                Some(item) => {
+            msg = rx.recv() => match msg {
+                Some(WorkerMsg::Doc(item)) => {
                     if buffer.is_empty() {
                         deadline = tokio::time::Instant::now() + max_age;
                     }
                     buffer.push(item);
                     buffer.len() >= max_docs
+                }
+                Some(WorkerMsg::Flush(done)) => {
+                    if buffer.is_empty() {
+                        // Nothing to cut: the waiter is satisfied now.
+                        let _ = done.send(());
+                        false
+                    } else {
+                        waiters.push(done);
+                        true
+                    }
                 }
                 None => {
                     // Channel closed: final flush then exit.
@@ -521,11 +562,17 @@ async fn stream_worker(
                     // re-creates a fresh worker via worker_for.
                     inner.workers.write().unwrap().remove(&stream);
                     rx.close();
-                    while let Ok(item) = rx.try_recv() {
-                        buffer.push(item);
+                    while let Ok(msg) = rx.try_recv() {
+                        match msg {
+                            WorkerMsg::Doc(item) => buffer.push(item),
+                            WorkerMsg::Flush(done) => waiters.push(done),
+                        }
                     }
                     if !buffer.is_empty() {
                         flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+                    }
+                    for done in waiters.drain(..) {
+                        let _ = done.send(());
                     }
                     info!(stream, "idle stream worker retired");
                     return;
@@ -543,6 +590,9 @@ async fn stream_worker(
                 mapping_json = record.mapping;
             }
             flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+            for done in waiters.drain(..) {
+                let _ = done.send(());
+            }
             deadline = tokio::time::Instant::now() + idle_exit;
         }
     }

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -13,11 +13,27 @@ use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
 use rsearch_index::{DocIdentity, IndexMapping, MappedSchema, SplitBuilder};
-use rsearch_metastore::Metastore;
+use rsearch_metastore::{Metastore, StreamMode};
 use rsearch_storage::Storage;
 
 use crate::error::{IngestError, IngestResult};
 use crate::wal::{Wal, WalItem, WalPos, WalReplay};
+
+/// What the write path needs to know about a stream per request: its id
+/// (tombstones are keyed by it) and its mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StreamInfo {
+    /// The stream's metastore id.
+    pub id: i64,
+    /// Log or document mode.
+    pub mode: StreamMode,
+}
+
+/// How long a resolved [`StreamInfo`] is reused before the metastore is
+/// asked again. A mode can only change while a stream is empty, so
+/// staleness is bounded and harmless; the node that changes it forgets
+/// its own entry immediately.
+const STREAM_INFO_TTL: Duration = Duration::from_secs(10);
 
 /// Node-local monotonic write-sequence source: micros since epoch, forced
 /// strictly increasing across calls so two writes to the same `_id` on
@@ -113,6 +129,8 @@ struct PipelineInner {
     rules: std::sync::RwLock<Arc<Vec<rsearch_metastore::RoutingRuleRecord>>>,
     /// Write-sequence source shared by every ingest entry point.
     seq: SeqClock,
+    /// Stream name → (info, resolved at). Read-locked per request.
+    stream_info: std::sync::RwLock<HashMap<String, (StreamInfo, std::time::Instant)>>,
 }
 
 /// Cloneable handle to the shared ingest pipeline: routes documents,
@@ -150,6 +168,7 @@ impl IngestPipeline {
                 metrics: IngestMetrics::default(),
                 rules: std::sync::RwLock::new(Arc::new(Vec::new())),
                 seq: SeqClock::default(),
+                stream_info: std::sync::RwLock::new(HashMap::new()),
             }),
         };
         // Keep the routing-rule cache warm.
@@ -278,6 +297,35 @@ impl IngestPipeline {
     /// The shared WAL handle.
     pub fn wal(&self) -> &Arc<Wal> {
         &self.inner.wal
+    }
+
+    /// Resolve a stream's id and mode (creating the stream, log mode, if it
+    /// does not exist — the same implicit creation `_bulk` has always
+    /// done), through a short TTL cache.
+    pub async fn stream_info(&self, name: &str) -> IngestResult<StreamInfo> {
+        if let Some((info, at)) = self.inner.stream_info.read().unwrap().get(name)
+            && at.elapsed() < STREAM_INFO_TTL
+        {
+            return Ok(*info);
+        }
+        let record = self.inner.metastore.ensure_stream(name).await?;
+        let info = StreamInfo {
+            id: record.id,
+            mode: record.mode(),
+        };
+        let mut cache = self.inner.stream_info.write().unwrap();
+        // Bounded: stream names are client-controlled.
+        if cache.len() > 10_000 {
+            cache.clear();
+        }
+        cache.insert(name.to_string(), (info, std::time::Instant::now()));
+        Ok(info)
+    }
+
+    /// Drop a cached [`StreamInfo`] (after this node changed the stream's
+    /// mode) so the next write re-reads it.
+    pub fn forget_stream(&self, name: &str) {
+        self.inner.stream_info.write().unwrap().remove(name);
     }
 
     /// Next write-sequence stamp (`_seq`) for a document accepted by this
@@ -676,17 +724,20 @@ async fn flush_inner(
     }
     if let Err(e) = inner
         .metastore
-        .stage_split(
-            &packaged.meta.split_id,
+        .stage_split(&rsearch_metastore::NewSplit {
+            split_id: &packaged.meta.split_id,
             stream_id,
-            &key,
-            packaged.meta.doc_count as i64,
-            packaged.size_bytes as i64,
-            packaged.meta.time_start_millis,
-            packaged.meta.time_end_millis,
-            packaged.footer_len as i64,
-            Some(&inner.config.node_id),
-        )
+            storage_key: &key,
+            doc_count: packaged.meta.doc_count as i64,
+            size_bytes: packaged.size_bytes as i64,
+            time_start_millis: packaged.meta.time_start_millis,
+            time_end_millis: packaged.meta.time_end_millis,
+            footer_len: packaged.footer_len as i64,
+            created_by: Some(&inner.config.node_id),
+            seq_min: packaged.meta.seq_min,
+            seq_max: packaged.meta.seq_max,
+            tombstone_seq_applied: 0,
+        })
         .await
     {
         return Err((IngestError::Metastore(e), batch));

--- a/crates/rsearch-ingest/src/wal.rs
+++ b/crates/rsearch-ingest/src/wal.rs
@@ -3,7 +3,11 @@
 //! deleted once every document they contain has been published in a split.
 //!
 //! Record layout: [len: u32 LE][crc32(payload): u32 LE][payload]
-//! where payload = [stream_len: u16 LE][stream][doc JSON bytes].
+//! where payload (v2) =
+//!   [0x8000 | stream_len: u16 LE][stream][id_len: u16 LE][id][seq: i64 LE][doc JSON bytes]
+//! Legacy (v1) payloads — written before documents carried an identity —
+//! are [stream_len: u16 LE][stream][doc JSON bytes] with the high bit of
+//! `stream_len` clear; they replay with a generated id at sequence 0.
 
 use std::collections::BTreeMap;
 use std::io::{BufWriter, Read, Write};
@@ -17,16 +21,36 @@ pub struct WalPos {
     pub segment: u64,
 }
 
+/// One record to append: a document plus its identity, bound for a stream.
+#[derive(Debug, Clone)]
+pub struct WalItem {
+    /// Target stream.
+    pub stream: String,
+    /// Document id (`_id`).
+    pub id: String,
+    /// Write sequence stamp (`_seq`).
+    pub seq: i64,
+    /// Raw document JSON (the client's original line).
+    pub doc: std::sync::Arc<str>,
+}
+
 /// A replayed record.
 #[derive(Debug, Clone)]
 pub struct WalRecord {
     /// Target stream the document was accepted for.
     pub stream: String,
+    /// Document id; a fresh UUID for legacy records that carried none.
+    pub id: String,
+    /// Write sequence stamp; 0 for legacy records.
+    pub seq: i64,
     /// Raw document JSON bytes as originally appended.
     pub doc: Vec<u8>,
     /// Position to confirm once the document is published.
     pub pos: WalPos,
 }
+
+/// High bit of the `stream_len` field marks a v2 payload (with identity).
+const V2_FLAG: u16 = 0x8000;
 
 struct SegmentState {
     outstanding: u64,
@@ -143,19 +167,15 @@ impl Wal {
         ))
     }
 
-    /// Append a batch of (stream, doc) pairs durably. Returns the position
-    /// of each record. Blocking — call via spawn_blocking.
+    /// Append a batch of records durably. Returns the position of each
+    /// record. Blocking — call via spawn_blocking.
     ///
     /// Two phases: records are written and OS-flushed under the writer lock
     /// (records serialized directly, CRC streamed — no per-record temp
     /// buffer), then the fsync runs under a separate gate so concurrent
     /// appends coalesce into one fsync (group commit) instead of each
     /// paying its own.
-    pub fn append_batch<S, D>(&self, items: &[(S, D)]) -> std::io::Result<Vec<WalPos>>
-    where
-        S: AsRef<str>,
-        D: AsRef<str>,
-    {
+    pub fn append_batch(&self, items: &[WalItem]) -> std::io::Result<Vec<WalPos>> {
         use std::sync::atomic::Ordering;
         let mut positions = Vec::with_capacity(items.len());
         // Segments sealed by rotation during this batch are fsynced below,
@@ -165,27 +185,42 @@ impl Wal {
         let mut victims: Vec<PathBuf> = Vec::new();
         let (fd, my_gen) = {
             let mut inner = self.inner.lock().unwrap();
-            for (stream, doc) in items {
-                let doc = doc.as_ref().as_bytes();
+            for item in items {
+                let doc = item.doc.as_bytes();
                 if inner.current_len >= self.max_segment_bytes {
                     let (old_file, mut gc) = self.rotate(&mut inner)?;
                     sealed.push(old_file);
                     victims.append(&mut gc);
                 }
-                let stream_bytes = stream.as_ref().as_bytes();
-                let payload_len = 2 + stream_bytes.len() + doc.len();
-                let len_field = stream_bytes.len() as u16;
-                // Stream the CRC over the three payload slices; write them
+                let stream_bytes = item.stream.as_bytes();
+                let id_bytes = item.id.as_bytes();
+                if stream_bytes.len() >= V2_FLAG as usize || id_bytes.len() > u16::MAX as usize {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "stream name or document id too long for the WAL",
+                    ));
+                }
+                let payload_len = 2 + stream_bytes.len() + 2 + id_bytes.len() + 8 + doc.len();
+                let len_field = stream_bytes.len() as u16 | V2_FLAG;
+                let id_len_field = id_bytes.len() as u16;
+                let seq_bytes = item.seq.to_le_bytes();
+                // Stream the CRC over the payload slices; write them
                 // directly to the buffered writer (no intermediate Vec).
                 let mut hasher = crc32fast::Hasher::new();
                 hasher.update(&len_field.to_le_bytes());
                 hasher.update(stream_bytes);
+                hasher.update(&id_len_field.to_le_bytes());
+                hasher.update(id_bytes);
+                hasher.update(&seq_bytes);
                 hasher.update(doc);
                 let crc = hasher.finalize();
                 inner.writer.write_all(&(payload_len as u32).to_le_bytes())?;
                 inner.writer.write_all(&crc.to_le_bytes())?;
                 inner.writer.write_all(&len_field.to_le_bytes())?;
                 inner.writer.write_all(stream_bytes)?;
+                inner.writer.write_all(&id_len_field.to_le_bytes())?;
+                inner.writer.write_all(id_bytes)?;
+                inner.writer.write_all(&seq_bytes)?;
                 inner.writer.write_all(doc)?;
                 inner.current_len += 8 + payload_len as u64;
                 let seq = inner.current_seq;
@@ -327,7 +362,18 @@ struct SegmentCursor {
     seq: u64,
     reader: std::io::BufReader<std::fs::File>,
     buf: Vec<u8>,
-    stream_len: usize,
+    /// Parsed layout of the record in `buf`.
+    layout: RecordLayout,
+}
+
+/// Byte offsets of a validated record's parts within the payload buffer.
+#[derive(Default, Clone, Copy)]
+struct RecordLayout {
+    stream: (usize, usize),
+    /// `None` for a legacy (v1) record without identity.
+    id: Option<(usize, usize)>,
+    seq: i64,
+    doc_start: usize,
 }
 
 impl SegmentCursor {
@@ -336,7 +382,7 @@ impl SegmentCursor {
             seq,
             reader: std::io::BufReader::new(std::fs::File::open(path)?),
             buf: Vec::new(),
-            stream_len: 0,
+            layout: RecordLayout::default(),
         })
     }
 
@@ -363,18 +409,47 @@ impl SegmentCursor {
         if crc32fast::hash(&self.buf) != crc {
             return false; // corruption — stop replaying this segment
         }
-        let stream_len = u16::from_le_bytes(self.buf[0..2].try_into().unwrap()) as usize;
+        let len_field = u16::from_le_bytes(self.buf[0..2].try_into().unwrap());
+        let stream_len = (len_field & !V2_FLAG) as usize;
         if 2 + stream_len > self.buf.len() {
             return false;
         }
-        self.stream_len = stream_len;
+        let mut layout = RecordLayout {
+            stream: (2, 2 + stream_len),
+            ..RecordLayout::default()
+        };
+        if len_field & V2_FLAG == 0 {
+            layout.doc_start = 2 + stream_len;
+        } else {
+            let mut at = 2 + stream_len;
+            if at + 2 > self.buf.len() {
+                return false;
+            }
+            let id_len = u16::from_le_bytes(self.buf[at..at + 2].try_into().unwrap()) as usize;
+            at += 2;
+            if at + id_len + 8 > self.buf.len() {
+                return false;
+            }
+            layout.id = Some((at, at + id_len));
+            at += id_len;
+            layout.seq = i64::from_le_bytes(self.buf[at..at + 8].try_into().unwrap());
+            layout.doc_start = at + 8;
+        }
+        self.layout = layout;
         true
     }
 
     fn record(&self) -> WalRecord {
+        let (s0, s1) = self.layout.stream;
+        let id = match self.layout.id {
+            Some((i0, i1)) => String::from_utf8_lossy(&self.buf[i0..i1]).to_string(),
+            None => uuid::Uuid::new_v4().simple().to_string(),
+        };
         WalRecord {
-            stream: String::from_utf8_lossy(&self.buf[2..2 + self.stream_len]).to_string(),
-            doc: self.buf[2 + self.stream_len..].to_vec(),
+            stream: String::from_utf8_lossy(&self.buf[s0..s1]).to_string(),
+            id,
+            seq: self.layout.seq,
+            doc: self.buf[self.layout.doc_start..].to_vec(),
             pos: WalPos { segment: self.seq },
         }
     }
@@ -414,10 +489,47 @@ impl Iterator for WalReplay {
 mod tests {
     use super::*;
 
-    fn items(n: usize, stream: &str) -> Vec<(String, String)> {
+    fn items(n: usize, stream: &str) -> Vec<WalItem> {
         (0..n)
-            .map(|i| (stream.to_string(), format!("{{\"n\":{i}}}")))
+            .map(|i| WalItem {
+                stream: stream.to_string(),
+                id: format!("id-{i}"),
+                seq: 1_000 + i as i64,
+                doc: std::sync::Arc::from(format!("{{\"n\":{i}}}")),
+            })
             .collect()
+    }
+
+    /// Hand-write a legacy (v1) record: [len][crc][stream_len][stream][doc].
+    fn append_legacy(path: &Path, stream: &str, doc: &str) {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(stream.len() as u16).to_le_bytes());
+        payload.extend_from_slice(stream.as_bytes());
+        payload.extend_from_slice(doc.as_bytes());
+        let mut out = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        out.write_all(&(payload.len() as u32).to_le_bytes()).unwrap();
+        out.write_all(&crc32fast::hash(&payload).to_le_bytes()).unwrap();
+        out.write_all(&payload).unwrap();
+    }
+
+    #[test]
+    fn replays_identity_and_legacy_records() {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let (wal, _) = Wal::open(dir.path(), 1 << 20).unwrap();
+            wal.append_batch(&items(2, "app")).unwrap();
+        }
+        append_legacy(&segment_path(dir.path(), 0), "legacy", "{\"old\":true}");
+        let (_, replayed) = Wal::open(dir.path(), 1 << 20).unwrap();
+        let records: Vec<WalRecord> = replayed.collect::<std::io::Result<_>>().unwrap();
+        assert_eq!(records.len(), 3);
+        assert_eq!(records[0].id, "id-0");
+        assert_eq!(records[0].seq, 1_000);
+        assert_eq!(records[1].doc, b"{\"n\":1}");
+        assert_eq!(records[2].stream, "legacy");
+        assert_eq!(records[2].seq, 0);
+        assert_eq!(records[2].id.len(), 32, "legacy records get a generated id");
+        assert_eq!(records[2].doc, b"{\"old\":true}");
     }
 
     #[test]

--- a/crates/rsearch-ingest/src/wal.rs
+++ b/crates/rsearch-ingest/src/wal.rs
@@ -4,7 +4,11 @@
 //!
 //! Record layout: [len: u32 LE][crc32(payload): u32 LE][payload]
 //! where payload (v2) =
-//!   [0x8000 | stream_len: u16 LE][stream][id_len: u16 LE][id][seq: i64 LE][doc JSON bytes]
+//!   [0x8000 | stream_len: u16 LE][stream][flags | id_len: u16 LE][id][seq: i64 LE][doc JSON bytes]
+//! `flags` is bit 15 of the id length field: set when the write must be
+//! accompanied by a tombstone hiding older versions of `id` (document-mode
+//! replace) — replay re-issues it so a crash between the WAL append and
+//! the tombstone write can't leave the old version visible.
 //! Legacy (v1) payloads — written before documents carried an identity —
 //! are [stream_len: u16 LE][stream][doc JSON bytes] with the high bit of
 //! `stream_len` clear; they replay with a generated id at sequence 0.
@@ -30,6 +34,10 @@ pub struct WalItem {
     pub id: String,
     /// Write sequence stamp (`_seq`).
     pub seq: i64,
+    /// The write replaces older versions of `id` (document-mode stream):
+    /// a tombstone `before_seq = seq` accompanies it, and replay re-issues
+    /// that tombstone.
+    pub tombstone: bool,
     /// Raw document JSON (the client's original line).
     pub doc: std::sync::Arc<str>,
 }
@@ -43,6 +51,8 @@ pub struct WalRecord {
     pub id: String,
     /// Write sequence stamp; 0 for legacy records.
     pub seq: i64,
+    /// Whether a tombstone `before_seq = seq` must accompany the document.
+    pub tombstone: bool,
     /// Raw document JSON bytes as originally appended.
     pub doc: Vec<u8>,
     /// Position to confirm once the document is published.
@@ -51,6 +61,8 @@ pub struct WalRecord {
 
 /// High bit of the `stream_len` field marks a v2 payload (with identity).
 const V2_FLAG: u16 = 0x8000;
+/// High bit of the `id_len` field: the write carries a tombstone.
+const TOMBSTONE_FLAG: u16 = 0x8000;
 
 struct SegmentState {
     outstanding: u64,
@@ -194,7 +206,9 @@ impl Wal {
                 }
                 let stream_bytes = item.stream.as_bytes();
                 let id_bytes = item.id.as_bytes();
-                if stream_bytes.len() >= V2_FLAG as usize || id_bytes.len() > u16::MAX as usize {
+                if stream_bytes.len() >= V2_FLAG as usize
+                    || id_bytes.len() >= TOMBSTONE_FLAG as usize
+                {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
                         "stream name or document id too long for the WAL",
@@ -202,7 +216,8 @@ impl Wal {
                 }
                 let payload_len = 2 + stream_bytes.len() + 2 + id_bytes.len() + 8 + doc.len();
                 let len_field = stream_bytes.len() as u16 | V2_FLAG;
-                let id_len_field = id_bytes.len() as u16;
+                let id_len_field =
+                    id_bytes.len() as u16 | if item.tombstone { TOMBSTONE_FLAG } else { 0 };
                 let seq_bytes = item.seq.to_le_bytes();
                 // Stream the CRC over the payload slices; write them
                 // directly to the buffered writer (no intermediate Vec).
@@ -373,6 +388,7 @@ struct RecordLayout {
     /// `None` for a legacy (v1) record without identity.
     id: Option<(usize, usize)>,
     seq: i64,
+    tombstone: bool,
     doc_start: usize,
 }
 
@@ -425,7 +441,9 @@ impl SegmentCursor {
             if at + 2 > self.buf.len() {
                 return false;
             }
-            let id_len = u16::from_le_bytes(self.buf[at..at + 2].try_into().unwrap()) as usize;
+            let id_len_field = u16::from_le_bytes(self.buf[at..at + 2].try_into().unwrap());
+            let id_len = (id_len_field & !TOMBSTONE_FLAG) as usize;
+            layout.tombstone = id_len_field & TOMBSTONE_FLAG != 0;
             at += 2;
             if at + id_len + 8 > self.buf.len() {
                 return false;
@@ -449,6 +467,7 @@ impl SegmentCursor {
             stream: String::from_utf8_lossy(&self.buf[s0..s1]).to_string(),
             id,
             seq: self.layout.seq,
+            tombstone: self.layout.tombstone,
             doc: self.buf[self.layout.doc_start..].to_vec(),
             pos: WalPos { segment: self.seq },
         }
@@ -495,6 +514,7 @@ mod tests {
                 stream: stream.to_string(),
                 id: format!("id-{i}"),
                 seq: 1_000 + i as i64,
+                tombstone: i % 2 == 1,
                 doc: std::sync::Arc::from(format!("{{\"n\":{i}}}")),
             })
             .collect()
@@ -525,9 +545,12 @@ mod tests {
         assert_eq!(records.len(), 3);
         assert_eq!(records[0].id, "id-0");
         assert_eq!(records[0].seq, 1_000);
+        assert!(!records[0].tombstone);
         assert_eq!(records[1].doc, b"{\"n\":1}");
+        assert!(records[1].tombstone);
         assert_eq!(records[2].stream, "legacy");
         assert_eq!(records[2].seq, 0);
+        assert!(!records[2].tombstone);
         assert_eq!(records[2].id.len(), 32, "legacy records get a generated id");
         assert_eq!(records[2].doc, b"{\"old\":true}");
     }

--- a/crates/rsearch-metastore/migrations/20260819185120_stream_mode.sql
+++ b/crates/rsearch-metastore/migrations/20260819185120_stream_mode.sql
@@ -1,0 +1,7 @@
+-- Stream (index) mode: 'log' is the append-only default; 'document'
+-- streams accept delete/update by _id and pay tombstone filtering at
+-- query time (phase 14, issue #34).
+
+ALTER TABLE streams
+    ADD COLUMN mode TEXT NOT NULL DEFAULT 'log'
+        CHECK (mode IN ('log', 'document'));

--- a/crates/rsearch-metastore/migrations/20260819185719_doc_tombstones.sql
+++ b/crates/rsearch-metastore/migrations/20260819185719_doc_tombstones.sql
@@ -1,0 +1,29 @@
+-- Document-mode tombstones (phase 14, issue #34).
+--
+-- A tombstone hides every document in `stream_id` whose `_id` = `doc_id`
+-- and whose `_seq` < `before_seq`. `delete` writes one with before_seq =
+-- now; `index` on a document-mode stream writes one with before_seq = the
+-- new version's `_seq`, so reads see exactly the newest version. One row
+-- per (stream, doc) — a later write raises before_seq and re-issues the
+-- row's `seq` so incremental readers (WHERE seq > last_seen) pick it up.
+-- Rows are purged once no split can still hold a document they hide.
+
+CREATE TABLE doc_tombstones (
+    seq BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    stream_id BIGINT NOT NULL REFERENCES streams(id) ON DELETE CASCADE,
+    doc_id TEXT NOT NULL,
+    before_seq BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (stream_id, doc_id)
+);
+
+-- Incremental fetch per stream.
+CREATE INDEX idx_doc_tombstones_stream_seq ON doc_tombstones (stream_id, seq);
+
+-- Per-split `_seq` range (NULL for legacy splits without ids: tombstones
+-- never apply) and the highest tombstone seq already applied when the
+-- split was (re)built — ingest-built splits start at 0.
+ALTER TABLE splits
+    ADD COLUMN seq_min BIGINT,
+    ADD COLUMN seq_max BIGINT,
+    ADD COLUMN tombstone_seq_applied BIGINT NOT NULL DEFAULT 0;

--- a/crates/rsearch-metastore/migrations/20260819200858_tombstone_indexes.sql
+++ b/crates/rsearch-metastore/migrations/20260819200858_tombstone_indexes.sql
@@ -1,0 +1,6 @@
+-- Purge scans tombstones by age; the per-stream floor it joins against
+-- groups id-carrying splits by stream and state.
+CREATE INDEX idx_doc_tombstones_created_at ON doc_tombstones (created_at);
+CREATE INDEX idx_splits_stream_applied
+    ON splits (stream_id, tombstone_seq_applied)
+    WHERE state IN ('staged', 'published') AND seq_min IS NOT NULL;

--- a/crates/rsearch-metastore/src/control.rs
+++ b/crates/rsearch-metastore/src/control.rs
@@ -89,7 +89,8 @@ impl Metastore {
     ) -> MetastoreResult<Vec<SplitRecord>> {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
-                    time_start_millis, time_end_millis, footer_len, created_by
+                    time_start_millis, time_end_millis, footer_len, created_by,
+                    seq_min, seq_max, tombstone_seq_applied
              FROM splits
              WHERE state = 'published' AND size_bytes < $1
              ORDER BY stream_id, time_start_millis
@@ -135,7 +136,8 @@ impl Metastore {
     ) -> MetastoreResult<Vec<SplitRecord>> {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
-                    time_start_millis, time_end_millis, footer_len, created_by
+                    time_start_millis, time_end_millis, footer_len, created_by,
+                    seq_min, seq_max, tombstone_seq_applied
              FROM splits
              WHERE state = 'staged'
                AND created_at < now() - make_interval(secs => $1)
@@ -156,7 +158,8 @@ impl Metastore {
     ) -> MetastoreResult<Vec<SplitRecord>> {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
-                    time_start_millis, time_end_millis, footer_len, created_by
+                    time_start_millis, time_end_millis, footer_len, created_by,
+                    seq_min, seq_max, tombstone_seq_applied
              FROM splits
              WHERE state = 'marked_for_delete'
                AND updated_at < now() - make_interval(secs => $1)

--- a/crates/rsearch-metastore/src/error.rs
+++ b/crates/rsearch-metastore/src/error.rs
@@ -16,6 +16,10 @@ pub enum MetastoreError {
     #[error("stream not found: {0}")]
     StreamNotFound(String),
 
+    /// The stream already holds data, so its mode can no longer change.
+    #[error("stream '{0}' already holds data; its mode cannot be changed")]
+    StreamModeFixed(String),
+
     /// Split missing, or not in the state a transition requires.
     #[error("split not found or not in expected state: {0}")]
     SplitStateConflict(String),

--- a/crates/rsearch-metastore/src/lib.rs
+++ b/crates/rsearch-metastore/src/lib.rs
@@ -21,5 +21,6 @@ pub use routing::RoutingRuleRecord;
 pub use error::{MetastoreError, MetastoreResult};
 pub use metastore::Metastore;
 pub use types::{
-    NodeRecord, SplitRecord, SplitState, StreamRecord, StreamStats, UnderReplicatedKey,
+    NodeRecord, SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats,
+    UnderReplicatedKey,
 };

--- a/crates/rsearch-metastore/src/lib.rs
+++ b/crates/rsearch-metastore/src/lib.rs
@@ -11,16 +11,18 @@ mod locations;
 mod metastore;
 mod nodes;
 mod routing;
+mod tombstones;
 mod types;
 
 pub use alerts::AlertRecord;
 pub use auth::{ApiKeyRecord, UserRecord};
 pub use control::CONTROL_LEADER_LOCK;
 pub use routing::RoutingRuleRecord;
+pub use tombstones::{NewTombstone, TombstoneRecord};
 
 pub use error::{MetastoreError, MetastoreResult};
 pub use metastore::Metastore;
 pub use types::{
-    NodeRecord, SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats,
+    NewSplit, NodeRecord, SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats,
     UnderReplicatedKey,
 };

--- a/crates/rsearch-metastore/src/lib.rs
+++ b/crates/rsearch-metastore/src/lib.rs
@@ -18,7 +18,7 @@ pub use alerts::AlertRecord;
 pub use auth::{ApiKeyRecord, UserRecord};
 pub use control::CONTROL_LEADER_LOCK;
 pub use routing::RoutingRuleRecord;
-pub use tombstones::{NewTombstone, TombstoneRecord};
+pub use tombstones::{NewTombstone, StreamTombstoneStats, TombstoneRecord};
 
 pub use error::{MetastoreError, MetastoreResult};
 pub use metastore::Metastore;

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -4,10 +4,11 @@ use sqlx::postgres::PgPoolOptions;
 use rsearch_common::config::MetastoreConfig;
 
 use crate::error::{MetastoreError, MetastoreResult};
-use crate::types::{SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats};
+use crate::types::{NewSplit, SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats};
 
-const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
-     size_bytes, time_start_millis, time_end_millis, footer_len, created_by";
+pub(crate) const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
+     size_bytes, time_start_millis, time_end_millis, footer_len, created_by, \
+     seq_min, seq_max, tombstone_seq_applied";
 
 /// Postgres-backed metadata store shared by every node role: streams,
 /// splits, nodes, placement, auth, routing rules, and alerts. Cloning
@@ -208,33 +209,25 @@ impl Metastore {
     // ---- split lifecycle ----
 
     /// Register a freshly-uploaded split in `staged` state.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn stage_split(
-        &self,
-        split_id: &str,
-        stream_id: i64,
-        storage_key: &str,
-        doc_count: i64,
-        size_bytes: i64,
-        time_start_millis: i64,
-        time_end_millis: i64,
-        footer_len: i64,
-        created_by: Option<&str>,
-    ) -> MetastoreResult<()> {
+    pub async fn stage_split(&self, split: &NewSplit<'_>) -> MetastoreResult<()> {
         sqlx::query(
             "INSERT INTO splits (split_id, stream_id, storage_key, doc_count, size_bytes,
-                                 time_start_millis, time_end_millis, footer_len, created_by)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                                 time_start_millis, time_end_millis, footer_len, created_by,
+                                 seq_min, seq_max, tombstone_seq_applied)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
         )
-        .bind(split_id)
-        .bind(stream_id)
-        .bind(storage_key)
-        .bind(doc_count)
-        .bind(size_bytes)
-        .bind(time_start_millis)
-        .bind(time_end_millis)
-        .bind(footer_len)
-        .bind(created_by)
+        .bind(split.split_id)
+        .bind(split.stream_id)
+        .bind(split.storage_key)
+        .bind(split.doc_count)
+        .bind(split.size_bytes)
+        .bind(split.time_start_millis)
+        .bind(split.time_end_millis)
+        .bind(split.footer_len)
+        .bind(split.created_by)
+        .bind(split.seq_min)
+        .bind(split.seq_max)
+        .bind(split.tombstone_seq_applied)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -4,7 +4,7 @@ use sqlx::postgres::PgPoolOptions;
 use rsearch_common::config::MetastoreConfig;
 
 use crate::error::{MetastoreError, MetastoreResult};
-use crate::types::{SplitRecord, SplitState, StreamRecord, StreamStats};
+use crate::types::{SplitRecord, SplitState, StreamMode, StreamRecord, StreamStats};
 
 const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
      size_bytes, time_start_millis, time_end_millis, footer_len, created_by";
@@ -61,7 +61,7 @@ impl Metastore {
         let row = sqlx::query_as::<_, StreamRecord>(
             "INSERT INTO streams (name) VALUES ($1)
              ON CONFLICT (name) DO UPDATE SET updated_at = now()
-             RETURNING id, name, mapping, retention_hours",
+             RETURNING id, name, mapping, retention_hours, mode",
         )
         .bind(name)
         .fetch_one(&self.pool)
@@ -72,7 +72,7 @@ impl Metastore {
     /// Look up a stream by name; `StreamNotFound` if missing.
     pub async fn get_stream(&self, name: &str) -> MetastoreResult<StreamRecord> {
         sqlx::query_as::<_, StreamRecord>(
-            "SELECT id, name, mapping, retention_hours FROM streams WHERE name = $1",
+            "SELECT id, name, mapping, retention_hours, mode FROM streams WHERE name = $1",
         )
         .bind(name)
         .fetch_optional(&self.pool)
@@ -83,7 +83,7 @@ impl Metastore {
     /// Per-stream stats over published splits (for `_cat/indices`).
     pub async fn stream_stats(&self) -> MetastoreResult<Vec<StreamStats>> {
         Ok(sqlx::query_as::<_, StreamStats>(
-            "SELECT st.name, st.retention_hours,
+            "SELECT st.name, st.retention_hours, st.mode,
                     COUNT(s.id) FILTER (WHERE s.state = 'published') AS split_count,
                     COALESCE(SUM(s.doc_count) FILTER (WHERE s.state = 'published'), 0)::bigint AS doc_count,
                     COALESCE(SUM(s.size_bytes) FILTER (WHERE s.state = 'published'), 0)::bigint AS size_bytes
@@ -99,7 +99,7 @@ impl Metastore {
     /// Look up a stream by id; `StreamNotFound` if missing.
     pub async fn get_stream_by_id(&self, id: i64) -> MetastoreResult<StreamRecord> {
         sqlx::query_as::<_, StreamRecord>(
-            "SELECT id, name, mapping, retention_hours FROM streams WHERE id = $1",
+            "SELECT id, name, mapping, retention_hours, mode FROM streams WHERE id = $1",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -110,7 +110,7 @@ impl Metastore {
     /// All streams, ordered by name.
     pub async fn list_streams(&self) -> MetastoreResult<Vec<StreamRecord>> {
         Ok(sqlx::query_as::<_, StreamRecord>(
-            "SELECT id, name, mapping, retention_hours FROM streams ORDER BY name",
+            "SELECT id, name, mapping, retention_hours, mode FROM streams ORDER BY name",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -132,6 +132,47 @@ impl Metastore {
         .await?;
         if result.rows_affected() == 0 {
             return Err(MetastoreError::StreamNotFound(name.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Fetch-or-create a stream with an explicit mode. An existing stream
+    /// keeps its mode; the caller compares and decides (mode is fixed once
+    /// the stream holds data — see [`Metastore::set_stream_mode`]).
+    pub async fn ensure_stream_with_mode(
+        &self,
+        name: &str,
+        mode: StreamMode,
+    ) -> MetastoreResult<StreamRecord> {
+        let row = sqlx::query_as::<_, StreamRecord>(
+            "INSERT INTO streams (name, mode) VALUES ($1, $2)
+             ON CONFLICT (name) DO UPDATE SET updated_at = now()
+             RETURNING id, name, mapping, retention_hours, mode",
+        )
+        .bind(name)
+        .bind(mode.as_str())
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Change a stream's mode. Only allowed while the stream holds no
+    /// splits (a log stream's documents have no tombstone semantics to
+    /// retrofit); otherwise `StreamModeFixed`.
+    pub async fn set_stream_mode(&self, name: &str, mode: StreamMode) -> MetastoreResult<()> {
+        let result = sqlx::query(
+            "UPDATE streams SET mode = $2, updated_at = now()
+             WHERE name = $1
+               AND NOT EXISTS (SELECT 1 FROM splits WHERE splits.stream_id = streams.id)",
+        )
+        .bind(name)
+        .bind(mode.as_str())
+        .execute(&self.pool)
+        .await?;
+        if result.rows_affected() == 0 {
+            // Distinguish "no such stream" from "has data".
+            self.get_stream(name).await?;
+            return Err(MetastoreError::StreamModeFixed(name.to_string()));
         }
         Ok(())
     }

--- a/crates/rsearch-metastore/src/tombstones.rs
+++ b/crates/rsearch-metastore/src/tombstones.rs
@@ -1,0 +1,97 @@
+//! Document-mode tombstones: per-(stream, `_id`) "hide versions older than
+//! `before_seq`" markers, applied at query time and made physical by
+//! compaction (phase 14).
+
+use crate::error::MetastoreResult;
+use crate::metastore::Metastore;
+
+/// One tombstone row.
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq, Eq)]
+pub struct TombstoneRecord {
+    /// Monotonic tombstone ordinal (re-issued when a row is updated), the
+    /// cursor incremental readers page by.
+    pub seq: i64,
+    /// The document id the tombstone hides versions of.
+    pub doc_id: String,
+    /// Versions with `_seq` strictly below this are hidden.
+    pub before_seq: i64,
+}
+
+/// A tombstone to write: (stream id, document id, before_seq).
+#[derive(Debug, Clone)]
+pub struct NewTombstone {
+    /// Owning stream id.
+    pub stream_id: i64,
+    /// Document id.
+    pub doc_id: String,
+    /// Hide versions with `_seq` below this.
+    pub before_seq: i64,
+}
+
+impl Metastore {
+    /// Upsert a batch of tombstones in one statement. An existing row for
+    /// the same (stream, doc) is raised to a greater `before_seq` and
+    /// re-sequenced so readers paging by `seq` see the change; a lower or
+    /// equal bound leaves it untouched.
+    pub async fn upsert_tombstones(&self, items: &[NewTombstone]) -> MetastoreResult<()> {
+        if items.is_empty() {
+            return Ok(());
+        }
+        let stream_ids: Vec<i64> = items.iter().map(|t| t.stream_id).collect();
+        let doc_ids: Vec<String> = items.iter().map(|t| t.doc_id.clone()).collect();
+        let before_seqs: Vec<i64> = items.iter().map(|t| t.before_seq).collect();
+        // Within one statement the same (stream, doc) may appear twice
+        // (two writes to one id in a batch); ON CONFLICT can't update a row
+        // twice, so collapse duplicates to their max before_seq first.
+        sqlx::query(
+            "INSERT INTO doc_tombstones (stream_id, doc_id, before_seq)
+             SELECT stream_id, doc_id, MAX(before_seq)
+             FROM UNNEST($1::bigint[], $2::text[], $3::bigint[]) AS t(stream_id, doc_id, before_seq)
+             GROUP BY stream_id, doc_id
+             ON CONFLICT (stream_id, doc_id) DO UPDATE
+               SET before_seq = EXCLUDED.before_seq,
+                   seq = DEFAULT,
+                   created_at = now()
+               WHERE EXCLUDED.before_seq > doc_tombstones.before_seq",
+        )
+        .bind(&stream_ids)
+        .bind(&doc_ids)
+        .bind(&before_seqs)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    /// Tombstones of a stream with `seq > after_seq`, ascending, up to
+    /// `limit` — the incremental page readers use to extend their cache.
+    pub async fn tombstones_since(
+        &self,
+        stream_id: i64,
+        after_seq: i64,
+        limit: i64,
+    ) -> MetastoreResult<Vec<TombstoneRecord>> {
+        Ok(sqlx::query_as::<_, TombstoneRecord>(
+            "SELECT seq, doc_id, before_seq FROM doc_tombstones
+             WHERE stream_id = $1 AND seq > $2
+             ORDER BY seq
+             LIMIT $3",
+        )
+        .bind(stream_id)
+        .bind(after_seq)
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?)
+    }
+
+    /// Number of tombstone rows for a stream.
+    pub async fn tombstone_count(&self, stream_id: i64) -> MetastoreResult<i64> {
+        Ok(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM doc_tombstones WHERE stream_id = $1",
+            )
+            .bind(stream_id)
+            .fetch_one(self.pool())
+            .await?,
+        )
+    }
+}

--- a/crates/rsearch-metastore/src/tombstones.rs
+++ b/crates/rsearch-metastore/src/tombstones.rs
@@ -95,3 +95,104 @@ impl Metastore {
         )
     }
 }
+
+/// Per-stream tombstone rollup for the compaction job.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct StreamTombstoneStats {
+    /// Stream id.
+    pub stream_id: i64,
+    /// Tombstone rows for the stream.
+    pub count: i64,
+    /// Age of the oldest row, seconds.
+    pub oldest_age_secs: f64,
+    /// Highest tombstone seq.
+    pub max_seq: i64,
+}
+
+impl Metastore {
+    /// Tombstone rollups for every stream that has any, oldest first.
+    pub async fn tombstone_stats(&self) -> MetastoreResult<Vec<StreamTombstoneStats>> {
+        Ok(sqlx::query_as::<_, StreamTombstoneStats>(
+            "SELECT stream_id, COUNT(*) AS count,
+                    EXTRACT(EPOCH FROM (now() - MIN(created_at)))::float8 AS oldest_age_secs,
+                    MAX(seq) AS max_seq
+             FROM doc_tombstones
+             GROUP BY stream_id
+             ORDER BY MIN(created_at)",
+        )
+        .fetch_all(self.pool())
+        .await?)
+    }
+
+    /// Published splits of a stream that carry ids and have not yet
+    /// applied tombstones up to `through_seq`, oldest first.
+    pub async fn splits_needing_compaction(
+        &self,
+        stream_id: i64,
+        through_seq: i64,
+        limit: i64,
+    ) -> MetastoreResult<Vec<crate::types::SplitRecord>> {
+        let query = format!(
+            "SELECT {} FROM splits
+             WHERE stream_id = $1 AND state = 'published'
+               AND seq_min IS NOT NULL AND tombstone_seq_applied < $2
+             ORDER BY tombstone_seq_applied, time_start_millis
+             LIMIT $3",
+            crate::metastore::SPLIT_COLUMNS
+        );
+        Ok(
+            sqlx::query_as::<_, crate::types::SplitRecord>(sqlx::AssertSqlSafe(query))
+                .bind(stream_id)
+                .bind(through_seq)
+                .bind(limit)
+                .fetch_all(self.pool())
+                .await?,
+        )
+    }
+
+    /// Record that a split holds no version hidden by any tombstone up to
+    /// `through_seq` (verified by the compaction job), so those tombstones
+    /// no longer need to be applied to it or kept for it.
+    pub async fn mark_tombstones_applied(
+        &self,
+        split_id: &str,
+        through_seq: i64,
+    ) -> MetastoreResult<()> {
+        sqlx::query(
+            "UPDATE splits SET tombstone_seq_applied = GREATEST(tombstone_seq_applied, $2),
+                               updated_at = now()
+             WHERE split_id = $1",
+        )
+        .bind(split_id)
+        .bind(through_seq)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    /// Delete tombstones older than `grace_secs` that no staged/published
+    /// split can still hold a hidden version for. Returns rows removed.
+    pub async fn purge_tombstones(&self, grace_secs: f64, limit: i64) -> MetastoreResult<u64> {
+        let result = sqlx::query(
+            "DELETE FROM doc_tombstones t
+             WHERE t.seq IN (
+                 SELECT c.seq FROM doc_tombstones c
+                 WHERE c.created_at < now() - make_interval(secs => $1)
+                   AND NOT EXISTS (
+                       SELECT 1 FROM splits s
+                       WHERE s.stream_id = c.stream_id
+                         AND s.state IN ('staged', 'published')
+                         AND s.seq_min IS NOT NULL
+                         AND s.seq_min < c.before_seq
+                         AND s.tombstone_seq_applied < c.seq
+                   )
+                 LIMIT $2
+             )",
+        )
+        .bind(grace_secs)
+        .bind(limit)
+        .execute(self.pool())
+        .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/rsearch-metastore/src/tombstones.rs
+++ b/crates/rsearch-metastore/src/tombstones.rs
@@ -5,6 +5,10 @@
 use crate::error::MetastoreResult;
 use crate::metastore::Metastore;
 
+/// Advisory-lock class for per-stream tombstone serialization (distinct
+/// from the control-leader lock).
+const TOMBSTONE_LOCK_CLASS: i32 = 0x7343_0002;
+
 /// One tombstone row.
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq, Eq)]
 pub struct TombstoneRecord {
@@ -29,10 +33,16 @@ pub struct NewTombstone {
 }
 
 impl Metastore {
-    /// Upsert a batch of tombstones in one statement. An existing row for
-    /// the same (stream, doc) is raised to a greater `before_seq` and
-    /// re-sequenced so readers paging by `seq` see the change; a lower or
-    /// equal bound leaves it untouched.
+    /// Upsert a batch of tombstones. An existing row for the same
+    /// (stream, doc) is raised to a greater `before_seq` and re-sequenced
+    /// so readers paging by `seq` see the change; a lower or equal bound
+    /// leaves it untouched.
+    ///
+    /// Runs in a transaction that takes a per-stream advisory lock before
+    /// drawing sequence numbers, so tombstones of one stream *commit* in
+    /// `seq` order: an incremental reader that saw `seq = N` has seen every
+    /// row below N, and a compaction stamping `applied_through = N` has
+    /// really applied them all.
     pub async fn upsert_tombstones(&self, items: &[NewTombstone]) -> MetastoreResult<()> {
         if items.is_empty() {
             return Ok(());
@@ -40,6 +50,19 @@ impl Metastore {
         let stream_ids: Vec<i64> = items.iter().map(|t| t.stream_id).collect();
         let doc_ids: Vec<String> = items.iter().map(|t| t.doc_id.clone()).collect();
         let before_seqs: Vec<i64> = items.iter().map(|t| t.before_seq).collect();
+        let mut locked: Vec<i64> = stream_ids.clone();
+        locked.sort_unstable();
+        locked.dedup();
+        let mut tx = self.pool().begin().await?;
+        // Sorted lock order across streams keeps concurrent batches
+        // deadlock-free.
+        for stream_id in &locked {
+            sqlx::query("SELECT pg_advisory_xact_lock($1, $2)")
+                .bind(TOMBSTONE_LOCK_CLASS)
+                .bind((stream_id % i64::from(i32::MAX)) as i32)
+                .execute(&mut *tx)
+                .await?;
+        }
         // Within one statement the same (stream, doc) may appear twice
         // (two writes to one id in a batch); ON CONFLICT can't update a row
         // twice, so collapse duplicates to their max before_seq first.
@@ -57,9 +80,35 @@ impl Metastore {
         .bind(&stream_ids)
         .bind(&doc_ids)
         .bind(&before_seqs)
-        .execute(self.pool())
+        .execute(&mut *tx)
         .await?;
+        tx.commit().await?;
         Ok(())
+    }
+
+    /// The highest tombstone bound already recorded for each of the given
+    /// (stream, doc) pairs — what a new write to that id must exceed to
+    /// take effect. Pairs without a tombstone are absent from the result.
+    pub async fn tombstone_bounds(
+        &self,
+        pairs: &[(i64, String)],
+    ) -> MetastoreResult<Vec<(i64, String, i64)>> {
+        if pairs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let stream_ids: Vec<i64> = pairs.iter().map(|(s, _)| *s).collect();
+        let doc_ids: Vec<String> = pairs.iter().map(|(_, d)| d.clone()).collect();
+        let rows = sqlx::query_as::<_, (i64, String, i64)>(
+            "SELECT t.stream_id, t.doc_id, t.before_seq
+             FROM doc_tombstones t
+             JOIN UNNEST($1::bigint[], $2::text[]) AS p(stream_id, doc_id)
+               ON p.stream_id = t.stream_id AND p.doc_id = t.doc_id",
+        )
+        .bind(&stream_ids)
+        .bind(&doc_ids)
+        .fetch_all(self.pool())
+        .await?;
+        Ok(rows)
     }
 
     /// Tombstones of a stream with `seq > after_seq`, ascending, up to
@@ -82,18 +131,6 @@ impl Metastore {
         .fetch_all(self.pool())
         .await?)
     }
-
-    /// Number of tombstone rows for a stream.
-    pub async fn tombstone_count(&self, stream_id: i64) -> MetastoreResult<i64> {
-        Ok(
-            sqlx::query_scalar::<_, i64>(
-                "SELECT COUNT(*) FROM doc_tombstones WHERE stream_id = $1",
-            )
-            .bind(stream_id)
-            .fetch_one(self.pool())
-            .await?,
-        )
-    }
 }
 
 /// Per-stream tombstone rollup for the compaction job.
@@ -110,15 +147,31 @@ pub struct StreamTombstoneStats {
 }
 
 impl Metastore {
-    /// Tombstone rollups for every stream that has any, oldest first.
+    /// Highest `_seq` recorded in any staged/published split of a stream
+    /// (None when no split carries ids) — a lower bound a node's sequence
+    /// clock observes so its next write orders after every published one.
+    pub async fn stream_max_seq(&self, stream_id: i64) -> MetastoreResult<Option<i64>> {
+        Ok(sqlx::query_scalar::<_, Option<i64>>(
+            "SELECT MAX(seq_max) FROM splits
+             WHERE stream_id = $1 AND state IN ('staged', 'published')",
+        )
+        .bind(stream_id)
+        .fetch_one(self.pool())
+        .await?)
+    }
+
+    /// Tombstone rollups for every document-mode stream that has any,
+    /// oldest first. A full scan of the table — callers run it at a lower
+    /// cadence than the control tick.
     pub async fn tombstone_stats(&self) -> MetastoreResult<Vec<StreamTombstoneStats>> {
         Ok(sqlx::query_as::<_, StreamTombstoneStats>(
-            "SELECT stream_id, COUNT(*) AS count,
-                    EXTRACT(EPOCH FROM (now() - MIN(created_at)))::float8 AS oldest_age_secs,
-                    MAX(seq) AS max_seq
-             FROM doc_tombstones
-             GROUP BY stream_id
-             ORDER BY MIN(created_at)",
+            "SELECT t.stream_id, COUNT(*) AS count,
+                    EXTRACT(EPOCH FROM (now() - MIN(t.created_at)))::float8 AS oldest_age_secs,
+                    MAX(t.seq) AS max_seq
+             FROM doc_tombstones t
+             JOIN streams st ON st.id = t.stream_id AND st.mode = 'document'
+             GROUP BY t.stream_id
+             ORDER BY MIN(t.created_at)",
         )
         .fetch_all(self.pool())
         .await?)
@@ -170,22 +223,27 @@ impl Metastore {
         Ok(())
     }
 
-    /// Delete tombstones older than `grace_secs` that no staged/published
-    /// split can still hold a hidden version for. Returns rows removed.
+    /// Delete tombstones older than `grace_secs` that every staged/
+    /// published id-carrying split of their stream has already applied
+    /// (tombstone `seq` at or below the stream's lowest
+    /// `tombstone_seq_applied`). Streams with no such splits keep nothing.
+    /// Index-driven on both sides: O(rows purged), not O(tombstones ×
+    /// splits). Returns rows removed.
     pub async fn purge_tombstones(&self, grace_secs: f64, limit: i64) -> MetastoreResult<u64> {
         let result = sqlx::query(
-            "DELETE FROM doc_tombstones t
+            "WITH floor AS (
+                 SELECT stream_id, MIN(tombstone_seq_applied) AS min_applied
+                 FROM splits
+                 WHERE state IN ('staged', 'published') AND seq_min IS NOT NULL
+                 GROUP BY stream_id
+             )
+             DELETE FROM doc_tombstones t
              WHERE t.seq IN (
                  SELECT c.seq FROM doc_tombstones c
+                 LEFT JOIN floor f ON f.stream_id = c.stream_id
                  WHERE c.created_at < now() - make_interval(secs => $1)
-                   AND NOT EXISTS (
-                       SELECT 1 FROM splits s
-                       WHERE s.stream_id = c.stream_id
-                         AND s.state IN ('staged', 'published')
-                         AND s.seq_min IS NOT NULL
-                         AND s.seq_min < c.before_seq
-                         AND s.tombstone_seq_applied < c.seq
-                   )
+                   AND (f.min_applied IS NULL OR c.seq <= f.min_applied)
+                 ORDER BY c.created_at
                  LIMIT $2
              )",
         )

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -119,6 +119,42 @@ pub struct SplitRecord {
     pub footer_len: i64,
     /// Id of the node that built the split, when known.
     pub created_by: Option<String>,
+    /// Lowest `_seq` in the split; None for legacy splits without ids.
+    pub seq_min: Option<i64>,
+    /// Highest `_seq` in the split; None for legacy splits without ids.
+    pub seq_max: Option<i64>,
+    /// Highest tombstone `seq` applied when the split was built (0 for
+    /// ingest-built splits: nothing applied yet).
+    pub tombstone_seq_applied: i64,
+}
+
+/// A split to register (see `Metastore::stage_split`).
+#[derive(Debug, Clone)]
+pub struct NewSplit<'a> {
+    /// Globally unique split identifier.
+    pub split_id: &'a str,
+    /// Owning stream id.
+    pub stream_id: i64,
+    /// Object key in storage.
+    pub storage_key: &'a str,
+    /// Documents in the split.
+    pub doc_count: i64,
+    /// Split file size.
+    pub size_bytes: i64,
+    /// Earliest document timestamp, epoch millis.
+    pub time_start_millis: i64,
+    /// Latest document timestamp, epoch millis.
+    pub time_end_millis: i64,
+    /// Footer metadata length.
+    pub footer_len: i64,
+    /// Building node id.
+    pub created_by: Option<&'a str>,
+    /// Lowest `_seq` (None when the split has no ids).
+    pub seq_min: Option<i64>,
+    /// Highest `_seq` (None when the split has no ids).
+    pub seq_max: Option<i64>,
+    /// Highest tombstone seq applied while building.
+    pub tombstone_seq_applied: i64,
 }
 
 impl SplitRecord {

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -35,6 +35,37 @@ impl std::str::FromStr for SplitState {
     }
 }
 
+/// How a stream treats writes to an existing `_id`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum StreamMode {
+    /// Append-only log store: every write is a new document; `delete` and
+    /// `update` are rejected. The default.
+    Log,
+    /// Document index: `index` on an existing `_id` replaces it, `delete`
+    /// and `update` work, reads filter tombstoned versions.
+    Document,
+}
+
+impl StreamMode {
+    /// The mode's wire/storage name.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            StreamMode::Log => "log",
+            StreamMode::Document => "document",
+        }
+    }
+
+    /// Parse the wire/storage name.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "log" => Some(StreamMode::Log),
+            "document" => Some(StreamMode::Document),
+            _ => None,
+        }
+    }
+}
+
 /// A stream (index) row.
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct StreamRecord {
@@ -46,6 +77,20 @@ pub struct StreamRecord {
     pub mapping: serde_json::Value,
     /// Retention window in hours; None = keep forever.
     pub retention_hours: Option<i32>,
+    /// Raw mode string; parse via [`StreamRecord::mode`].
+    pub mode: String,
+}
+
+impl StreamRecord {
+    /// Parsed [`StreamMode`]; unknown strings fall back to `Log`.
+    pub fn mode(&self) -> StreamMode {
+        StreamMode::parse(&self.mode).unwrap_or(StreamMode::Log)
+    }
+
+    /// Whether this stream is a document-mode index.
+    pub fn is_document_mode(&self) -> bool {
+        self.mode() == StreamMode::Document
+    }
 }
 
 /// A split (immutable index file) row.
@@ -90,6 +135,8 @@ pub struct StreamStats {
     pub name: String,
     /// Retention window in hours; None = keep forever.
     pub retention_hours: Option<i32>,
+    /// Stream mode (`log` | `document`).
+    pub mode: String,
     /// Number of published splits.
     pub split_count: i64,
     /// Total documents across published splits.

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -3,7 +3,7 @@
 //!     cargo test -p rsearch-metastore -- --ignored
 
 use rsearch_common::config::MetastoreConfig;
-use rsearch_metastore::{Metastore, MetastoreError, SplitState};
+use rsearch_metastore::{Metastore, MetastoreError, SplitState, StreamMode};
 
 async fn metastore() -> Option<Metastore> {
     let url = std::env::var("RSEARCH_TEST_DATABASE_URL").ok()?;
@@ -42,6 +42,37 @@ async fn stream_crud_and_mapping() {
         ms.get_stream(&name).await,
         Err(MetastoreError::StreamNotFound(_))
     ));
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn stream_mode_is_fixed_once_data_exists() {
+    let Some(ms) = metastore().await else { return };
+    let name = unique("mode");
+
+    // Auto-created streams are log mode; an empty stream may switch.
+    let stream = ms.ensure_stream(&name).await.unwrap();
+    assert_eq!(stream.mode(), StreamMode::Log);
+    ms.set_stream_mode(&name, StreamMode::Document).await.unwrap();
+    assert!(ms.get_stream(&name).await.unwrap().is_document_mode());
+    // ensure_stream_with_mode never flips an existing stream.
+    let again = ms.ensure_stream_with_mode(&name, StreamMode::Log).await.unwrap();
+    assert_eq!(again.mode(), StreamMode::Document);
+
+    // Once a split exists the mode is fixed.
+    let split_id = unique("split");
+    ms.stage_split(&split_id, stream.id, "k", 1, 1, 0, 0, 0, None)
+        .await
+        .unwrap();
+    assert!(matches!(
+        ms.set_stream_mode(&name, StreamMode::Log).await,
+        Err(MetastoreError::StreamModeFixed(_))
+    ));
+    assert!(matches!(
+        ms.set_stream_mode(&unique("missing"), StreamMode::Log).await,
+        Err(MetastoreError::StreamNotFound(_))
+    ));
+    ms.delete_stream(&name).await.unwrap();
 }
 
 #[tokio::test]

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -3,7 +3,7 @@
 //!     cargo test -p rsearch-metastore -- --ignored
 
 use rsearch_common::config::MetastoreConfig;
-use rsearch_metastore::{Metastore, MetastoreError, SplitState, StreamMode};
+use rsearch_metastore::{Metastore, MetastoreError, NewSplit, SplitState, StreamMode};
 
 async fn metastore() -> Option<Metastore> {
     let url = std::env::var("RSEARCH_TEST_DATABASE_URL").ok()?;
@@ -61,9 +61,22 @@ async fn stream_mode_is_fixed_once_data_exists() {
 
     // Once a split exists the mode is fixed.
     let split_id = unique("split");
-    ms.stage_split(&split_id, stream.id, "k", 1, 1, 0, 0, 0, None)
-        .await
-        .unwrap();
+    ms.stage_split(&NewSplit {
+        split_id: &split_id,
+        stream_id: stream.id,
+        storage_key: "k",
+        doc_count: 1,
+        size_bytes: 1,
+        time_start_millis: 0,
+        time_end_millis: 0,
+        footer_len: 0,
+        created_by: None,
+        seq_min: None,
+        seq_max: None,
+        tombstone_seq_applied: 0,
+    })
+    .await
+    .unwrap();
     assert!(matches!(
         ms.set_stream_mode(&name, StreamMode::Log).await,
         Err(MetastoreError::StreamModeFixed(_))
@@ -82,17 +95,20 @@ async fn split_state_machine() {
     let stream = ms.ensure_stream(&unique("splits")).await.unwrap();
     let split_id = unique("split");
 
-    ms.stage_split(
-        &split_id,
-        stream.id,
-        &format!("streams/{}/{}.split", stream.name, split_id),
-        1000,
-        4096,
-        1_753_300_000_000,
-        1_753_300_060_000,
-        512,
-        Some("node-a"),
-    )
+    ms.stage_split(&NewSplit {
+        split_id: &split_id,
+        stream_id: stream.id,
+        storage_key: &format!("streams/{}/{}.split", stream.name, split_id),
+        doc_count: 1000,
+        size_bytes: 4096,
+        time_start_millis: 1_753_300_000_000,
+        time_end_millis: 1_753_300_060_000,
+        footer_len: 512,
+        created_by: Some("node-a"),
+        seq_min: Some(10),
+        seq_max: Some(20),
+        tombstone_seq_applied: 0,
+    })
     .await
     .unwrap();
 
@@ -266,4 +282,49 @@ async fn replication_targets_draining_last_resort() {
             .await
             .unwrap();
     }
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn tombstones_upsert_and_page_by_seq() {
+    use rsearch_metastore::NewTombstone;
+    let Some(ms) = metastore().await else { return };
+    let stream = ms.ensure_stream(&unique("tomb")).await.unwrap();
+    let t = |doc: &str, before: i64| NewTombstone {
+        stream_id: stream.id,
+        doc_id: doc.to_string(),
+        before_seq: before,
+    };
+
+    // Duplicates within one batch collapse to the max before_seq.
+    ms.upsert_tombstones(&[t("a", 10), t("b", 20), t("a", 15)])
+        .await
+        .unwrap();
+    let rows = ms.tombstones_since(stream.id, 0, 100).await.unwrap();
+    assert_eq!(rows.len(), 2);
+    let a = rows.iter().find(|r| r.doc_id == "a").unwrap().clone();
+    assert_eq!(a.before_seq, 15);
+    let last_seq = rows.iter().map(|r| r.seq).max().unwrap();
+
+    // Nothing new since the last seq.
+    assert!(ms.tombstones_since(stream.id, last_seq, 100).await.unwrap().is_empty());
+
+    // Raising an existing row re-sequences it so incremental readers see
+    // it again; lowering is ignored (keeps the max).
+    ms.upsert_tombstones(&[t("a", 30), t("b", 5)]).await.unwrap();
+    let newer = ms.tombstones_since(stream.id, last_seq, 100).await.unwrap();
+    assert_eq!(newer.len(), 1);
+    assert_eq!((newer[0].doc_id.as_str(), newer[0].before_seq), ("a", 30));
+    assert!(newer[0].seq > a.seq);
+    let all = ms.tombstones_since(stream.id, 0, 100).await.unwrap();
+    assert_eq!(all.iter().find(|r| r.doc_id == "b").unwrap().before_seq, 20);
+    assert_eq!(ms.tombstone_count(stream.id).await.unwrap(), 2);
+
+    // Paging honors the limit in seq order.
+    let page = ms.tombstones_since(stream.id, 0, 1).await.unwrap();
+    assert_eq!(page.len(), 1);
+    assert_eq!(page[0].doc_id, "b");
+
+    ms.delete_stream(&stream.name).await.unwrap();
+    assert_eq!(ms.tombstone_count(stream.id).await.unwrap(), 0, "cascade");
 }

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -338,13 +338,9 @@ async fn tombstones_upsert_and_page_by_seq() {
         ms.tombstones_since(stream.id, 0, 10).await.unwrap().is_empty(),
         "cascade"
     );
-}
 
-#[tokio::test]
-#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
-async fn tombstone_purge_respects_split_floor_and_grace() {
-    use rsearch_metastore::NewTombstone;
-    let Some(ms) = metastore().await else { return };
+    // ---- purge (same test: purge is global, so it must not run
+    // concurrently with the assertions above).
     let stream = ms.ensure_stream(&unique("purge")).await.unwrap();
     let t = |doc: &str, before: i64| NewTombstone {
         stream_id: stream.id,
@@ -374,15 +370,23 @@ async fn tombstone_purge_respects_split_floor_and_grace() {
     ms.stage_split(&split(stream.id, &s1, seq_a)).await.unwrap();
     ms.publish_split(&s1).await.unwrap();
 
+    let remaining = |ms: &Metastore, id: i64| async move {
+        ms.tombstones_since(id, 0, 10)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|t| t.seq)
+            .collect::<Vec<_>>()
+    };
     // Grace not elapsed: nothing purged even though a is applied.
-    assert_eq!(ms.purge_tombstones(3600.0, 100).await.unwrap(), 0);
+    ms.purge_tombstones(3600.0, 1_000).await.unwrap();
+    assert_eq!(remaining(&ms, stream.id).await, vec![seq_a, seq_b]);
     // Grace 0: only a (seq <= floor); b is above the floor.
-    assert_eq!(ms.purge_tombstones(0.0, 100).await.unwrap(), 1);
-    let left = ms.tombstones_since(stream.id, 0, 10).await.unwrap();
-    assert_eq!(left.len(), 1);
-    assert_eq!(left[0].seq, seq_b);
+    ms.purge_tombstones(0.0, 1_000).await.unwrap();
+    assert_eq!(remaining(&ms, stream.id).await, vec![seq_b]);
     // Raising the floor releases b.
     ms.mark_tombstones_applied(&s1, seq_b).await.unwrap();
-    assert_eq!(ms.purge_tombstones(0.0, 100).await.unwrap(), 1);
+    ms.purge_tombstones(0.0, 1_000).await.unwrap();
+    assert!(remaining(&ms, stream.id).await.is_empty());
     ms.delete_stream(&stream.name).await.unwrap();
 }

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -318,7 +318,15 @@ async fn tombstones_upsert_and_page_by_seq() {
     assert!(newer[0].seq > a.seq);
     let all = ms.tombstones_since(stream.id, 0, 100).await.unwrap();
     assert_eq!(all.iter().find(|r| r.doc_id == "b").unwrap().before_seq, 20);
-    assert_eq!(ms.tombstone_count(stream.id).await.unwrap(), 2);
+    assert_eq!(all.len(), 2);
+
+    // Bounds lookup: what a new write must exceed.
+    let mut bounds = ms
+        .tombstone_bounds(&[(stream.id, "a".into()), (stream.id, "zzz".into())])
+        .await
+        .unwrap();
+    bounds.sort();
+    assert_eq!(bounds, vec![(stream.id, "a".to_string(), 30)]);
 
     // Paging honors the limit in seq order.
     let page = ms.tombstones_since(stream.id, 0, 1).await.unwrap();
@@ -326,5 +334,55 @@ async fn tombstones_upsert_and_page_by_seq() {
     assert_eq!(page[0].doc_id, "b");
 
     ms.delete_stream(&stream.name).await.unwrap();
-    assert_eq!(ms.tombstone_count(stream.id).await.unwrap(), 0, "cascade");
+    assert!(
+        ms.tombstones_since(stream.id, 0, 10).await.unwrap().is_empty(),
+        "cascade"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn tombstone_purge_respects_split_floor_and_grace() {
+    use rsearch_metastore::NewTombstone;
+    let Some(ms) = metastore().await else { return };
+    let stream = ms.ensure_stream(&unique("purge")).await.unwrap();
+    let t = |doc: &str, before: i64| NewTombstone {
+        stream_id: stream.id,
+        doc_id: doc.to_string(),
+        before_seq: before,
+    };
+    ms.upsert_tombstones(&[t("a", 10), t("b", 20)]).await.unwrap();
+    let rows = ms.tombstones_since(stream.id, 0, 10).await.unwrap();
+    let (seq_a, seq_b) = (rows[0].seq, rows[1].seq);
+    fn split<'a>(stream_id: i64, id: &'a str, applied: i64) -> NewSplit<'a> {
+        NewSplit {
+        split_id: id,
+        stream_id,
+        storage_key: "k",
+        doc_count: 1,
+        size_bytes: 1,
+        time_start_millis: 0,
+        time_end_millis: 0,
+        footer_len: 0,
+        created_by: None,
+        seq_min: Some(1),
+        seq_max: Some(2),
+        tombstone_seq_applied: applied,
+        }
+    }
+    let s1 = unique("s1");
+    ms.stage_split(&split(stream.id, &s1, seq_a)).await.unwrap();
+    ms.publish_split(&s1).await.unwrap();
+
+    // Grace not elapsed: nothing purged even though a is applied.
+    assert_eq!(ms.purge_tombstones(3600.0, 100).await.unwrap(), 0);
+    // Grace 0: only a (seq <= floor); b is above the floor.
+    assert_eq!(ms.purge_tombstones(0.0, 100).await.unwrap(), 1);
+    let left = ms.tombstones_since(stream.id, 0, 10).await.unwrap();
+    assert_eq!(left.len(), 1);
+    assert_eq!(left[0].seq, seq_b);
+    // Raising the floor releases b.
+    ms.mark_tombstones_applied(&s1, seq_b).await.unwrap();
+    assert_eq!(ms.purge_tombstones(0.0, 100).await.unwrap(), 1);
+    ms.delete_stream(&stream.name).await.unwrap();
 }

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -147,6 +147,9 @@ impl SearchRequest {
     }
 }
 
+/// A fetched page document: (page position, stored `_id`, `_source` text).
+type FetchedDoc = (usize, Option<String>, Option<String>);
+
 /// A hit reference — no `_source` yet; it's fetched only for the final
 /// page after the global merge, and includes a stable tiebreaker.
 #[derive(Clone)]
@@ -333,7 +336,6 @@ impl SearchService {
             .enumerate()
             .map(|(idx, split)| {
                 let this = &*self;
-                let schema = schema.clone();
                 let query = query.clone();
                 let aggregations = aggregations.clone();
                 let counted = counted.clone();
@@ -355,7 +357,6 @@ impl SearchService {
                     let outcome = tokio::task::spawn_blocking(move || {
                         search_one_split(
                             &reader,
-                            &schema,
                             &query,
                             aggregations,
                             fetch_limit,
@@ -413,16 +414,12 @@ impl SearchService {
             .take(request.size)
             .collect();
 
-        // Fetch _source only for the final page, grouped by split so each
-        // reader is used once (H4).
-        let page_entries = if request.include_source {
-            self.fetch_page_sources(&splits, &schema, &page, &request.stream)
-                .await?
-        } else {
-            page.iter()
-                .map(|hit| hit_envelope(hit, &splits, &request.stream, None))
-                .collect()
-        };
+        // Fetch the page's documents (`_id`, and `_source` unless disabled)
+        // only for the final page, grouped by split so each reader is used
+        // once (H4).
+        let page_entries = self
+            .fetch_page_sources(&splits, &page, &request.stream, request.include_source)
+            .await?;
 
         let merged_aggs = match (&aggregations, &aggs_json) {
             (Some(aggs), Some(_)) => {
@@ -478,14 +475,17 @@ impl SearchService {
         Ok(response)
     }
 
-    /// Fetch `_source` for the final page only, grouping by split so each
-    /// reader is used once on a single blocking task.
+    /// Fetch the stored documents for the final page only, grouping by
+    /// split so each reader is used once on a single blocking task. Yields
+    /// each hit's `_id` (the stored one, or the synthetic
+    /// `split:segment:doc` address for legacy splits without ids) and its
+    /// `_source` when `include_source`.
     async fn fetch_page_sources(
         &self,
         splits: &[rsearch_metastore::SplitRecord],
-        schema: &Arc<MappedSchema>,
         page: &[SplitHit],
         stream: &str,
+        include_source: bool,
     ) -> SearchResult<Vec<Value>> {
         use futures::stream::{self, StreamExt};
 
@@ -500,19 +500,25 @@ impl SearchService {
             .map(|(split_idx, wants)| {
                 let this = &*self;
                 let split = &splits[split_idx];
-                let schema = schema.clone();
                 async move {
                     let reader = this.reader(&split.split_id, &split.storage_key).await?;
                     tokio::task::spawn_blocking(move || {
                         let searcher = reader.searcher()?;
+                        let schema = reader.mapped_schema();
                         let mut out = Vec::with_capacity(wants.len());
                         for (pos, address) in wants {
                             let doc: TantivyDocument =
                                 searcher.doc(address).map_err(SearchError::Tantivy)?;
-                            let source = doc
-                                .get_first(schema.source)
-                                .and_then(|v| v.as_str().map(str::to_string));
-                            out.push((pos, source));
+                            let id = schema.id.and_then(|f| {
+                                doc.get_first(f).and_then(|v| v.as_str().map(str::to_string))
+                            });
+                            let source = include_source
+                                .then(|| {
+                                    doc.get_first(schema.source)
+                                        .and_then(|v| v.as_str().map(str::to_string))
+                                })
+                                .flatten();
+                            out.push((pos, id, source));
                         }
                         Ok::<_, SearchError>(out)
                     })
@@ -521,39 +527,51 @@ impl SearchService {
                 }
             })
             .collect();
-        let mut sources: Vec<Value> = vec![Value::Null; page.len()];
-        let fetched: Vec<Vec<(usize, Option<String>)>> = stream::iter(futs)
+        let mut fetched_docs: Vec<(Option<String>, Option<String>)> =
+            vec![(None, None); page.len()];
+        let fetched: Vec<Vec<FetchedDoc>> = stream::iter(futs)
             .buffer_unordered(SPLIT_SEARCH_CONCURRENCY)
             .collect::<Vec<SearchResult<_>>>()
             .await
             .into_iter()
             .collect::<SearchResult<Vec<_>>>()?;
-        for (pos, source) in fetched.into_iter().flatten() {
-            sources[pos] = source
-                .as_deref()
-                .and_then(|s| serde_json::from_str(s).ok())
-                .unwrap_or(Value::Null);
+        for (pos, id, source) in fetched.into_iter().flatten() {
+            fetched_docs[pos] = (id, source);
         }
         Ok(page
             .iter()
-            .zip(sources)
-            .map(|(hit, source)| hit_envelope(hit, splits, stream, Some(source)))
+            .zip(fetched_docs)
+            .map(|(hit, (id, source))| {
+                let source = include_source.then(|| {
+                    source
+                        .as_deref()
+                        .and_then(|s| serde_json::from_str(s).ok())
+                        .unwrap_or(Value::Null)
+                });
+                hit_envelope(hit, splits, stream, id, source)
+            })
             .collect())
     }
 }
 
-/// Build the ES hit envelope. `source` is Some(value) when `_source` is
-/// requested (value may be Null if unfetchable), None to omit the field.
+/// Build the ES hit envelope. `id` is the stored `_id` when the split has
+/// one (legacy splits fall back to the synthetic split:segment:doc
+/// address); `source` is Some(value) when `_source` is requested (value
+/// may be Null if unfetchable), None to omit the field.
 fn hit_envelope(
     hit: &SplitHit,
     splits: &[rsearch_metastore::SplitRecord],
     stream: &str,
+    id: Option<String>,
     source: Option<Value>,
 ) -> Value {
     let split_id = &splits[hit.split_idx].split_id;
+    let id = id.unwrap_or_else(|| {
+        format!("{}:{}:{}", split_id, hit.doc.segment_ord, hit.doc.doc_id)
+    });
     let mut entry = json!({
         "_index": stream,
-        "_id": format!("{}:{}:{}", split_id, hit.doc.segment_ord, hit.doc.doc_id),
+        "_id": id,
         "_score": Value::Null,
         "sort": [hit.timestamp_millis],
     });
@@ -571,7 +589,6 @@ fn default_limits() -> AggregationLimitsGuard {
 #[allow(clippy::too_many_arguments)]
 fn search_one_split(
     reader: &SplitReader,
-    schema: &MappedSchema,
     query_json: &Value,
     aggregations: Option<Aggregations>,
     fetch_limit: usize,
@@ -582,7 +599,10 @@ fn search_one_split(
     fully_covered: bool,
 ) -> SearchResult<SplitOutcome> {
     let index = reader.index();
-    let query = translate_query(index, schema, query_json)?;
+    // Translate against the split's own schema: field ordinals follow the
+    // mapping the split was built with, which can differ from the stream's
+    // current mapping (PUT /{index} after the split was written).
+    let query = translate_query(index, reader.mapped_schema(), query_json)?;
     let searcher = reader.searcher()?;
 
     let order = if sort_desc { Order::Desc } else { Order::Asc };

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -14,12 +14,15 @@ use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::collector::{Count, TopDocs};
+use tantivy::query::{BooleanQuery, Occur, Query};
 use tantivy::schema::Value as _;
 use tantivy::{DocAddress, Order, TantivyDocument};
 use tokio::sync::Mutex;
 use tracing::warn;
 
-use rsearch_index::{IndexMapping, MappedSchema, SplitCache, SplitReader};
+use rsearch_index::{
+    ExcludeDocsQuery, ExclusionSet, IndexMapping, MappedSchema, SplitCache, SplitReader, Tombstone,
+};
 use rsearch_metastore::Metastore;
 use rsearch_storage::Storage;
 
@@ -44,6 +47,13 @@ const STREAM_CACHE_TTL: Duration = Duration::from_secs(10);
 /// ES-compatible default exact-count ceiling; beyond this the reported
 /// total is a lower bound (`"relation": "gte"`).
 const DEFAULT_TRACK_TOTAL_HITS: usize = 10_000;
+/// How long a document-mode stream's tombstone list may be reused before
+/// the metastore is asked for newer rows. A node that wrote a tombstone
+/// invalidates its own cache immediately; other search nodes see it
+/// within this window.
+const TOMBSTONE_CACHE_TTL: Duration = Duration::from_secs(1);
+/// Tombstone rows fetched per metastore round trip.
+const TOMBSTONE_PAGE: i64 = 10_000;
 /// Hard ceiling on from+size (ES max_result_window).
 const MAX_RESULT_WINDOW: usize = 10_000;
 /// Max splits one query may touch. A query over more than this (an
@@ -147,8 +157,9 @@ impl SearchRequest {
     }
 }
 
-/// A fetched page document: (page position, stored `_id`, `_source` text).
-type FetchedDoc = (usize, Option<String>, Option<String>);
+/// A fetched page document: (page position, stored `_id`, `_seq`,
+/// `_source` text).
+type FetchedDoc = (usize, Option<String>, Option<i64>, Option<String>);
 
 /// A hit reference — no `_source` yet; it's fetched only for the final
 /// page after the global merge, and includes a stable tiebreaker.
@@ -157,6 +168,15 @@ struct SplitHit {
     timestamp_millis: i64,
     split_idx: usize,
     doc: DocAddress,
+}
+
+/// A document-mode stream's tombstones as last fetched: ascending by
+/// `seq`, append-only between refreshes (the list is what every split's
+/// incremental `apply_tombstones` consumes).
+struct StreamTombstones {
+    entries: Arc<Vec<Tombstone>>,
+    /// None = explicitly invalidated (a local write); refresh on next use.
+    fetched_at: Option<Instant>,
 }
 
 struct SplitOutcome {
@@ -190,6 +210,8 @@ pub struct SearchService {
     /// metastore roundtrip and full Tantivy schema rebuild for data that
     /// only changes on PUT /{index}.
     streams: std::sync::Mutex<HashMap<String, (Arc<CachedStream>, Instant)>>,
+    /// Stream id → tombstone list (document-mode streams only).
+    tombstones: std::sync::Mutex<HashMap<i64, StreamTombstones>>,
 }
 
 impl SearchService {
@@ -209,7 +231,66 @@ impl SearchService {
                 .collect(),
             opening: std::sync::Mutex::new(HashMap::new()),
             streams: std::sync::Mutex::new(HashMap::new()),
+            tombstones: std::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Drop the freshness of a stream's cached tombstones so the next
+    /// query re-reads the metastore — called by the node's own write path
+    /// so a delete is visible to an immediately following local search.
+    pub fn invalidate_tombstones(&self, stream_id: i64) {
+        if let Some(entry) = self.tombstones.lock().unwrap().get_mut(&stream_id) {
+            entry.fetched_at = None;
+        }
+    }
+
+    /// The stream's tombstones, ascending by seq, extended from the
+    /// metastore when the cache is stale.
+    async fn tombstones_for(&self, stream_id: i64) -> SearchResult<Arc<Vec<Tombstone>>> {
+        let cached = {
+            let map = self.tombstones.lock().unwrap();
+            map.get(&stream_id).map(|t| (t.entries.clone(), t.fetched_at))
+        };
+        if let Some((entries, Some(at))) = &cached
+            && at.elapsed() < TOMBSTONE_CACHE_TTL
+        {
+            return Ok(entries.clone());
+        }
+        let mut entries: Vec<Tombstone> = cached
+            .map(|(e, _)| e.as_ref().clone())
+            .unwrap_or_default();
+        let mut after = entries.last().map(|t| t.seq).unwrap_or(0);
+        loop {
+            let page = self
+                .metastore
+                .tombstones_since(stream_id, after, TOMBSTONE_PAGE)
+                .await?;
+            let done = (page.len() as i64) < TOMBSTONE_PAGE;
+            if let Some(last) = page.last() {
+                after = last.seq;
+            }
+            entries.extend(page.into_iter().map(|t| Tombstone {
+                seq: t.seq,
+                doc_id: t.doc_id,
+                before_seq: t.before_seq,
+            }));
+            if done {
+                break;
+            }
+        }
+        let entries = Arc::new(entries);
+        let mut map = self.tombstones.lock().unwrap();
+        if map.len() > 10_000 {
+            map.clear();
+        }
+        map.insert(
+            stream_id,
+            StreamTombstones {
+                entries: entries.clone(),
+                fetched_at: Some(Instant::now()),
+            },
+        );
+        Ok(entries)
     }
 
     fn reader_shard(&self, split_id: &str) -> &std::sync::Mutex<lru::LruCache<String, Arc<SplitReader>>> {
@@ -312,6 +393,15 @@ impl SearchService {
             None => None,
         };
 
+        // Document-mode streams hide tombstoned versions; the list is
+        // shared by every split's incremental application below.
+        let tombstones: Option<Arc<Vec<Tombstone>>> = if stream.is_document_mode() {
+            let list = self.tombstones_for(stream.id).await?;
+            (!list.is_empty()).then_some(list)
+        } else {
+            None
+        };
+
         let fetch_limit = request.from + request.size;
         let query = Arc::new(request.query.clone());
         // Whether the query is exactly match_all — lets fully-covered
@@ -342,6 +432,11 @@ impl SearchService {
                 let split_id = split.split_id.clone();
                 let storage_key = split.storage_key.clone();
                 let doc_count = split.doc_count as usize;
+                // Only splits that carry ids (seq_min known) can hold a
+                // tombstoned version.
+                let tombstones = tombstones
+                    .clone()
+                    .filter(|_| split.seq_min.is_some());
                 // A split fully inside [t_start, t_end] needs no filtering
                 // for a match_all query — its whole doc_count matches, so it
                 // reports its count without scanning (H3).
@@ -355,6 +450,11 @@ impl SearchService {
                         None => false,
                     };
                     let outcome = tokio::task::spawn_blocking(move || {
+                        let exclusions = match tombstones {
+                            Some(list) => Some(reader.apply_tombstones(&list)?),
+                            None => None,
+                        }
+                        .filter(|set| !set.is_empty());
                         search_one_split(
                             &reader,
                             &query,
@@ -365,6 +465,7 @@ impl SearchService {
                             idx,
                             doc_count,
                             fully_covered,
+                            exclusions,
                         )
                     })
                     .await
@@ -512,13 +613,22 @@ impl SearchService {
                             let id = schema.id.and_then(|f| {
                                 doc.get_first(f).and_then(|v| v.as_str().map(str::to_string))
                             });
+                            let seq = match schema.seq {
+                                Some(_) => searcher
+                                    .segment_reader(address.segment_ord)
+                                    .fast_fields()
+                                    .i64(rsearch_index::SEQ_FIELD)
+                                    .ok()
+                                    .and_then(|col| col.first(address.doc_id)),
+                                None => None,
+                            };
                             let source = include_source
                                 .then(|| {
                                     doc.get_first(schema.source)
                                         .and_then(|v| v.as_str().map(str::to_string))
                                 })
                                 .flatten();
-                            out.push((pos, id, source));
+                            out.push((pos, id, seq, source));
                         }
                         Ok::<_, SearchError>(out)
                     })
@@ -527,28 +637,28 @@ impl SearchService {
                 }
             })
             .collect();
-        let mut fetched_docs: Vec<(Option<String>, Option<String>)> =
-            vec![(None, None); page.len()];
+        let mut fetched_docs: Vec<(Option<String>, Option<i64>, Option<String>)> =
+            vec![(None, None, None); page.len()];
         let fetched: Vec<Vec<FetchedDoc>> = stream::iter(futs)
             .buffer_unordered(SPLIT_SEARCH_CONCURRENCY)
             .collect::<Vec<SearchResult<_>>>()
             .await
             .into_iter()
             .collect::<SearchResult<Vec<_>>>()?;
-        for (pos, id, source) in fetched.into_iter().flatten() {
-            fetched_docs[pos] = (id, source);
+        for (pos, id, seq, source) in fetched.into_iter().flatten() {
+            fetched_docs[pos] = (id, seq, source);
         }
         Ok(page
             .iter()
             .zip(fetched_docs)
-            .map(|(hit, (id, source))| {
+            .map(|(hit, (id, seq, source))| {
                 let source = include_source.then(|| {
                     source
                         .as_deref()
                         .and_then(|s| serde_json::from_str(s).ok())
                         .unwrap_or(Value::Null)
                 });
-                hit_envelope(hit, splits, stream, id, source)
+                hit_envelope(hit, splits, stream, id, seq, source)
             })
             .collect())
     }
@@ -563,6 +673,7 @@ fn hit_envelope(
     splits: &[rsearch_metastore::SplitRecord],
     stream: &str,
     id: Option<String>,
+    seq: Option<i64>,
     source: Option<Value>,
 ) -> Value {
     let split_id = &splits[hit.split_idx].split_id;
@@ -575,6 +686,11 @@ fn hit_envelope(
         "_score": Value::Null,
         "sort": [hit.timestamp_millis],
     });
+    // `_version` is the write sequence: what the bulk/_doc responses
+    // reported for this version of the document.
+    if let Some(seq) = seq {
+        entry["_version"] = json!(seq);
+    }
     if let Some(source) = source {
         entry["_source"] = source;
     }
@@ -597,12 +713,24 @@ fn search_one_split(
     split_idx: usize,
     doc_count: usize,
     fully_covered: bool,
+    exclusions: Option<Arc<ExclusionSet>>,
 ) -> SearchResult<SplitOutcome> {
     let index = reader.index();
     // Translate against the split's own schema: field ordinals follow the
     // mapping the split was built with, which can differ from the stream's
     // current mapping (PUT /{index} after the split was written).
-    let query = translate_query(index, reader.mapped_schema(), query_json)?;
+    let mut query = translate_query(index, reader.mapped_schema(), query_json)?;
+    // Tombstoned versions are excluded inside the query so every collector
+    // (top-k, Count, aggregations) agrees; the doc_count shortcut below
+    // subtracts them instead of scanning.
+    let mut doc_count = doc_count;
+    if let Some(set) = exclusions {
+        doc_count = doc_count.saturating_sub(set.len());
+        query = Box::new(BooleanQuery::new(vec![
+            (Occur::Must, query),
+            (Occur::MustNot, Box::new(ExcludeDocsQuery::new(set)) as Box<dyn Query>),
+        ]));
+    }
     let searcher = reader.searcher()?;
 
     let order = if sort_desc { Order::Desc } else { Order::Asc };

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -54,6 +54,10 @@ const DEFAULT_TRACK_TOTAL_HITS: usize = 10_000;
 const TOMBSTONE_CACHE_TTL: Duration = Duration::from_secs(1);
 /// Tombstone rows fetched per metastore round trip.
 const TOMBSTONE_PAGE: i64 = 10_000;
+/// How often a stream's cached tombstone list is rebuilt from scratch so
+/// rows the control plane purged drop out of memory (incremental refreshes
+/// only ever append).
+const TOMBSTONE_REBUILD_EVERY: Duration = Duration::from_secs(300);
 /// Hard ceiling on from+size (ES max_result_window).
 const MAX_RESULT_WINDOW: usize = 10_000;
 /// Max splits one query may touch. A query over more than this (an
@@ -186,6 +190,8 @@ struct StreamTombstones {
     entries: Arc<Vec<Tombstone>>,
     /// None = explicitly invalidated (a local write); refresh on next use.
     fetched_at: Option<Instant>,
+    /// When the list was last loaded from scratch.
+    rebuilt_at: Instant,
 }
 
 struct SplitOutcome {
@@ -221,6 +227,10 @@ pub struct SearchService {
     streams: std::sync::Mutex<HashMap<String, (Arc<CachedStream>, Instant)>>,
     /// Stream id → tombstone list (document-mode streams only).
     tombstones: std::sync::Mutex<HashMap<i64, StreamTombstones>>,
+    /// Per-stream single-flight for tombstone refreshes, so N concurrent
+    /// queries after a TTL expiry (or a cold start) page the metastore
+    /// once, not N times.
+    tombstone_refresh: std::sync::Mutex<HashMap<i64, Arc<Mutex<()>>>>,
 }
 
 impl SearchService {
@@ -241,7 +251,14 @@ impl SearchService {
             opening: std::sync::Mutex::new(HashMap::new()),
             streams: std::sync::Mutex::new(HashMap::new()),
             tombstones: std::sync::Mutex::new(HashMap::new()),
+            tombstone_refresh: std::sync::Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Forget a cached stream record (after this node changed its mode or
+    /// mapping) so the next query re-reads it.
+    pub fn invalidate_stream(&self, name: &str) {
+        self.streams.lock().unwrap().remove(name);
     }
 
     /// Drop the freshness of a stream's cached tombstones so the next
@@ -254,31 +271,68 @@ impl SearchService {
     }
 
     /// The stream's tombstones, ascending by seq, extended from the
-    /// metastore when the cache is stale.
+    /// metastore when the cache is stale. Steady state costs one small
+    /// query per TTL (usually returning nothing, in which case the cached
+    /// list is reused untouched); every `TOMBSTONE_REBUILD_EVERY` the list
+    /// is reloaded from scratch so purged rows leave memory.
     async fn tombstones_for(&self, stream_id: i64) -> SearchResult<Arc<Vec<Tombstone>>> {
-        let cached = {
-            let map = self.tombstones.lock().unwrap();
-            map.get(&stream_id).map(|t| (t.entries.clone(), t.fetched_at))
+        let snapshot = |this: &Self| {
+            this.tombstones
+                .lock()
+                .unwrap()
+                .get(&stream_id)
+                .map(|t| (t.entries.clone(), t.fetched_at, t.rebuilt_at))
         };
-        if let Some((entries, Some(at))) = &cached
-            && at.elapsed() < TOMBSTONE_CACHE_TTL
+        let fresh = |fetched_at: Option<Instant>| {
+            fetched_at.is_some_and(|at| at.elapsed() < TOMBSTONE_CACHE_TTL)
+        };
+        if let Some((entries, fetched_at, _)) = snapshot(self)
+            && fresh(fetched_at)
+        {
+            return Ok(entries);
+        }
+        // Single-flight per stream.
+        let gate = self
+            .tombstone_refresh
+            .lock()
+            .unwrap()
+            .entry(stream_id)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        let _guard = gate.lock().await;
+        let cached = snapshot(self);
+        if let Some((entries, fetched_at, _)) = &cached
+            && fresh(*fetched_at)
         {
             return Ok(entries.clone());
         }
-        let mut entries: Vec<Tombstone> = cached
-            .map(|(e, _)| e.as_ref().clone())
-            .unwrap_or_default();
-        let mut after = entries.last().map(|t| t.seq).unwrap_or(0);
+        let rebuild = cached
+            .as_ref()
+            .is_none_or(|(_, _, rebuilt_at)| rebuilt_at.elapsed() >= TOMBSTONE_REBUILD_EVERY);
+        let (mut entries, mut after, rebuilt_at) = match (&cached, rebuild) {
+            (Some((entries, _, rebuilt_at)), false) => {
+                (None, entries.last().map(|t| t.seq).unwrap_or(0), *rebuilt_at)
+            }
+            _ => (Some(Vec::new()), 0, Instant::now()),
+        };
         loop {
             let page = self
                 .metastore
                 .tombstones_since(stream_id, after, TOMBSTONE_PAGE)
                 .await?;
             let done = (page.len() as i64) < TOMBSTONE_PAGE;
-            if let Some(last) = page.last() {
-                after = last.seq;
+            if page.is_empty() {
+                break;
             }
-            entries.extend(page.into_iter().map(|t| Tombstone {
+            after = page.last().map(|t| t.seq).unwrap_or(after);
+            // Clone the cached list only once something new arrived.
+            let list = entries.get_or_insert_with(|| {
+                cached
+                    .as_ref()
+                    .map(|(e, _, _)| e.as_ref().clone())
+                    .unwrap_or_default()
+            });
+            list.extend(page.into_iter().map(|t| Tombstone {
                 seq: t.seq,
                 doc_id: t.doc_id,
                 before_seq: t.before_seq,
@@ -287,7 +341,11 @@ impl SearchService {
                 break;
             }
         }
-        let entries = Arc::new(entries);
+        let entries = match entries {
+            Some(list) => Arc::new(list),
+            // Nothing new: keep the existing Arc.
+            None => cached.as_ref().map(|(e, _, _)| e.clone()).unwrap_or_default(),
+        };
         let mut map = self.tombstones.lock().unwrap();
         if map.len() > 10_000 {
             map.clear();
@@ -297,6 +355,7 @@ impl SearchService {
             StreamTombstones {
                 entries: entries.clone(),
                 fetched_at: Some(Instant::now()),
+                rebuilt_at,
             },
         );
         Ok(entries)
@@ -332,7 +391,15 @@ impl SearchService {
         Ok(cached)
     }
 
-    async fn reader(&self, split_id: &str, storage_key: &str) -> SearchResult<Arc<SplitReader>> {
+    /// Open (or reuse) a split's reader. `applied_through` is the split's
+    /// `tombstone_seq_applied`: a fresh reader starts there, so tombstones
+    /// compaction already made physical are never looked up again.
+    async fn reader(
+        &self,
+        split_id: &str,
+        storage_key: &str,
+        applied_through: i64,
+    ) -> SearchResult<Arc<SplitReader>> {
         if let Some(reader) = self.reader_shard(split_id).lock().unwrap().get(split_id) {
             return Ok(reader.clone());
         }
@@ -353,7 +420,10 @@ impl SearchService {
         // otherwise leak it forever (one map entry per failing split id).
         let opened = SplitReader::open(self.storage.clone(), storage_key, self.cache.clone()).await;
         let reader = match opened {
-            Ok(reader) => Arc::new(reader),
+            Ok(reader) => {
+                reader.seed_applied_through(applied_through);
+                Arc::new(reader)
+            }
             Err(e) => {
                 self.opening.lock().unwrap().remove(split_id);
                 return Err(e.into());
@@ -374,29 +444,51 @@ impl SearchService {
     /// an ingest buffer is not visible yet (use `?refresh=wait_for` on the
     /// write when a read-after-write must see it).
     pub async fn get_document(&self, stream: &str, id: &str) -> SearchResult<Option<FoundDocument>> {
+        let mut found = self.get_documents(stream, std::slice::from_ref(&id.to_string())).await?;
+        Ok(found.remove(id))
+    }
+
+    /// Look up many documents by `_id` in a few searches (one `ids` query
+    /// per chunk of ids) — the newest live version of each id found.
+    pub async fn get_documents(
+        &self,
+        stream: &str,
+        ids: &[String],
+    ) -> SearchResult<HashMap<String, FoundDocument>> {
         // Several live versions of one id can only coexist transiently
-        // (same-instant writes on different nodes); take the newest.
-        let request = SearchRequest {
-            stream: stream.to_string(),
-            query: json!({"ids": {"values": [id]}}),
-            from: 0,
-            size: 16,
-            sort_desc: true,
-            aggs: None,
-            include_source: true,
-            track_total_hits: Some(0),
-        };
-        let response = self.search(request).await?;
-        let best = response["hits"]["hits"]
-            .as_array()
-            .into_iter()
-            .flatten()
-            .filter(|hit| hit["_id"].as_str() == Some(id))
-            .max_by_key(|hit| hit["_version"].as_i64().unwrap_or(0));
-        Ok(best.map(|hit| FoundDocument {
-            version: hit["_version"].as_i64().unwrap_or(0),
-            source: hit["_source"].clone(),
-        }))
+        // (same-instant writes on different nodes); the newest wins. The
+        // page leaves headroom for those duplicates within the result
+        // window.
+        const CHUNK: usize = 1_000;
+        let mut out: HashMap<String, FoundDocument> = HashMap::new();
+        for chunk in ids.chunks(CHUNK) {
+            let request = SearchRequest {
+                stream: stream.to_string(),
+                query: json!({"ids": {"values": chunk}}),
+                from: 0,
+                size: MAX_RESULT_WINDOW,
+                sort_desc: true,
+                aggs: None,
+                include_source: true,
+                track_total_hits: Some(0),
+            };
+            let response = self.search(request).await?;
+            for hit in response["hits"]["hits"].as_array().into_iter().flatten() {
+                let Some(id) = hit["_id"].as_str() else { continue };
+                let version = hit["_version"].as_i64().unwrap_or(0);
+                let newer = out.get(id).is_none_or(|cur| version > cur.version);
+                if newer {
+                    out.insert(
+                        id.to_string(),
+                        FoundDocument {
+                            version,
+                            source: hit["_source"].clone(),
+                        },
+                    );
+                }
+            }
+        }
+        Ok(out)
     }
 
     /// Execute a search and return the full ES-shaped response body.
@@ -470,6 +562,7 @@ impl SearchService {
                 let counted = counted.clone();
                 let split_id = split.split_id.clone();
                 let storage_key = split.storage_key.clone();
+                let applied_through = split.tombstone_seq_applied;
                 let doc_count = split.doc_count as usize;
                 // Only splits that carry ids (seq_min known) can hold a
                 // tombstoned version.
@@ -483,7 +576,7 @@ impl SearchService {
                     && t_start.map(|s| split.time_start_millis >= s).unwrap_or(true)
                     && t_end.map(|e| split.time_end_millis <= e).unwrap_or(true);
                 async move {
-                    let reader = this.reader(&split_id, &storage_key).await?;
+                    let reader = this.reader(&split_id, &storage_key, applied_through).await?;
                     let skip_count = match track {
                         Some(cap) => counted.load(Ordering::Relaxed) >= cap,
                         None => false,
@@ -641,7 +734,9 @@ impl SearchService {
                 let this = &*self;
                 let split = &splits[split_idx];
                 async move {
-                    let reader = this.reader(&split.split_id, &split.storage_key).await?;
+                    let reader = this
+                        .reader(&split.split_id, &split.storage_key, split.tombstone_seq_applied)
+                        .await?;
                     tokio::task::spawn_blocking(move || {
                         let searcher = reader.searcher()?;
                         let schema = reader.mapped_schema();

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -62,6 +62,15 @@ const MAX_RESULT_WINDOW: usize = 10_000;
 /// scheduling a search on each.
 const MAX_QUERY_SPLITS: usize = 10_000;
 
+/// A document found by `_id` (see `SearchService::get_document`).
+#[derive(Debug, Clone)]
+pub struct FoundDocument {
+    /// The document's `_seq` (reported as `_version`).
+    pub version: i64,
+    /// Its `_source`.
+    pub source: Value,
+}
+
 /// A parsed `_search` request body.
 pub struct SearchRequest {
     /// Stream (index) the search runs against.
@@ -358,6 +367,36 @@ impl SearchService {
             .put(split_id.to_string(), reader.clone());
         self.opening.lock().unwrap().remove(split_id);
         Ok(reader)
+    }
+
+    /// Look a document up by `_id`: the newest live version (tombstones
+    /// applied), or None. Reads published splits only — a write still in
+    /// an ingest buffer is not visible yet (use `?refresh=wait_for` on the
+    /// write when a read-after-write must see it).
+    pub async fn get_document(&self, stream: &str, id: &str) -> SearchResult<Option<FoundDocument>> {
+        // Several live versions of one id can only coexist transiently
+        // (same-instant writes on different nodes); take the newest.
+        let request = SearchRequest {
+            stream: stream.to_string(),
+            query: json!({"ids": {"values": [id]}}),
+            from: 0,
+            size: 16,
+            sort_desc: true,
+            aggs: None,
+            include_source: true,
+            track_total_hits: Some(0),
+        };
+        let response = self.search(request).await?;
+        let best = response["hits"]["hits"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|hit| hit["_id"].as_str() == Some(id))
+            .max_by_key(|hit| hit["_version"].as_i64().unwrap_or(0));
+        Ok(best.map(|hit| FoundDocument {
+            version: hit["_version"].as_i64().unwrap_or(0),
+            source: hit["_source"].clone(),
+        }))
     }
 
     /// Execute a search and return the full ES-shaped response body.

--- a/crates/rsearch-search/src/lib.rs
+++ b/crates/rsearch-search/src/lib.rs
@@ -8,5 +8,5 @@ pub mod logql;
 mod query_dsl;
 
 pub use error::{SearchError, SearchResult};
-pub use executor::{SearchRequest, SearchService};
+pub use executor::{FoundDocument, SearchRequest, SearchService};
 pub use query_dsl::{extract_time_bounds, rewrite_agg_fields, translate_query};

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -37,6 +37,19 @@ fn resolve(schema: &MappedSchema, name: &str) -> Resolved {
     if let Some((field, ty)) = schema.fields.get(name) {
         return Resolved::Typed(*field, *ty);
     }
+    // Reserved identity fields: keyword `_id`, numeric `_seq`. A legacy
+    // split (no such fields) falls through to a `_dynamic` path that no
+    // document has, so the clause simply matches nothing there.
+    if name == rsearch_index::ID_FIELD
+        && let Some(field) = schema.id
+    {
+        return Resolved::Typed(field, FieldType::Keyword);
+    }
+    if name == rsearch_index::SEQ_FIELD
+        && let Some(field) = schema.seq
+    {
+        return Resolved::Typed(field, FieldType::Long);
+    }
     Resolved::Dynamic(schema.dynamic, name.to_string())
 }
 
@@ -260,6 +273,7 @@ pub fn translate_query(
         "bool" => translate_bool(index, schema, body),
         "term" => translate_term(schema, body),
         "terms" => translate_terms(schema, body),
+        "ids" => translate_ids(schema, body),
         "range" => translate_range(schema, body),
         "exists" => translate_exists(schema, body),
         "match" => translate_match(index, schema, body, false),
@@ -267,7 +281,7 @@ pub fn translate_query(
         "query_string" => translate_query_string(index, schema, body),
         other => Err(SearchError::BadRequest(format!(
             "unsupported query type '{other}' (supported: match_all, bool, term, terms, \
-             range, exists, match, match_phrase, query_string)"
+             ids, range, exists, match, match_phrase, query_string)"
         ))),
     }
 }
@@ -398,6 +412,21 @@ fn translate_term(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn Q
         .ok_or_else(|| SearchError::BadRequest("term query needs a field".into()))?;
     let value = spec.get("value").unwrap_or(spec);
     term_query_for(schema, name, value)
+}
+
+/// `{"ids": {"values": ["a", "b"]}}` — documents whose `_id` is listed.
+fn translate_ids(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn Query>> {
+    let values = body
+        .get("values")
+        .and_then(Value::as_array)
+        .ok_or_else(|| SearchError::BadRequest("ids query needs a 'values' array".into()))?;
+    let clauses: Vec<(Occur, Box<dyn Query>)> = values
+        .iter()
+        .map(|v| {
+            term_query_for(schema, rsearch_index::ID_FIELD, v).map(|q| (Occur::Should, q))
+        })
+        .collect::<SearchResult<_>>()?;
+    Ok(Box::new(BooleanQuery::new(clauses)))
 }
 
 fn translate_terms(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn Query>> {

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -414,12 +414,21 @@ fn translate_term(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn Q
     term_query_for(schema, name, value)
 }
 
+/// Cap on `ids.values` (ES's default `max_terms_count` is 65536; a bulk
+/// lookup chunks at 1000).
+const MAX_IDS_VALUES: usize = 10_000;
+
 /// `{"ids": {"values": ["a", "b"]}}` — documents whose `_id` is listed.
 fn translate_ids(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn Query>> {
     let values = body
         .get("values")
         .and_then(Value::as_array)
         .ok_or_else(|| SearchError::BadRequest("ids query needs a 'values' array".into()))?;
+    if values.len() > MAX_IDS_VALUES {
+        return Err(SearchError::BadRequest(format!(
+            "ids query accepts at most {MAX_IDS_VALUES} values"
+        )));
+    }
     let clauses: Vec<(Occur, Box<dyn Query>)> = values
         .iter()
         .map(|v| {

--- a/crates/rsearch-server/src/admin_api.rs
+++ b/crates/rsearch-server/src/admin_api.rs
@@ -30,6 +30,7 @@ pub async fn cat_indices(State(state): State<AppState>) -> Response {
                         "store.size": format!("{}kb", s.size_bytes / 1024),
                         "splits": s.split_count,
                         "retention_hours": s.retention_hours,
+                        "mode": s.mode,
                     })
                 })
                 .collect::<Vec<_>>(),

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -179,6 +179,15 @@ fn classify(method: &str, path: &str) -> Action {
         // Ingest
         ("POST", ["_bulk"]) => Action::Ingest(None),
         ("POST", [index, "_bulk"]) => Action::Ingest(Some(index.to_string())),
+        // Document APIs (#34): writes are stream-scoped ingest, reads are
+        // stream-scoped search — so an application key never needs admin.
+        ("PUT" | "POST" | "DELETE", [index, "_doc", ..])
+        | ("PUT" | "POST", [index, "_create", _])
+        | ("POST", [index, "_update", _])
+        | ("POST", [index, "_delete_by_query"]) => Action::Ingest(Some(index.to_string())),
+        ("GET" | "HEAD", [index, "_doc", _]) | ("GET", [index, "_source", _]) => {
+            Action::Search(Some(index.to_string()))
+        }
         // Search / read
         (_, [index, "_search"]) => Action::Search(Some(index.to_string())),
         ("POST", ["_msearch"]) => Action::Search(None),
@@ -444,6 +453,19 @@ mod tests {
             classify("GET", "/app-logs/_settings"),
             Action::Search(Some("app-logs".into()))
         );
+        // Document APIs.
+        assert_eq!(classify("PUT", "/recs/_doc/1"), Action::Ingest(Some("recs".into())));
+        assert_eq!(classify("POST", "/recs/_doc"), Action::Ingest(Some("recs".into())));
+        assert_eq!(classify("DELETE", "/recs/_doc/1"), Action::Ingest(Some("recs".into())));
+        assert_eq!(classify("POST", "/recs/_update/1"), Action::Ingest(Some("recs".into())));
+        assert_eq!(classify("PUT", "/recs/_create/1"), Action::Ingest(Some("recs".into())));
+        assert_eq!(
+            classify("POST", "/recs/_delete_by_query"),
+            Action::Ingest(Some("recs".into()))
+        );
+        assert_eq!(classify("GET", "/recs/_doc/1"), Action::Search(Some("recs".into())));
+        assert_eq!(classify("HEAD", "/recs/_doc/1"), Action::Search(Some("recs".into())));
+        assert_eq!(classify("GET", "/recs/_source/1"), Action::Search(Some("recs".into())));
         // Reserved top-level paths never fall into the index arms.
         assert_eq!(classify("PUT", "/_rsearch"), Action::Admin);
         assert_eq!(classify("GET", "/_rsearch"), Action::Admin);

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -182,11 +182,24 @@ fn classify(method: &str, path: &str) -> Action {
         // Search / read
         (_, [index, "_search"]) => Action::Search(Some(index.to_string())),
         ("POST", ["_msearch"]) => Action::Search(None),
-        ("GET", [index, "_mapping"]) => Action::Search(Some(index.to_string())),
+        ("GET", [index, "_mapping"]) | ("GET", [index, "_settings"]) => {
+            Action::Search(Some(index.to_string()))
+        }
+
         ("GET", ["_cat", ..]) | ("GET", ["_rsearch", "stats"]) => Action::Search(None),
         // Prometheus scrape — same read level as stats; scrape configs
         // pass a session or API-key token as a bearer credential.
         ("GET", ["metrics"]) => Action::Search(None),
+        // Single-segment index paths, after every reserved top-level route
+        // above. Index creation / mapping update is an ingest-level action:
+        // an ingest key scoped to a stream already creates it implicitly
+        // via _bulk, so PUT /{index} (mode + mapping) needs no more.
+        ("PUT", [index]) if !index.starts_with('_') => {
+            Action::Ingest(Some(index.to_string()))
+        }
+        ("GET" | "HEAD", [index]) if !index.starts_with('_') => {
+            Action::Search(Some(index.to_string()))
+        }
         // Everything else that mutates: admin.
         _ => Action::Admin,
     }
@@ -422,7 +435,19 @@ mod tests {
         assert_eq!(classify("GET", "/loki/api/v1/tail"), Action::Search(None));
         assert_eq!(classify("GET", "/loki/api/v1/index/volume"), Action::Search(None));
         assert_eq!(classify("GET", "/ready"), Action::Open);
-        assert_eq!(classify("PUT", "/app-logs"), Action::Admin);
+        // Index create/describe are stream-scoped ingest/search actions so
+        // an application can hold a least-privilege key (#34).
+        assert_eq!(classify("PUT", "/app-logs"), Action::Ingest(Some("app-logs".into())));
+        assert_eq!(classify("GET", "/app-logs"), Action::Search(Some("app-logs".into())));
+        assert_eq!(classify("HEAD", "/app-logs"), Action::Search(Some("app-logs".into())));
+        assert_eq!(
+            classify("GET", "/app-logs/_settings"),
+            Action::Search(Some("app-logs".into()))
+        );
+        // Reserved top-level paths never fall into the index arms.
+        assert_eq!(classify("PUT", "/_rsearch"), Action::Admin);
+        assert_eq!(classify("GET", "/_rsearch"), Action::Admin);
+        assert_eq!(classify("GET", "/metrics"), Action::Search(None));
         assert_eq!(classify("PUT", "/_rsearch/users/alice"), Action::Admin);
         assert_eq!(
             classify("PUT", "/_rsearch/routing_rules/x"),

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -19,22 +19,46 @@ use tracing::warn;
 
 use crate::state::AppState;
 
-pub async fn bulk_root(State(state): State<AppState>, body: String) -> Response {
-    handle_bulk(state, None, body).await
+/// `?refresh=` on `_bulk` and the document routes: `true` / `wait_for`
+/// (treated alike — both wait until the written documents are searchable)
+/// or `false` / absent. Only document-mode streams honor it; log streams
+/// ignore it so a shipper that sets it can't force a split per request.
+pub fn parse_refresh(value: Option<&str>) -> bool {
+    matches!(value, Some("true") | Some("wait_for") | Some(""))
+}
+
+#[derive(serde::Deserialize, Default)]
+pub struct BulkQuery {
+    refresh: Option<String>,
+}
+
+pub async fn bulk_root(
+    State(state): State<AppState>,
+    Query(query): Query<BulkQuery>,
+    body: String,
+) -> Response {
+    handle_bulk(state, None, body, parse_refresh(query.refresh.as_deref())).await
 }
 
 pub async fn bulk_index(
     State(state): State<AppState>,
     Path(index): Path<String>,
+    Query(query): Query<BulkQuery>,
     body: String,
 ) -> Response {
-    handle_bulk(state, Some(index), body).await
+    handle_bulk(state, Some(index), body, parse_refresh(query.refresh.as_deref())).await
 }
 
 #[derive(serde::Deserialize)]
 pub struct InternalBulkQuery {
     index: Option<String>,
+    refresh: Option<String>,
 }
+
+/// How long a refresh waits for the cut split to publish before the
+/// response goes out anyway (the documents are WAL-durable and will
+/// appear; a storage/metastore outage must not hang the client forever).
+const REFRESH_WAIT_LIMIT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Receive a batch handed off by a peer (#19). Authenticated by the
 /// cluster token like the internal object API; always indexes locally —
@@ -64,14 +88,20 @@ pub async fn bulk_internal(
         );
     }
     forwarder.received.fetch_add(1, Ordering::Relaxed);
-    match handle_bulk_local(state, query.index, body).await {
+    let refresh = parse_refresh(query.refresh.as_deref());
+    match handle_bulk_local(state, query.index, body, refresh).await {
         Ok(result) => Json(result).into_response(),
         Err(response) => response,
     }
 }
 
-async fn handle_bulk(state: AppState, default_index: Option<String>, body: String) -> Response {
-    match execute_bulk(state, default_index, body).await {
+async fn handle_bulk(
+    state: AppState,
+    default_index: Option<String>,
+    body: String,
+    refresh: bool,
+) -> Response {
+    match execute_bulk(state, default_index, body, refresh).await {
         Ok(result) => Json(result).into_response(),
         Err(response) => response,
     }
@@ -85,6 +115,7 @@ pub async fn execute_bulk(
     state: AppState,
     default_index: Option<String>,
     body: String,
+    refresh: bool,
 ) -> Result<Value, Response> {
     if state.draining.load(Ordering::Relaxed) {
         // Draining: refuse new writes so the WAL empties out before
@@ -109,7 +140,7 @@ pub async fn execute_bulk(
         && let Some((peer_id, peer_addr)) = forwarder.pick_target().await
     {
         match forwarder
-            .forward(&peer_addr, default_index.as_deref(), body.clone().into())
+            .forward(&peer_addr, default_index.as_deref(), refresh, body.clone().into())
             .await
         {
             // Relay only a peer 2xx (its per-item results). Anything else
@@ -138,7 +169,7 @@ pub async fn execute_bulk(
             }
         }
     }
-    handle_bulk_local(state, default_index, body).await
+    handle_bulk_local(state, default_index, body, refresh).await
 }
 
 /// Reason given when `delete`/`update` hit a log-mode stream.
@@ -276,6 +307,7 @@ async fn handle_bulk_local(
     state: AppState,
     default_index: Option<String>,
     body: String,
+    refresh: bool,
 ) -> Result<Value, Response> {
     let started = Instant::now();
     let Some(pipeline) = state.pipeline.clone() else {
@@ -615,6 +647,8 @@ async fn handle_bulk_local(
     // Enqueue each routed copy; an item succeeds if at least one route
     // was accepted. Saturated routes get confirmed so the WAL drains.
     let mut position_iter = positions.into_iter();
+    // Document-mode streams that received a write, for ?refresh.
+    let mut to_refresh: Vec<String> = Vec::new();
     for plan in writes {
         let action = plan.wire_action;
         let stream_name = &plan.item.stream;
@@ -634,7 +668,15 @@ async fn handle_bulk_local(
                 .enqueue(stream, plan.item.raw.clone(), identity, pos)
                 .await
             {
-                Ok(()) => accepted += 1,
+                Ok(()) => {
+                    accepted += 1;
+                    if refresh
+                        && infos.get(stream).is_some_and(|i| i.mode == StreamMode::Document)
+                        && !to_refresh.contains(stream)
+                    {
+                        to_refresh.push(stream.clone());
+                    }
+                }
                 Err(IngestError::Saturated) => {
                     pipeline.wal().confirm(&[pos]);
                     saturated = true;
@@ -672,6 +714,26 @@ async fn handle_bulk_local(
         });
     }
     results.sort_by_key(|r| r.position);
+
+    // ?refresh: cut the written streams' batches now and wait (bounded)
+    // until they are published, so a search right after this response
+    // sees the documents.
+    if !to_refresh.is_empty() {
+        let wait = async {
+            for stream in &to_refresh {
+                if let Err(e) = pipeline.flush_stream(stream).await {
+                    warn!(stream, error = %e, "refresh flush failed");
+                }
+            }
+        };
+        if tokio::time::timeout(REFRESH_WAIT_LIMIT, wait).await.is_err() {
+            warn!(
+                streams = ?to_refresh,
+                "refresh wait exceeded {}s; responding without it",
+                REFRESH_WAIT_LIMIT.as_secs()
+            );
+        }
+    }
 
     let errors = results.iter().any(|r| {
         r.body

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
@@ -9,7 +10,10 @@ use serde_json::{Value, json};
 
 use rsearch_common::crypto;
 use rsearch_index::DocIdentity;
-use rsearch_ingest::{BulkParseOutcome, IngestError, WalItem, parse_bulk_body};
+use rsearch_ingest::{
+    BulkAction, BulkParseOutcome, IngestError, StreamInfo, WalItem, parse_bulk_body,
+};
+use rsearch_metastore::{NewTombstone, StreamMode};
 use rsearch_storage::INTERNAL_TOKEN_HEADER;
 use tracing::warn;
 
@@ -117,6 +121,46 @@ async fn handle_bulk(state: AppState, default_index: Option<String>, body: Strin
     handle_bulk_local(state, default_index, body).await
 }
 
+/// Reason given when `delete`/`update` hit a log-mode stream.
+fn log_mode_reason(action: &str, stream: &str) -> String {
+    format!(
+        "{action} is not supported on log-mode index [{stream}]; create the index with \
+         {{\"settings\":{{\"index\":{{\"mode\":\"document\"}}}}}} to enable \
+         document-level writes"
+    )
+}
+
+/// One per-item outcome, positioned for the response.
+struct ItemResult {
+    position: usize,
+    body: Value,
+}
+
+fn item_ok(action: &str, index: &str, id: &str, version: i64, result: &str, status: u16) -> Value {
+    json!({
+        action: {
+            "_index": index,
+            "_id": id,
+            "_version": version,
+            "result": result,
+            "status": status,
+            "_shards": {"total": 1, "successful": 1, "failed": 0},
+        }
+    })
+}
+
+fn item_err(action: &str, index: &str, id: Option<&str>, status: u16, error_type: &str, reason: &str) -> Value {
+    let mut body = json!({
+        "_index": index,
+        "status": status,
+        "error": {"type": error_type, "reason": reason},
+    });
+    if let Some(id) = id {
+        body["_id"] = json!(id);
+    }
+    json!({ action: body })
+}
+
 async fn handle_bulk_local(
     state: AppState,
     default_index: Option<String>,
@@ -137,73 +181,207 @@ async fn handle_bulk_local(
     if outcome.total == 0 {
         return error_response(StatusCode::BAD_REQUEST, "empty bulk body");
     }
-
-    // Routing expansion, then the durability point: append every routed
-    // copy to the WAL with a single fsync.
     let BulkParseOutcome {
         items, rejections, ..
     } = outcome;
-    // Each item takes one write-sequence stamp, shared by all its routed
-    // copies, so the WAL, the split, and the bulk response agree on it.
-    let expanded: Vec<(usize, rsearch_ingest::BulkItem, Vec<String>, i64)> = items
+    let mut results: Vec<ItemResult> = rejections
         .into_iter()
-        .map(|(position, item)| {
-            let routes = pipeline.expand_routes(&item.stream, &item.doc);
-            let seq = pipeline.next_seq();
-            (position, item, routes, seq)
+        .map(|(position, action, index, reason)| ItemResult {
+            position,
+            body: item_err(&action, &index, None, 400, "illegal_argument_exception", &reason),
         })
         .collect();
+
+    // Routing expansion + one write-sequence stamp per item (shared by all
+    // its routed copies, so the WAL, the split, and the response agree).
+    // Deletes route nowhere: they target exactly the named stream.
+    struct Planned {
+        position: usize,
+        item: rsearch_ingest::BulkItem,
+        routes: Vec<String>,
+        seq: i64,
+    }
+    let mut planned: Vec<Planned> = Vec::with_capacity(items.len());
+    for (position, item) in items {
+        let routes = match item.action {
+            BulkAction::Index | BulkAction::Create => {
+                pipeline.expand_routes(&item.stream, &item.doc)
+            }
+            BulkAction::Update | BulkAction::Delete => vec![item.stream.clone()],
+        };
+        planned.push(Planned {
+            position,
+            item,
+            routes,
+            seq: pipeline.next_seq(),
+        });
+    }
+
+    // Resolve every target stream's id + mode (creating missing streams,
+    // as _bulk always has). Document-mode targets get tombstones.
+    let mut infos: HashMap<String, StreamInfo> = HashMap::new();
+    for plan in &planned {
+        for stream in &plan.routes {
+            if infos.contains_key(stream) {
+                continue;
+            }
+            match pipeline.stream_info(stream).await {
+                Ok(info) => {
+                    infos.insert(stream.clone(), info);
+                }
+                Err(e) => {
+                    return error_response(
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        &format!("metastore unavailable: {e}"),
+                    );
+                }
+            }
+        }
+    }
+
+    // Tombstones are written before anything is WAL-appended: a crash
+    // between the two can lose an unacked write (the client retries), but
+    // never leaves a replayed document without the tombstone that hides
+    // its predecessors.
+    let mut tombstones: Vec<NewTombstone> = Vec::new();
+    let mut writes: Vec<&Planned> = Vec::new();
+    for plan in &planned {
+        let action = plan.item.action.as_str();
+        match plan.item.action {
+            BulkAction::Index | BulkAction::Create => {
+                if plan.item.explicit_id {
+                    for stream in &plan.routes {
+                        if let Some(info) = infos.get(stream)
+                            && info.mode == StreamMode::Document
+                        {
+                            tombstones.push(NewTombstone {
+                                stream_id: info.id,
+                                doc_id: plan.item.doc_id.clone(),
+                                before_seq: plan.seq,
+                            });
+                        }
+                    }
+                }
+                writes.push(plan);
+            }
+            BulkAction::Delete => match infos.get(&plan.item.stream) {
+                Some(info) if info.mode == StreamMode::Document => {
+                    tombstones.push(NewTombstone {
+                        stream_id: info.id,
+                        doc_id: plan.item.doc_id.clone(),
+                        before_seq: plan.seq,
+                    });
+                    results.push(ItemResult {
+                        position: plan.position,
+                        body: item_ok(action, &plan.item.stream, &plan.item.doc_id, plan.seq, "deleted", 200),
+                    });
+                }
+                _ => results.push(ItemResult {
+                    position: plan.position,
+                    body: item_err(
+                        action,
+                        &plan.item.stream,
+                        Some(&plan.item.doc_id),
+                        400,
+                        "illegal_argument_exception",
+                        &log_mode_reason(action, &plan.item.stream),
+                    ),
+                }),
+            },
+            BulkAction::Update => results.push(ItemResult {
+                position: plan.position,
+                body: item_err(
+                    action,
+                    &plan.item.stream,
+                    Some(&plan.item.doc_id),
+                    400,
+                    "illegal_argument_exception",
+                    &match infos.get(&plan.item.stream) {
+                        Some(info) if info.mode == StreamMode::Document => {
+                            "update is not supported in _bulk yet".to_string()
+                        }
+                        _ => log_mode_reason(action, &plan.item.stream),
+                    },
+                ),
+            }),
+        }
+    }
+    if !tombstones.is_empty() {
+        if let Err(e) = state.metastore.upsert_tombstones(&tombstones).await {
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                &format!("metastore unavailable (tombstones): {e}"),
+            );
+        }
+        // A search immediately after this write on this node must see it.
+        if let Some(search) = &state.search {
+            let mut seen = std::collections::HashSet::new();
+            for t in &tombstones {
+                if seen.insert(t.stream_id) {
+                    search.invalidate_tombstones(t.stream_id);
+                }
+            }
+        }
+    }
+
+    // The durability point: append every routed copy to the WAL with a
+    // single fsync.
     let wal = pipeline.wal().clone();
-    let wal_items: Vec<WalItem> = expanded
+    let wal_items: Vec<WalItem> = writes
         .iter()
-        .flat_map(|(_, item, routes, seq)| {
+        .flat_map(|plan| {
             // WAL payload = the client's original line bytes (no
             // re-serialize, no byte copy — the Arc is shared).
-            routes.iter().map(move |stream| WalItem {
+            plan.routes.iter().map(move |stream| WalItem {
                 stream: stream.clone(),
-                id: item.doc_id.clone(),
-                seq: *seq,
-                doc: item.raw.clone(),
+                id: plan.item.doc_id.clone(),
+                seq: plan.seq,
+                doc: plan.item.raw.clone(),
             })
         })
         .collect();
-    let positions = match tokio::task::spawn_blocking(move || wal.append_batch(&wal_items)).await {
-        Ok(Ok(positions)) => positions,
-        Ok(Err(e)) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("wal append failed: {e}"),
-            );
-        }
-        Err(e) => {
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                &format!("wal task failed: {e}"),
-            );
+    let positions = if wal_items.is_empty() {
+        Vec::new()
+    } else {
+        match tokio::task::spawn_blocking(move || wal.append_batch(&wal_items)).await {
+            Ok(Ok(positions)) => positions,
+            Ok(Err(e)) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("wal append failed: {e}"),
+                );
+            }
+            Err(e) => {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("wal task failed: {e}"),
+                );
+            }
         }
     };
 
     // Enqueue each routed copy; an item succeeds if at least one route
     // was accepted. Saturated routes get confirmed so the WAL drains.
-    let mut responses: Vec<(usize, Value)> = Vec::new();
     let mut position_iter = positions.into_iter();
-    for (position, item, routes, seq) in expanded {
-        let action = item.action.as_str();
-        let stream_name = item.stream;
-        let doc_id = item.doc_id;
-        let raw = item.raw;
+    for plan in writes {
+        let action = plan.item.action.as_str();
+        let stream_name = &plan.item.stream;
+        let doc_id = &plan.item.doc_id;
         let mut accepted = 0usize;
         let mut saturated = false;
         let mut internal_error: Option<String> = None;
-        for stream in routes.iter() {
+        for stream in plan.routes.iter() {
             // One WAL position exists per routed copy by construction; if
             // a refactor ever breaks that, fail the item — not the process.
             let Some(pos) = position_iter.next() else {
                 internal_error = Some("internal: missing WAL position for routed copy".into());
                 break;
             };
-            let identity = DocIdentity::new(doc_id.clone(), seq);
-            match pipeline.enqueue(stream, raw.clone(), identity, pos).await {
+            let identity = DocIdentity::new(doc_id.clone(), plan.seq);
+            match pipeline
+                .enqueue(stream, plan.item.raw.clone(), identity, pos)
+                .await
+            {
                 Ok(()) => accepted += 1,
                 Err(IngestError::Saturated) => {
                     pipeline.wal().confirm(&[pos]);
@@ -215,67 +393,55 @@ async fn handle_bulk_local(
                 }
             }
         }
-        let entry = if accepted > 0 {
-            json!({
-                action: {
-                    "_index": stream_name,
-                    "_id": doc_id,
-                    "_version": seq,
-                    "result": "created",
-                    "status": 201,
-                    "_shards": {"total": 1, "successful": 1, "failed": 0},
-                }
-            })
+        let body = if accepted > 0 {
+            // ES reports "updated" for an index that replaced a document;
+            // an explicit id on a document-mode stream may have, and the
+            // cheap honest answer without a lookup is "created" for fresh
+            // ids and "updated" for explicit ones (the tombstone covers
+            // both cases).
+            let replaced = plan.item.explicit_id
+                && plan.item.action == BulkAction::Index
+                && infos
+                    .get(stream_name)
+                    .is_some_and(|i| i.mode == StreamMode::Document);
+            let (result, status) = if replaced { ("updated", 200) } else { ("created", 201) };
+            item_ok(action, stream_name, doc_id, plan.seq, result, status)
         } else if saturated {
-            json!({
-                action: {
-                    "_index": stream_name,
-                    "_id": doc_id,
-                    "status": 429,
-                    "error": {
-                        "type": "es_rejected_execution_exception",
-                        "reason": "ingest queue is full; retry with backoff",
-                    }
-                }
-            })
+            item_err(
+                action,
+                stream_name,
+                Some(doc_id),
+                429,
+                "es_rejected_execution_exception",
+                "ingest queue is full; retry with backoff",
+            )
         } else {
-            json!({
-                action: {
-                    "_index": stream_name,
-                    "_id": doc_id,
-                    "status": 500,
-                    "error": {
-                        "type": "internal_error",
-                        "reason": internal_error.unwrap_or_else(|| "no route accepted".into()),
-                    },
-                }
-            })
+            item_err(
+                action,
+                stream_name,
+                Some(doc_id),
+                500,
+                "internal_error",
+                &internal_error.unwrap_or_else(|| "no route accepted".into()),
+            )
         };
-        responses.push((position, entry));
+        results.push(ItemResult {
+            position: plan.position,
+            body,
+        });
     }
-    for (position, action, index, reason) in rejections {
-        responses.push((
-            position,
-            json!({
-                action: {
-                    "_index": index,
-                    "status": 400,
-                    "error": {"type": "illegal_argument_exception", "reason": reason},
-                }
-            }),
-        ));
-    }
-    responses.sort_by_key(|(position, _)| *position);
+    results.sort_by_key(|r| r.position);
 
-    let errors = responses.iter().any(|(_, item)| {
-        item.as_object()
+    let errors = results.iter().any(|r| {
+        r.body
+            .as_object()
             .and_then(|o| o.values().next())
             .and_then(|v| v.get("status"))
             .and_then(Value::as_i64)
             .map(|s| s >= 300)
             .unwrap_or(true)
     });
-    let items: Vec<Value> = responses.into_iter().map(|(_, item)| item).collect();
+    let items: Vec<Value> = results.into_iter().map(|r| r.body).collect();
     Json(json!({
         "took": started.elapsed().as_millis() as u64,
         "errors": errors,

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -8,7 +8,8 @@ use axum::Json;
 use serde_json::{Value, json};
 
 use rsearch_common::crypto;
-use rsearch_ingest::{BulkParseOutcome, IngestError, parse_bulk_body};
+use rsearch_index::DocIdentity;
+use rsearch_ingest::{BulkParseOutcome, IngestError, WalItem, parse_bulk_body};
 use rsearch_storage::INTERNAL_TOKEN_HEADER;
 use tracing::warn;
 
@@ -142,22 +143,28 @@ async fn handle_bulk_local(
     let BulkParseOutcome {
         items, rejections, ..
     } = outcome;
-    let expanded: Vec<(usize, rsearch_ingest::BulkItem, Vec<String>)> = items
+    // Each item takes one write-sequence stamp, shared by all its routed
+    // copies, so the WAL, the split, and the bulk response agree on it.
+    let expanded: Vec<(usize, rsearch_ingest::BulkItem, Vec<String>, i64)> = items
         .into_iter()
         .map(|(position, item)| {
             let routes = pipeline.expand_routes(&item.stream, &item.doc);
-            (position, item, routes)
+            let seq = pipeline.next_seq();
+            (position, item, routes, seq)
         })
         .collect();
     let wal = pipeline.wal().clone();
-    let wal_items: Vec<(String, std::sync::Arc<str>)> = expanded
+    let wal_items: Vec<WalItem> = expanded
         .iter()
-        .flat_map(|(_, item, routes)| {
+        .flat_map(|(_, item, routes, seq)| {
             // WAL payload = the client's original line bytes (no
             // re-serialize, no byte copy — the Arc is shared).
-            routes
-                .iter()
-                .map(move |stream| (stream.clone(), item.raw.clone()))
+            routes.iter().map(move |stream| WalItem {
+                stream: stream.clone(),
+                id: item.doc_id.clone(),
+                seq: *seq,
+                doc: item.raw.clone(),
+            })
         })
         .collect();
     let positions = match tokio::task::spawn_blocking(move || wal.append_batch(&wal_items)).await {
@@ -180,7 +187,7 @@ async fn handle_bulk_local(
     // was accepted. Saturated routes get confirmed so the WAL drains.
     let mut responses: Vec<(usize, Value)> = Vec::new();
     let mut position_iter = positions.into_iter();
-    for (position, item, routes) in expanded {
+    for (position, item, routes, seq) in expanded {
         let action = item.action.as_str();
         let stream_name = item.stream;
         let doc_id = item.doc_id;
@@ -195,7 +202,8 @@ async fn handle_bulk_local(
                 internal_error = Some("internal: missing WAL position for routed copy".into());
                 break;
             };
-            match pipeline.enqueue(stream, raw.clone(), pos).await {
+            let identity = DocIdentity::new(doc_id.clone(), seq);
+            match pipeline.enqueue(stream, raw.clone(), identity, pos).await {
                 Ok(()) => accepted += 1,
                 Err(IngestError::Saturated) => {
                     pipeline.wal().confirm(&[pos]);
@@ -212,7 +220,7 @@ async fn handle_bulk_local(
                 action: {
                     "_index": stream_name,
                     "_id": doc_id,
-                    "_version": 1,
+                    "_version": seq,
                     "result": "created",
                     "status": 201,
                     "_shards": {"total": 1, "successful": 1, "failed": 0},

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use serde_json::{Value, json};
@@ -64,23 +64,41 @@ pub async fn bulk_internal(
         );
     }
     forwarder.received.fetch_add(1, Ordering::Relaxed);
-    handle_bulk_local(state, query.index, body).await
+    match handle_bulk_local(state, query.index, body).await {
+        Ok(result) => Json(result).into_response(),
+        Err(response) => response,
+    }
 }
 
 async fn handle_bulk(state: AppState, default_index: Option<String>, body: String) -> Response {
+    match execute_bulk(state, default_index, body).await {
+        Ok(result) => Json(result).into_response(),
+        Err(response) => response,
+    }
+}
+
+/// Run a bulk body end to end — peer handoff when enabled, otherwise
+/// locally — and return the ES bulk response JSON, or a whole-request
+/// error response. The `_doc` routes synthesize one-item bodies and go
+/// through here so every write path shares the same semantics.
+pub async fn execute_bulk(
+    state: AppState,
+    default_index: Option<String>,
+    body: String,
+) -> Result<Value, Response> {
     if state.draining.load(Ordering::Relaxed) {
         // Draining: refuse new writes so the WAL empties out before
         // shutdown; shippers retry against another ingest node.
-        return error_response(
+        return Err(error_response(
             StatusCode::SERVICE_UNAVAILABLE,
             "node is draining; send bulk traffic to another ingest node",
-        );
+        ));
     }
     if state.pipeline.is_none() {
-        return error_response(
+        return Err(error_response(
             StatusCode::BAD_REQUEST,
             "this node does not run the ingest role",
-        );
+        ));
     }
     // Server-side balancing (#19): shippers pin keep-alive connections to
     // one node, so spread whole batches round-robin across live ingest
@@ -99,14 +117,16 @@ async fn handle_bulk(state: AppState, default_index: Option<String>, body: Strin
             // without the endpoint — falls through to local indexing,
             // which reproduces the right client-facing outcome itself.
             Ok((status, response)) if (200..300).contains(&status) => {
-                forwarder.forwarded.fetch_add(1, Ordering::Relaxed);
-                let status = StatusCode::from_u16(status).unwrap_or(StatusCode::OK);
-                return (
-                    status,
-                    [(header::CONTENT_TYPE, "application/json")],
-                    response,
-                )
-                    .into_response();
+                match serde_json::from_slice::<Value>(&response) {
+                    Ok(value) => {
+                        forwarder.forwarded.fetch_add(1, Ordering::Relaxed);
+                        return Ok(value);
+                    }
+                    Err(e) => {
+                        forwarder.forward_fallbacks.fetch_add(1, Ordering::Relaxed);
+                        warn!(peer = %peer_id, error = %e, "bulk handoff returned malformed JSON; indexing locally");
+                    }
+                }
             }
             Ok((status, _)) => {
                 forwarder.forward_fallbacks.fetch_add(1, Ordering::Relaxed);
@@ -128,6 +148,97 @@ fn log_mode_reason(action: &str, stream: &str) -> String {
          {{\"settings\":{{\"index\":{{\"mode\":\"document\"}}}}}} to enable \
          document-level writes"
     )
+}
+
+/// Look up the current live version of a document for a read-modify-write
+/// action. `Err` carries a closure producing the per-item error body.
+async fn lookup_current(
+    state: &AppState,
+    stream: &str,
+    id: &str,
+) -> Result<Option<rsearch_search::FoundDocument>, Box<dyn Fn(&str, &str, &str) -> Value + Send>> {
+    let Some(lookup) = &state.doc_lookup else {
+        return Err(Box::new(|action, index, id| {
+            item_err(
+                action,
+                index,
+                Some(id),
+                400,
+                "illegal_argument_exception",
+                "document lookups need a node running the ingest or search role",
+            )
+        }));
+    };
+    match lookup.get_document(stream, id).await {
+        Ok(found) => Ok(found),
+        // A stream that exists but has no splits yet has nothing to find.
+        Err(rsearch_search::SearchError::Metastore(
+            rsearch_metastore::MetastoreError::StreamNotFound(_),
+        )) => Ok(None),
+        Err(e) => {
+            let reason = e.to_string();
+            Err(Box::new(move |action, index, id| {
+                item_err(action, index, Some(id), 503, "unavailable_shards_exception", &reason)
+            }))
+        }
+    }
+}
+
+/// Apply an ES `_update` body to the current document. Returns the new
+/// document and whether it was an upsert (no current version), `Ok(None)`
+/// when the document is missing and no upsert applies, or an error for a
+/// malformed body. Supports `doc`, `doc_as_upsert`, and `upsert`; scripts
+/// are not supported.
+fn apply_update(body: &Value, current: Option<Value>) -> Result<Option<(Value, bool)>, String> {
+    if body.get("script").is_some() {
+        return Err("scripted updates are not supported".to_string());
+    }
+    let partial = body
+        .get("doc")
+        .ok_or_else(|| "update body requires 'doc'".to_string())?;
+    if !partial.is_object() {
+        return Err("'doc' must be an object".to_string());
+    }
+    match current {
+        Some(mut current) => {
+            merge_json(&mut current, partial);
+            Ok(Some((current, false)))
+        }
+        None => {
+            let doc_as_upsert = body
+                .get("doc_as_upsert")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
+            if doc_as_upsert {
+                return Ok(Some((partial.clone(), true)));
+            }
+            match body.get("upsert") {
+                Some(upsert) if upsert.is_object() => Ok(Some((upsert.clone(), true))),
+                Some(_) => Err("'upsert' must be an object".to_string()),
+                None => Ok(None),
+            }
+        }
+    }
+}
+
+/// ES partial-update merge: objects merge recursively, everything else
+/// (including arrays) is replaced.
+fn merge_json(target: &mut Value, patch: &Value) {
+    match (target, patch) {
+        (Value::Object(target), Value::Object(patch)) => {
+            for (key, value) in patch {
+                match target.get_mut(key) {
+                    Some(existing) if existing.is_object() && value.is_object() => {
+                        merge_json(existing, value);
+                    }
+                    _ => {
+                        target.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+        (target, patch) => *target = patch.clone(),
+    }
 }
 
 /// One per-item outcome, positioned for the response.
@@ -165,21 +276,21 @@ async fn handle_bulk_local(
     state: AppState,
     default_index: Option<String>,
     body: String,
-) -> Response {
+) -> Result<Value, Response> {
     let started = Instant::now();
     let Some(pipeline) = state.pipeline.clone() else {
-        return error_response(
+        return Err(error_response(
             StatusCode::BAD_REQUEST,
             "this node does not run the ingest role",
-        );
+        ));
     };
 
     let outcome = match parse_bulk_body(&body, default_index.as_deref()) {
         Ok(outcome) => outcome,
-        Err(reason) => return error_response(StatusCode::BAD_REQUEST, &reason),
+        Err(reason) => return Err(error_response(StatusCode::BAD_REQUEST, &reason)),
     };
     if outcome.total == 0 {
-        return error_response(StatusCode::BAD_REQUEST, "empty bulk body");
+        return Err(error_response(StatusCode::BAD_REQUEST, "empty bulk body"));
     }
     let BulkParseOutcome {
         items, rejections, ..
@@ -192,17 +303,168 @@ async fn handle_bulk_local(
         })
         .collect();
 
-    // Routing expansion + one write-sequence stamp per item (shared by all
-    // its routed copies, so the WAL, the split, and the response agree).
-    // Deletes route nowhere: they target exactly the named stream.
+    // Resolve every named stream's id + mode up front (creating missing
+    // streams, as _bulk always has): the mode decides what each action
+    // means.
+    let mut infos: HashMap<String, StreamInfo> = HashMap::new();
+    async fn resolve_info(
+        pipeline: &rsearch_ingest::IngestPipeline,
+        infos: &mut HashMap<String, StreamInfo>,
+        stream: &str,
+    ) -> Result<StreamInfo, Response> {
+        if let Some(info) = infos.get(stream) {
+            return Ok(*info);
+        }
+        match pipeline.stream_info(stream).await {
+            Ok(info) => {
+                infos.insert(stream.to_string(), info);
+                Ok(info)
+            }
+            Err(e) => Err(error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                &format!("metastore unavailable: {e}"),
+            )),
+        }
+    }
+    for (_, item) in &items {
+        resolve_info(&pipeline, &mut infos, &item.stream).await?;
+    }
+
+    // Read-modify-write actions on document-mode streams (update, create)
+    // look the current version up first and become plain index writes —
+    // or per-item errors. Lookups see published splits only (a write still
+    // in an ingest buffer is invisible until its split is cut; use
+    // ?refresh=wait_for on the prior write when that matters).
     struct Planned {
         position: usize,
         item: rsearch_ingest::BulkItem,
         routes: Vec<String>,
         seq: i64,
+        /// (result, status) the response reports on success.
+        outcome: (&'static str, u16),
+        /// Action name as the client sent it (an `update` becomes an
+        /// `index` write internally but answers as `update`).
+        wire_action: &'static str,
     }
     let mut planned: Vec<Planned> = Vec::with_capacity(items.len());
-    for (position, item) in items {
+    for (position, mut item) in items {
+        let action = item.action.as_str();
+        let document_mode = infos
+            .get(&item.stream)
+            .is_some_and(|i| i.mode == StreamMode::Document);
+        let mut outcome = ("created", 201);
+        match item.action {
+            BulkAction::Index if document_mode && item.explicit_id => {
+                // Without a lookup we can't tell a fresh id from a
+                // replacement; ES reports "updated" for the latter, and
+                // "updated" is the honest answer for an explicit id on a
+                // document index (the tombstone covers both cases).
+                outcome = ("updated", 200);
+            }
+            BulkAction::Index => {}
+            BulkAction::Create if document_mode && item.explicit_id => {
+                match lookup_current(&state, &item.stream, &item.doc_id).await {
+                    Ok(Some(current)) => {
+                        results.push(ItemResult {
+                            position,
+                            body: item_err(
+                                action,
+                                &item.stream,
+                                Some(&item.doc_id),
+                                409,
+                                "version_conflict_engine_exception",
+                                &format!(
+                                    "[{}]: version conflict, document already exists (current version [{}])",
+                                    item.doc_id, current.version
+                                ),
+                            ),
+                        });
+                        continue;
+                    }
+                    Ok(None) => {}
+                    Err(body) => {
+                        results.push(ItemResult {
+                            position,
+                            body: body(action, &item.stream, &item.doc_id),
+                        });
+                        continue;
+                    }
+                }
+            }
+            BulkAction::Create => {}
+            BulkAction::Update => {
+                if !document_mode {
+                    results.push(ItemResult {
+                        position,
+                        body: item_err(
+                            action,
+                            &item.stream,
+                            Some(&item.doc_id),
+                            400,
+                            "illegal_argument_exception",
+                            &log_mode_reason(action, &item.stream),
+                        ),
+                    });
+                    continue;
+                }
+                let current = match lookup_current(&state, &item.stream, &item.doc_id).await {
+                    Ok(current) => current,
+                    Err(body) => {
+                        results.push(ItemResult {
+                            position,
+                            body: body(action, &item.stream, &item.doc_id),
+                        });
+                        continue;
+                    }
+                };
+                let merged = match apply_update(&item.doc, current.map(|c| c.source)) {
+                    Ok(Some((doc, was_upsert))) => {
+                        outcome = if was_upsert { ("created", 201) } else { ("updated", 200) };
+                        doc
+                    }
+                    Ok(None) => {
+                        results.push(ItemResult {
+                            position,
+                            body: item_err(
+                                action,
+                                &item.stream,
+                                Some(&item.doc_id),
+                                404,
+                                "document_missing_exception",
+                                &format!("[{}]: document missing", item.doc_id),
+                            ),
+                        });
+                        continue;
+                    }
+                    Err(reason) => {
+                        results.push(ItemResult {
+                            position,
+                            body: item_err(
+                                action,
+                                &item.stream,
+                                Some(&item.doc_id),
+                                400,
+                                "illegal_argument_exception",
+                                &reason,
+                            ),
+                        });
+                        continue;
+                    }
+                };
+                // Becomes an ordinary explicit-id index write; the response
+                // still says "update".
+                item.raw = std::sync::Arc::from(merged.to_string());
+                item.doc = merged;
+                item.action = BulkAction::Index;
+            }
+            BulkAction::Delete => {
+                outcome = ("deleted", 200);
+            }
+        }
+        // Routing expansion + one write-sequence stamp per item (shared by
+        // all its routed copies, so the WAL, the split, and the response
+        // agree). Deletes route nowhere: they target exactly the named
+        // stream.
         let routes = match item.action {
             BulkAction::Index | BulkAction::Create => {
                 pipeline.expand_routes(&item.stream, &item.doc)
@@ -214,28 +476,15 @@ async fn handle_bulk_local(
             item,
             routes,
             seq: pipeline.next_seq(),
+            outcome,
+            wire_action: action,
         });
     }
-
-    // Resolve every target stream's id + mode (creating missing streams,
-    // as _bulk always has). Document-mode targets get tombstones.
-    let mut infos: HashMap<String, StreamInfo> = HashMap::new();
+    // Routing rules may fan a document out to streams not named in the
+    // request; resolve those too.
     for plan in &planned {
         for stream in &plan.routes {
-            if infos.contains_key(stream) {
-                continue;
-            }
-            match pipeline.stream_info(stream).await {
-                Ok(info) => {
-                    infos.insert(stream.clone(), info);
-                }
-                Err(e) => {
-                    return error_response(
-                        StatusCode::SERVICE_UNAVAILABLE,
-                        &format!("metastore unavailable: {e}"),
-                    );
-                }
-            }
+            resolve_info(&pipeline, &mut infos, stream).await?;
         }
     }
 
@@ -246,7 +495,7 @@ async fn handle_bulk_local(
     let mut tombstones: Vec<NewTombstone> = Vec::new();
     let mut writes: Vec<&Planned> = Vec::new();
     for plan in &planned {
-        let action = plan.item.action.as_str();
+        let action = plan.wire_action;
         match plan.item.action {
             BulkAction::Index | BulkAction::Create => {
                 if plan.item.explicit_id {
@@ -273,7 +522,14 @@ async fn handle_bulk_local(
                     });
                     results.push(ItemResult {
                         position: plan.position,
-                        body: item_ok(action, &plan.item.stream, &plan.item.doc_id, plan.seq, "deleted", 200),
+                        body: item_ok(
+                            action,
+                            &plan.item.stream,
+                            &plan.item.doc_id,
+                            plan.seq,
+                            plan.outcome.0,
+                            plan.outcome.1,
+                        ),
                     });
                 }
                 _ => results.push(ItemResult {
@@ -288,30 +544,26 @@ async fn handle_bulk_local(
                     ),
                 }),
             },
+            // Updates were rewritten into index writes (or rejected) above.
             BulkAction::Update => results.push(ItemResult {
                 position: plan.position,
                 body: item_err(
                     action,
                     &plan.item.stream,
                     Some(&plan.item.doc_id),
-                    400,
-                    "illegal_argument_exception",
-                    &match infos.get(&plan.item.stream) {
-                        Some(info) if info.mode == StreamMode::Document => {
-                            "update is not supported in _bulk yet".to_string()
-                        }
-                        _ => log_mode_reason(action, &plan.item.stream),
-                    },
+                    500,
+                    "internal_error",
+                    "update was not resolved",
                 ),
             }),
         }
     }
     if !tombstones.is_empty() {
         if let Err(e) = state.metastore.upsert_tombstones(&tombstones).await {
-            return error_response(
+            return Err(error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 &format!("metastore unavailable (tombstones): {e}"),
-            );
+            ));
         }
         // A search immediately after this write on this node must see it.
         if let Some(search) = &state.search {
@@ -346,16 +598,16 @@ async fn handle_bulk_local(
         match tokio::task::spawn_blocking(move || wal.append_batch(&wal_items)).await {
             Ok(Ok(positions)) => positions,
             Ok(Err(e)) => {
-                return error_response(
+                return Err(error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     &format!("wal append failed: {e}"),
-                );
+                ));
             }
             Err(e) => {
-                return error_response(
+                return Err(error_response(
                     StatusCode::INTERNAL_SERVER_ERROR,
                     &format!("wal task failed: {e}"),
-                );
+                ));
             }
         }
     };
@@ -364,7 +616,7 @@ async fn handle_bulk_local(
     // was accepted. Saturated routes get confirmed so the WAL drains.
     let mut position_iter = positions.into_iter();
     for plan in writes {
-        let action = plan.item.action.as_str();
+        let action = plan.wire_action;
         let stream_name = &plan.item.stream;
         let doc_id = &plan.item.doc_id;
         let mut accepted = 0usize;
@@ -394,18 +646,7 @@ async fn handle_bulk_local(
             }
         }
         let body = if accepted > 0 {
-            // ES reports "updated" for an index that replaced a document;
-            // an explicit id on a document-mode stream may have, and the
-            // cheap honest answer without a lookup is "created" for fresh
-            // ids and "updated" for explicit ones (the tombstone covers
-            // both cases).
-            let replaced = plan.item.explicit_id
-                && plan.item.action == BulkAction::Index
-                && infos
-                    .get(stream_name)
-                    .is_some_and(|i| i.mode == StreamMode::Document);
-            let (result, status) = if replaced { ("updated", 200) } else { ("created", 201) };
-            item_ok(action, stream_name, doc_id, plan.seq, result, status)
+            item_ok(action, stream_name, doc_id, plan.seq, plan.outcome.0, plan.outcome.1)
         } else if saturated {
             item_err(
                 action,
@@ -442,15 +683,14 @@ async fn handle_bulk_local(
             .unwrap_or(true)
     });
     let items: Vec<Value> = results.into_iter().map(|r| r.body).collect();
-    Json(json!({
+    Ok(json!({
         "took": started.elapsed().as_millis() as u64,
         "errors": errors,
         "items": items,
     }))
-    .into_response()
 }
 
-fn error_response(status: StatusCode, reason: &str) -> Response {
+pub(crate) fn error_response(status: StatusCode, reason: &str) -> Response {
     (
         status,
         Json(json!({

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -181,38 +181,51 @@ fn log_mode_reason(action: &str, stream: &str) -> String {
     )
 }
 
-/// Look up the current live version of a document for a read-modify-write
-/// action. `Err` carries a closure producing the per-item error body.
-async fn lookup_current(
+/// Per-item error for a failed lookup (closure over action/index/id).
+type LookupErr = Box<dyn Fn(&str, &str, &str) -> Value + Send + Sync>;
+
+/// Current live versions for all (stream, id) pairs that read-modify-write
+/// actions in this batch need, in one `ids` search per stream. Ids not
+/// found are simply absent. A stream-level failure is returned per
+/// stream so each of its items can answer with the same error.
+async fn lookup_batch(
     state: &AppState,
-    stream: &str,
-    id: &str,
-) -> Result<Option<rsearch_search::FoundDocument>, Box<dyn Fn(&str, &str, &str) -> Value + Send>> {
-    let Some(lookup) = &state.doc_lookup else {
-        return Err(Box::new(|action, index, id| {
-            item_err(
-                action,
-                index,
-                Some(id),
-                400,
-                "illegal_argument_exception",
-                "document lookups need a node running the ingest or search role",
-            )
-        }));
-    };
-    match lookup.get_document(stream, id).await {
-        Ok(found) => Ok(found),
-        // A stream that exists but has no splits yet has nothing to find.
-        Err(rsearch_search::SearchError::Metastore(
-            rsearch_metastore::MetastoreError::StreamNotFound(_),
-        )) => Ok(None),
-        Err(e) => {
-            let reason = e.to_string();
-            Err(Box::new(move |action, index, id| {
-                item_err(action, index, Some(id), 503, "unavailable_shards_exception", &reason)
-            }))
-        }
+    wanted: &HashMap<String, Vec<String>>,
+) -> HashMap<String, Result<HashMap<String, rsearch_search::FoundDocument>, LookupErr>> {
+    let mut out = HashMap::new();
+    for (stream, ids) in wanted {
+        let Some(lookup) = &state.doc_lookup else {
+            out.insert(
+                stream.clone(),
+                Err(Box::new(|action: &str, index: &str, id: &str| {
+                    item_err(
+                        action,
+                        index,
+                        Some(id),
+                        400,
+                        "illegal_argument_exception",
+                        "document lookups need a node running the ingest or search role",
+                    )
+                }) as LookupErr),
+            );
+            continue;
+        };
+        let result = match lookup.get_documents(stream, ids).await {
+            Ok(found) => Ok(found),
+            // A stream that exists but has no splits yet has nothing to find.
+            Err(rsearch_search::SearchError::Metastore(
+                rsearch_metastore::MetastoreError::StreamNotFound(_),
+            )) => Ok(HashMap::new()),
+            Err(e) => {
+                let reason = e.to_string();
+                Err(Box::new(move |action: &str, index: &str, id: &str| {
+                    item_err(action, index, Some(id), 503, "unavailable_shards_exception", &reason)
+                }) as LookupErr)
+            }
+        };
+        out.insert(stream.clone(), result);
     }
+    out
 }
 
 /// Apply an ES `_update` body to the current document. Returns the new
@@ -269,6 +282,24 @@ fn merge_json(target: &mut Value, patch: &Value) {
             }
         }
         (target, patch) => *target = patch.clone(),
+    }
+}
+
+/// A search immediately after a local tombstone write must see it: drop
+/// the freshness of the affected streams' tombstone caches on this node —
+/// both the public search service and the write path's lookup service
+/// (the same instance when a node runs both roles).
+fn invalidate_tombstone_caches(state: &AppState, tombstones: &[NewTombstone]) {
+    let mut seen = std::collections::HashSet::new();
+    for t in tombstones {
+        if seen.insert(t.stream_id) {
+            if let Some(search) = &state.search {
+                search.invalidate_tombstones(t.stream_id);
+            }
+            if let Some(lookup) = &state.doc_lookup {
+                lookup.invalidate_tombstones(t.stream_id);
+            }
+        }
     }
 }
 
@@ -335,38 +366,118 @@ async fn handle_bulk_local(
         })
         .collect();
 
-    // Resolve every named stream's id + mode up front (creating missing
-    // streams, as _bulk always has): the mode decides what each action
-    // means.
+    // Resolve every named stream's id + mode up front: the mode decides
+    // what each action means. Writes create missing streams (as _bulk
+    // always has); delete/update against a stream that doesn't exist is a
+    // 404 like ES, not an implicit creation.
     let mut infos: HashMap<String, StreamInfo> = HashMap::new();
     async fn resolve_info(
         pipeline: &rsearch_ingest::IngestPipeline,
         infos: &mut HashMap<String, StreamInfo>,
         stream: &str,
-    ) -> Result<StreamInfo, Response> {
+        create: bool,
+    ) -> Result<Option<StreamInfo>, Response> {
         if let Some(info) = infos.get(stream) {
-            return Ok(*info);
+            return Ok(Some(*info));
         }
-        match pipeline.stream_info(stream).await {
-            Ok(info) => {
+        let resolved = if create {
+            pipeline.stream_info(stream).await.map(Some)
+        } else {
+            pipeline.stream_info_if_exists(stream).await
+        };
+        match resolved {
+            Ok(Some(info)) => {
                 infos.insert(stream.to_string(), info);
-                Ok(info)
+                Ok(Some(info))
             }
+            Ok(None) => Ok(None),
             Err(e) => Err(error_response(
                 StatusCode::SERVICE_UNAVAILABLE,
                 &format!("metastore unavailable: {e}"),
             )),
         }
     }
-    for (_, item) in &items {
-        resolve_info(&pipeline, &mut infos, &item.stream).await?;
+    let mut kept: Vec<(usize, rsearch_ingest::BulkItem)> = Vec::with_capacity(items.len());
+    for (position, item) in items {
+        let create = matches!(item.action, BulkAction::Index | BulkAction::Create);
+        match resolve_info(&pipeline, &mut infos, &item.stream, create).await? {
+            Some(_) => kept.push((position, item)),
+            None => results.push(ItemResult {
+                position,
+                body: item_err(
+                    item.action.as_str(),
+                    &item.stream,
+                    Some(&item.doc_id),
+                    404,
+                    "index_not_found_exception",
+                    &format!("no such index [{}]", item.stream),
+                ),
+            }),
+        }
+    }
+    let items = kept;
+
+    // Hybrid-clock causality: every write to an explicit id on a
+    // document-mode stream must stamp a sequence above the bound any
+    // earlier write (on any node) recorded for that id — otherwise a node
+    // whose wall clock lags would produce a "newer" version that the
+    // existing tombstone hides. One indexed lookup per batch.
+    let doc_mode = |infos: &HashMap<String, StreamInfo>, stream: &str| {
+        infos
+            .get(stream)
+            .is_some_and(|i| i.mode == StreamMode::Document)
+    };
+    let id_pairs: Vec<(i64, String)> = items
+        .iter()
+        .filter(|(_, item)| item.explicit_id && doc_mode(&infos, &item.stream))
+        .filter_map(|(_, item)| infos.get(&item.stream).map(|i| (i.id, item.doc_id.clone())))
+        .collect();
+    if !id_pairs.is_empty() {
+        match state.metastore.tombstone_bounds(&id_pairs).await {
+            Ok(bounds) => {
+                if let Some(max) = bounds.iter().map(|(_, _, b)| *b).max() {
+                    pipeline.observe_seq(max);
+                }
+            }
+            Err(e) => {
+                return Err(error_response(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    &format!("metastore unavailable: {e}"),
+                ));
+            }
+        }
     }
 
     // Read-modify-write actions on document-mode streams (update, create)
-    // look the current version up first and become plain index writes —
-    // or per-item errors. Lookups see published splits only (a write still
-    // in an ingest buffer is invisible until its split is cut; use
-    // ?refresh=wait_for on the prior write when that matters).
+    // look the current version up first — batched per stream — and become
+    // plain index writes, or per-item errors. Lookups see published
+    // splits only (a write still in an ingest buffer is invisible until
+    // its split is cut; use ?refresh=wait_for on the prior write when that
+    // matters).
+    let mut wanted: HashMap<String, Vec<String>> = HashMap::new();
+    for (_, item) in &items {
+        let needs = match item.action {
+            BulkAction::Update => doc_mode(&infos, &item.stream),
+            BulkAction::Create => doc_mode(&infos, &item.stream) && item.explicit_id,
+            _ => false,
+        };
+        if needs {
+            wanted
+                .entry(item.stream.clone())
+                .or_default()
+                .push(item.doc_id.clone());
+        }
+    }
+    let looked_up = lookup_batch(&state, &wanted).await;
+    let current_of = |stream: &str,
+                      id: &str|
+     -> Result<Option<rsearch_search::FoundDocument>, &LookupErr> {
+        match looked_up.get(stream) {
+            Some(Ok(found)) => Ok(found.get(id).cloned()),
+            Some(Err(e)) => Err(e),
+            None => Ok(None),
+        }
+    };
     struct Planned {
         position: usize,
         item: rsearch_ingest::BulkItem,
@@ -381,9 +492,7 @@ async fn handle_bulk_local(
     let mut planned: Vec<Planned> = Vec::with_capacity(items.len());
     for (position, mut item) in items {
         let action = item.action.as_str();
-        let document_mode = infos
-            .get(&item.stream)
-            .is_some_and(|i| i.mode == StreamMode::Document);
+        let document_mode = doc_mode(&infos, &item.stream);
         let mut outcome = ("created", 201);
         match item.action {
             BulkAction::Index if document_mode && item.explicit_id => {
@@ -395,7 +504,7 @@ async fn handle_bulk_local(
             }
             BulkAction::Index => {}
             BulkAction::Create if document_mode && item.explicit_id => {
-                match lookup_current(&state, &item.stream, &item.doc_id).await {
+                match current_of(&item.stream, &item.doc_id) {
                     Ok(Some(current)) => {
                         results.push(ItemResult {
                             position,
@@ -439,7 +548,7 @@ async fn handle_bulk_local(
                     });
                     continue;
                 }
-                let current = match lookup_current(&state, &item.stream, &item.doc_id).await {
+                let current = match current_of(&item.stream, &item.doc_id) {
                     Ok(current) => current,
                     Err(body) => {
                         results.push(ItemResult {
@@ -516,35 +625,23 @@ async fn handle_bulk_local(
     // request; resolve those too.
     for plan in &planned {
         for stream in &plan.routes {
-            resolve_info(&pipeline, &mut infos, stream).await?;
+            resolve_info(&pipeline, &mut infos, stream, true).await?;
         }
     }
 
-    // Tombstones are written before anything is WAL-appended: a crash
-    // between the two can lose an unacked write (the client retries), but
-    // never leaves a replayed document without the tombstone that hides
-    // its predecessors.
+    // Delete tombstones are written now, before the response says
+    // "deleted". Replacement tombstones (explicit-id index/create on a
+    // document-mode stream) are written only *after* the new version is
+    // WAL-durable and accepted — a rejected write (429/500) must leave the
+    // old version visible, not hide it. The WAL record carries the
+    // tombstone flag so a crash between the append and the upsert is
+    // repaired on replay.
     let mut tombstones: Vec<NewTombstone> = Vec::new();
     let mut writes: Vec<&Planned> = Vec::new();
     for plan in &planned {
         let action = plan.wire_action;
         match plan.item.action {
-            BulkAction::Index | BulkAction::Create => {
-                if plan.item.explicit_id {
-                    for stream in &plan.routes {
-                        if let Some(info) = infos.get(stream)
-                            && info.mode == StreamMode::Document
-                        {
-                            tombstones.push(NewTombstone {
-                                stream_id: info.id,
-                                doc_id: plan.item.doc_id.clone(),
-                                before_seq: plan.seq,
-                            });
-                        }
-                    }
-                }
-                writes.push(plan);
-            }
+            BulkAction::Index | BulkAction::Create => writes.push(plan),
             BulkAction::Delete => match infos.get(&plan.item.stream) {
                 Some(info) if info.mode == StreamMode::Document => {
                     tombstones.push(NewTombstone {
@@ -597,16 +694,16 @@ async fn handle_bulk_local(
                 &format!("metastore unavailable (tombstones): {e}"),
             ));
         }
-        // A search immediately after this write on this node must see it.
-        if let Some(search) = &state.search {
-            let mut seen = std::collections::HashSet::new();
-            for t in &tombstones {
-                if seen.insert(t.stream_id) {
-                    search.invalidate_tombstones(t.stream_id);
-                }
-            }
-        }
+        invalidate_tombstone_caches(&state, &tombstones);
     }
+    // Whether a routed copy of an explicit-id write replaces older
+    // versions (document-mode target) and so carries a tombstone.
+    let replaces = |plan: &Planned, stream: &str| {
+        plan.item.explicit_id
+            && infos
+                .get(stream)
+                .is_some_and(|i| i.mode == StreamMode::Document)
+    };
 
     // The durability point: append every routed copy to the WAL with a
     // single fsync.
@@ -620,6 +717,7 @@ async fn handle_bulk_local(
                 stream: stream.clone(),
                 id: plan.item.doc_id.clone(),
                 seq: plan.seq,
+                tombstone: replaces(plan, stream),
                 doc: plan.item.raw.clone(),
             })
         })
@@ -649,6 +747,8 @@ async fn handle_bulk_local(
     let mut position_iter = positions.into_iter();
     // Document-mode streams that received a write, for ?refresh.
     let mut to_refresh: Vec<String> = Vec::new();
+    // Replacement tombstones for accepted copies, written below.
+    let mut replacement_tombstones: Vec<NewTombstone> = Vec::new();
     for plan in writes {
         let action = plan.wire_action;
         let stream_name = &plan.item.stream;
@@ -670,11 +770,19 @@ async fn handle_bulk_local(
             {
                 Ok(()) => {
                     accepted += 1;
-                    if refresh
-                        && infos.get(stream).is_some_and(|i| i.mode == StreamMode::Document)
-                        && !to_refresh.contains(stream)
+                    if let Some(info) = infos.get(stream)
+                        && info.mode == StreamMode::Document
                     {
-                        to_refresh.push(stream.clone());
+                        if replaces(plan, stream) {
+                            replacement_tombstones.push(NewTombstone {
+                                stream_id: info.id,
+                                doc_id: doc_id.clone(),
+                                before_seq: plan.seq,
+                            });
+                        }
+                        if refresh && !to_refresh.contains(stream) {
+                            to_refresh.push(stream.clone());
+                        }
                     }
                 }
                 Err(IngestError::Saturated) => {
@@ -714,6 +822,36 @@ async fn handle_bulk_local(
         });
     }
     results.sort_by_key(|r| r.position);
+
+    // The accepted replacements' tombstones. The documents are already
+    // WAL-durable with the tombstone flag, so a metastore failure here is
+    // retried in the background rather than failing acked items; until it
+    // lands, the old and new version are both visible (never the reverse).
+    if !replacement_tombstones.is_empty() {
+        match state.metastore.upsert_tombstones(&replacement_tombstones).await {
+            Ok(()) => invalidate_tombstone_caches(&state, &replacement_tombstones),
+            Err(e) => {
+                warn!(error = %e, count = replacement_tombstones.len(), "replacement tombstones failed; retrying in background");
+                let state = state.clone();
+                tokio::spawn(async move {
+                    let mut backoff = std::time::Duration::from_millis(500);
+                    loop {
+                        tokio::time::sleep(backoff).await;
+                        match state.metastore.upsert_tombstones(&replacement_tombstones).await {
+                            Ok(()) => {
+                                invalidate_tombstone_caches(&state, &replacement_tombstones);
+                                return;
+                            }
+                            Err(e) => {
+                                warn!(error = %e, "replacement tombstones still failing");
+                                backoff = (backoff * 2).min(std::time::Duration::from_secs(30));
+                            }
+                        }
+                    }
+                });
+            }
+        }
+    }
 
     // ?refresh: cut the written streams' batches now and wait (bounded)
     // until they are published, so a search right after this response

--- a/crates/rsearch-server/src/bulk_forward.rs
+++ b/crates/rsearch-server/src/bulk_forward.rs
@@ -117,12 +117,17 @@ impl BulkForwarder {
         &self,
         addr: &str,
         default_index: Option<&str>,
+        refresh: bool,
         body: Bytes,
     ) -> Result<(u16, Bytes), String> {
         let mut url = url::Url::parse(addr).map_err(|e| format!("peer address '{addr}': {e}"))?;
         url.set_path("/_rsearch/internal/bulk");
         if let Some(index) = default_index {
             url.query_pairs_mut().append_pair("index", index);
+        }
+        if refresh {
+            // The peer indexes the batch, so its buffer is the one to cut.
+            url.query_pairs_mut().append_pair("refresh", "wait_for");
         }
         self.client
             .post_raw(url.as_str(), body)

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -159,6 +159,12 @@ impl ControlPlane {
         if settled && let Err(e) = self.merge_job().await {
             error!(error = %e, "merge job failed");
         }
+        if settled && let Err(e) = self.compaction_job().await {
+            error!(error = %e, "compaction job failed");
+        }
+        if let Err(e) = self.tombstone_purge_job().await {
+            error!(error = %e, "tombstone purge failed");
+        }
         if let Err(e) = self.retention_job().await {
             error!(error = %e, "retention job failed");
         }
@@ -575,14 +581,71 @@ impl ControlPlane {
         };
 
         let stream = self.metastore.get_stream_by_id(stream_id).await?;
-        let mapping = IndexMapping::from_json(&stream.mapping).unwrap_or_default();
-        let schema = MappedSchema::build(mapping);
         info!(
             stream = %stream.name,
             splits = group.len(),
             docs = group.iter().map(|s| s.doc_count).sum::<i64>(),
             "merging small splits"
         );
+        // A merge is also a compaction: document-mode streams drop their
+        // tombstoned versions on the way through.
+        let tombstones = self.stream_tombstones(&stream).await?;
+        let group_refs: Vec<&SplitRecord> = group.to_vec();
+        let rebuilt = self.rebuild_splits(&stream, &group_refs, &tombstones).await?;
+        match rebuilt {
+            Some(new_split_id) => info!(
+                merged_into = %new_split_id,
+                sources = group.len(),
+                "merge complete"
+            ),
+            None => info!(sources = group.len(), "merge: every document was tombstoned; sources dropped"),
+        }
+        Ok(())
+    }
+
+    /// The full tombstone list of a stream (ascending by seq), empty for
+    /// log streams. Paged out of the metastore; compaction keeps it small.
+    async fn stream_tombstones(
+        &self,
+        stream: &rsearch_metastore::StreamRecord,
+    ) -> anyhow::Result<Vec<rsearch_index::Tombstone>> {
+        if !stream.is_document_mode() {
+            return Ok(Vec::new());
+        }
+        const PAGE: i64 = 10_000;
+        let mut out = Vec::new();
+        let mut after = 0;
+        loop {
+            let page = self.metastore.tombstones_since(stream.id, after, PAGE).await?;
+            let done = (page.len() as i64) < PAGE;
+            if let Some(last) = page.last() {
+                after = last.seq;
+            }
+            out.extend(page.into_iter().map(|t| rsearch_index::Tombstone {
+                seq: t.seq,
+                doc_id: t.doc_id,
+                before_seq: t.before_seq,
+            }));
+            if done {
+                return Ok(out);
+            }
+        }
+    }
+
+    /// Re-index `sources` into one new split with `tombstones` applied
+    /// (hidden versions skipped), publish it and mark the sources for
+    /// delete atomically. Returns the new split id, or None when nothing
+    /// survived (the sources are then simply marked for delete).
+    async fn rebuild_splits(
+        &self,
+        stream: &rsearch_metastore::StreamRecord,
+        sources: &[&SplitRecord],
+        tombstones: &[rsearch_index::Tombstone],
+    ) -> anyhow::Result<Option<String>> {
+        let stream_id = stream.id;
+        let mapping = IndexMapping::from_json(&stream.mapping).unwrap_or_default();
+        let schema = MappedSchema::build(mapping);
+        let applied_through = tombstones.last().map(|t| t.seq).unwrap_or(0);
 
         // Stream every source split's docs straight into the new builder,
         // one split at a time on blocking threads. Peak memory is one doc
@@ -595,14 +658,18 @@ impl ControlPlane {
             SplitBuilder::new(stream_name, schema, &work_dir, budget)
         })
         .await??;
-        for split in &group {
+        let mut skipped_total = 0u64;
+        for split in sources {
             let reader = Arc::new(
                 SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
                     .await?,
             );
-            builder = tokio::task::spawn_blocking(move || {
+            let tombstones = tombstones.to_vec();
+            let (next_builder, skipped) = tokio::task::spawn_blocking(move || {
+                let exclusions = reader.apply_tombstones(&tombstones)?;
+                let skipped = exclusions.len() as u64;
                 reader.for_each_doc(
-                    |_, _| false,
+                    |segment_ord, doc_id| exclusions.contains(segment_ord, doc_id),
                     |doc| {
                         // Docs lacking their own timestamp keep the
                         // original one via the fallback. Identity is
@@ -620,9 +687,20 @@ impl ControlPlane {
                         )
                     },
                 )?;
-                Ok::<_, rsearch_index::IndexError>(builder)
+                Ok::<_, rsearch_index::IndexError>((builder, skipped))
             })
             .await??;
+            builder = next_builder;
+            skipped_total += skipped;
+        }
+        let old_ids: Vec<String> = sources.iter().map(|s| s.split_id.clone()).collect();
+        if builder.doc_count() == 0 {
+            // Everything was tombstoned: no replacement split to publish.
+            self.metastore.mark_splits_for_delete(&old_ids).await?;
+            self.metrics
+                .compacted_docs
+                .fetch_add(skipped_total, std::sync::atomic::Ordering::Relaxed);
+            return Ok(None);
         }
         let packaged = tokio::task::spawn_blocking(move || builder.finish()).await??;
 
@@ -641,19 +719,112 @@ impl ControlPlane {
                 created_by: Some(&self.node_id),
                 seq_min: packaged.meta.seq_min,
                 seq_max: packaged.meta.seq_max,
-                tombstone_seq_applied: 0,
+                tombstone_seq_applied: applied_through,
             })
             .await?;
-        let old_ids: Vec<String> = group.iter().map(|s| s.split_id.clone()).collect();
         self.metastore
             .swap_splits(&old_ids, &packaged.meta.split_id)
             .await?;
-        info!(
-            merged_into = %packaged.meta.split_id,
-            sources = old_ids.len(),
-            docs = packaged.meta.doc_count,
-            "merge complete"
-        );
+        if skipped_total > 0 {
+            self.metrics
+                .compacted_docs
+                .fetch_add(skipped_total, std::sync::atomic::Ordering::Relaxed);
+        }
+        Ok(Some(packaged.meta.split_id))
+    }
+
+    /// Document-mode compaction: once a stream has accumulated
+    /// `compact_min_tombstones` (or its oldest tombstone is past
+    /// `compact_max_age_secs`), visit its published splits that haven't
+    /// applied the current tombstones. A split with nothing to hide is
+    /// just marked up to date (no rewrite); one with hidden versions is
+    /// rewritten without them. Bounded per tick so a big backlog drains
+    /// over several ticks without starving the other jobs.
+    async fn compaction_job(&self) -> anyhow::Result<()> {
+        let stats = self.metastore.tombstone_stats().await?;
+        let mut budget = self.config.compact_splits_per_tick.max(1);
+        for stat in stats {
+            if budget <= 0 {
+                break;
+            }
+            let due = stat.count >= self.config.compact_min_tombstones
+                || stat.oldest_age_secs >= self.config.compact_max_age_secs;
+            if !due {
+                continue;
+            }
+            let stream = match self.metastore.get_stream_by_id(stat.stream_id).await {
+                Ok(stream) => stream,
+                Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => continue,
+                Err(e) => return Err(e.into()),
+            };
+            if !stream.is_document_mode() {
+                continue;
+            }
+            let candidates = self
+                .metastore
+                .splits_needing_compaction(stream.id, stat.max_seq, budget)
+                .await?;
+            if candidates.is_empty() {
+                continue;
+            }
+            let tombstones = self.stream_tombstones(&stream).await?;
+            let applied_through = tombstones.last().map(|t| t.seq).unwrap_or(0);
+            for split in &candidates {
+                budget -= 1;
+                // Cheap check first: does this split hold anything hidden?
+                let reader = Arc::new(
+                    SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
+                        .await?,
+                );
+                let list = tombstones.clone();
+                let hidden = tokio::task::spawn_blocking(move || {
+                    reader.apply_tombstones(&list).map(|set| set.len())
+                })
+                .await??;
+                if hidden == 0 {
+                    self.metastore
+                        .mark_tombstones_applied(&split.split_id, applied_through)
+                        .await?;
+                    continue;
+                }
+                info!(
+                    stream = %stream.name,
+                    split_id = %split.split_id,
+                    hidden,
+                    docs = split.doc_count,
+                    "compacting split"
+                );
+                match self.rebuild_splits(&stream, &[split], &tombstones).await {
+                    Ok(_) => {
+                        self.metrics
+                            .compactions
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    Err(e) => {
+                        // Most likely the split was merged/deleted under us
+                        // (swap conflict); the next tick re-evaluates.
+                        warn!(split_id = %split.split_id, error = %e, "compaction of split failed");
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Purge tombstones no split can still need (see
+    /// `Metastore::purge_tombstones`); bounded per tick.
+    async fn tombstone_purge_job(&self) -> anyhow::Result<()> {
+        const BATCH: i64 = 10_000;
+        let purged = self
+            .metastore
+            .purge_tombstones(self.config.tombstone_purge_grace_secs, BATCH)
+            .await?;
+        if purged > 0 {
+            self.metrics
+                .tombstones_purged
+                .fetch_add(purged, std::sync::atomic::Ordering::Relaxed);
+            info!(purged, "tombstones purged");
+        }
         Ok(())
     }
 

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -629,17 +629,20 @@ impl ControlPlane {
         let key = format!("streams/{}/{}.split", stream.name, packaged.meta.split_id);
         self.storage.put_file(&key, &packaged.file_path).await?;
         self.metastore
-            .stage_split(
-                &packaged.meta.split_id,
+            .stage_split(&rsearch_metastore::NewSplit {
+                split_id: &packaged.meta.split_id,
                 stream_id,
-                &key,
-                packaged.meta.doc_count as i64,
-                packaged.size_bytes as i64,
-                packaged.meta.time_start_millis,
-                packaged.meta.time_end_millis,
-                packaged.footer_len as i64,
-                Some(&self.node_id),
-            )
+                storage_key: &key,
+                doc_count: packaged.meta.doc_count as i64,
+                size_bytes: packaged.size_bytes as i64,
+                time_start_millis: packaged.meta.time_start_millis,
+                time_end_millis: packaged.meta.time_end_millis,
+                footer_len: packaged.footer_len as i64,
+                created_by: Some(&self.node_id),
+                seq_min: packaged.meta.seq_min,
+                seq_max: packaged.meta.seq_max,
+                tombstone_seq_applied: 0,
+            })
             .await?;
         let old_ids: Vec<String> = group.iter().map(|s| s.split_id.clone()).collect();
         self.metastore
@@ -772,6 +775,9 @@ mod tests {
             time_end_millis: id * 1_000 + 999,
             footer_len: 0,
             created_by: None,
+            seq_min: None,
+            seq_max: None,
+            tombstone_seq_applied: 0,
         }
     }
 

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -601,14 +601,25 @@ impl ControlPlane {
                     .await?,
             );
             builder = tokio::task::spawn_blocking(move || {
-                reader.for_each_doc(|doc, ts_millis| {
-                    // Docs lacking their own timestamp keep the original
-                    // one via the fallback.
-                    builder.add_json(
-                        doc,
-                        rsearch_index::DateTime::from_timestamp_millis(ts_millis),
-                    )
-                })?;
+                reader.for_each_doc(
+                    |_, _| false,
+                    |doc| {
+                        // Docs lacking their own timestamp keep the
+                        // original one via the fallback. Identity is
+                        // preserved; legacy docs (no id) get a fresh one at
+                        // sequence 0.
+                        let identity = match doc.id {
+                            Some(id) => rsearch_index::DocIdentity::new(id, doc.seq),
+                            None => rsearch_index::DocIdentity::generated(),
+                        };
+                        builder.add_document(
+                            doc.json,
+                            None,
+                            &identity,
+                            rsearch_index::DateTime::from_timestamp_millis(doc.timestamp_millis),
+                        )
+                    },
+                )?;
                 Ok::<_, rsearch_index::IndexError>(builder)
             })
             .await??;

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -52,6 +52,7 @@ pub struct ControlPlane {
     /// Gates the O(object_locations) under-replication aggregation so
     /// healthy steady-state ticks don't pay a full-table scan every 15s.
     repair_scan: std::sync::Mutex<RepairScanState>,
+    compaction: std::sync::Mutex<CompactionState>,
 }
 
 #[derive(Default)]
@@ -62,6 +63,18 @@ struct RepairScanState {
     /// The previous scan found under-replicated keys — keep scanning every
     /// tick until a scan comes back clean.
     last_found_work: bool,
+}
+
+/// How often the compaction job re-scans the tombstone table for streams
+/// that are due (a full scan; between scans it drains the streams found).
+const COMPACTION_SCAN_EVERY: Duration = Duration::from_secs(60);
+
+#[derive(Default)]
+struct CompactionState {
+    last_scan: Option<std::time::Instant>,
+    /// Streams found due by the last scan, not yet fully visited (popped
+    /// oldest-first).
+    due: Vec<rsearch_metastore::StreamTombstoneStats>,
 }
 
 struct ReplicationCtl {
@@ -106,6 +119,7 @@ impl ControlPlane {
             replication,
             metrics,
             repair_scan: std::sync::Mutex::new(RepairScanState::default()),
+            compaction: std::sync::Mutex::new(CompactionState::default()),
         })
     }
 
@@ -664,6 +678,9 @@ impl ControlPlane {
                 SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
                     .await?,
             );
+            // Tombstones this split already applied (an earlier rebuild)
+            // hide nothing in it; skip their lookups.
+            reader.seed_applied_through(split.tombstone_seq_applied);
             let tombstones = tombstones.to_vec();
             let (next_builder, skipped) = tokio::task::spawn_blocking(move || {
                 let exclusions = reader.apply_tombstones(&tombstones)?;
@@ -741,16 +758,46 @@ impl ControlPlane {
     /// rewritten without them. Bounded per tick so a big backlog drains
     /// over several ticks without starving the other jobs.
     async fn compaction_job(&self) -> anyhow::Result<()> {
-        let stats = self.metastore.tombstone_stats().await?;
+        // The rollup is a full scan of the tombstone table; it only needs
+        // to run every few ticks, and a tick that has nothing due after the
+        // last scan skips it. Streams found due are drained over the
+        // following ticks without re-scanning.
+        // Scan cadence: no finer than the age trigger needs, at most
+        // every COMPACTION_SCAN_EVERY.
+        let scan_every = Duration::from_secs_f64(self.config.compact_max_age_secs.max(1.0))
+            .min(COMPACTION_SCAN_EVERY);
+        let need_scan = {
+            let state = self.compaction.lock().unwrap();
+            state.due.is_empty()
+                && state
+                    .last_scan
+                    .is_none_or(|at| at.elapsed() >= scan_every)
+        };
+        if need_scan {
+            let stats = self.metastore.tombstone_stats().await?;
+            self.metrics.tombstones_pending.store(
+                stats.iter().map(|s| s.count as u64).sum(),
+                std::sync::atomic::Ordering::Relaxed,
+            );
+            let mut due: Vec<_> = stats
+                .into_iter()
+                .filter(|stat| {
+                    stat.count >= self.config.compact_min_tombstones
+                        || stat.oldest_age_secs >= self.config.compact_max_age_secs
+                })
+                .collect();
+            due.reverse(); // pop() yields oldest first
+            let mut state = self.compaction.lock().unwrap();
+            state.last_scan = Some(std::time::Instant::now());
+            state.due = due;
+        }
+        let mut stats = std::mem::take(&mut self.compaction.lock().unwrap().due);
         let mut budget = self.config.compact_splits_per_tick.max(1);
-        for stat in stats {
+        while let Some(stat) = stats.pop() {
             if budget <= 0 {
+                // Put it back for the next tick.
+                stats.push(stat);
                 break;
-            }
-            let due = stat.count >= self.config.compact_min_tombstones
-                || stat.oldest_age_secs >= self.config.compact_max_age_secs;
-            if !due {
-                continue;
             }
             let stream = match self.metastore.get_stream_by_id(stat.stream_id).await {
                 Ok(stream) => stream,
@@ -767,48 +814,71 @@ impl ControlPlane {
             if candidates.is_empty() {
                 continue;
             }
+            // More work may remain for this stream after the budget; it is
+            // re-evaluated on the next scan.
             let tombstones = self.stream_tombstones(&stream).await?;
             let applied_through = tombstones.last().map(|t| t.seq).unwrap_or(0);
             for split in &candidates {
                 budget -= 1;
-                // Cheap check first: does this split hold anything hidden?
-                let reader = Arc::new(
-                    SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
-                        .await?,
-                );
-                let list = tombstones.clone();
-                let hidden = tokio::task::spawn_blocking(move || {
-                    reader.apply_tombstones(&list).map(|set| set.len())
-                })
-                .await??;
-                if hidden == 0 {
-                    self.metastore
-                        .mark_tombstones_applied(&split.split_id, applied_through)
-                        .await?;
-                    continue;
-                }
-                info!(
-                    stream = %stream.name,
-                    split_id = %split.split_id,
-                    hidden,
-                    docs = split.doc_count,
-                    "compacting split"
-                );
-                match self.rebuild_splits(&stream, &[split], &tombstones).await {
-                    Ok(_) => {
-                        self.metrics
-                            .compactions
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    }
-                    Err(e) => {
-                        // Most likely the split was merged/deleted under us
-                        // (swap conflict); the next tick re-evaluates.
-                        warn!(split_id = %split.split_id, error = %e, "compaction of split failed");
-                    }
-                }
+                self.compact_split(&stream, split, &tombstones, applied_through).await;
+            }
+            if budget <= 0 {
+                // Budget exhausted on this stream: it stays due so the next
+                // tick continues where this one stopped.
+                stats.push(stat);
+                break;
             }
         }
+        self.compaction.lock().unwrap().due = stats;
         Ok(())
+    }
+
+    /// One split's compaction step: mark up to date when nothing is hidden,
+    /// otherwise rewrite without the hidden versions.
+    async fn compact_split(
+        &self,
+        stream: &rsearch_metastore::StreamRecord,
+        split: &SplitRecord,
+        tombstones: &[rsearch_index::Tombstone],
+        applied_through: i64,
+    ) {
+        let step = async {
+            // Cheap check first: does this split hold anything hidden by
+            // tombstones newer than the ones it already applied?
+            let reader = Arc::new(
+                SplitReader::open(self.storage.clone(), &split.storage_key, self.cache.clone())
+                    .await?,
+            );
+            reader.seed_applied_through(split.tombstone_seq_applied);
+            let list = tombstones.to_vec();
+            let hidden = tokio::task::spawn_blocking(move || {
+                reader.apply_tombstones(&list).map(|set| set.len())
+            })
+            .await??;
+            if hidden == 0 {
+                self.metastore
+                    .mark_tombstones_applied(&split.split_id, applied_through)
+                    .await?;
+                return Ok(());
+            }
+            info!(
+                stream = %stream.name,
+                split_id = %split.split_id,
+                hidden,
+                docs = split.doc_count,
+                "compacting split"
+            );
+            self.rebuild_splits(stream, &[split], tombstones).await?;
+            self.metrics
+                .compactions
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok::<_, anyhow::Error>(())
+        };
+        // A failure is most likely the split being merged/deleted under us
+        // (swap conflict); the next scan re-evaluates.
+        if let Err(e) = step.await {
+            warn!(split_id = %split.split_id, error = %e, "compaction step failed");
+        }
     }
 
     /// Purge tombstones no split can still need (see

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -12,7 +12,7 @@ use serde_json::{Value, json};
 
 use rsearch_search::{SearchError, SearchRequest};
 
-use crate::bulk_api::{error_response, execute_bulk};
+use crate::bulk_api::{error_response, execute_bulk, parse_refresh};
 use crate::state::AppState;
 
 /// Query parameters the document routes understand.
@@ -20,9 +20,14 @@ use crate::state::AppState;
 pub struct DocParams {
     /// `create` makes PUT/POST `_doc/{id}` behave like `_create/{id}`.
     op_type: Option<String>,
-    /// `true` | `wait_for` | `false` (see phase 14.5).
-    #[allow(dead_code)]
+    /// `true` | `wait_for` — respond only once the write is searchable.
     refresh: Option<String>,
+}
+
+impl DocParams {
+    fn refresh(&self) -> bool {
+        parse_refresh(self.refresh.as_deref())
+    }
 }
 
 /// Render the ES action line + body for a one-item bulk request.
@@ -42,8 +47,8 @@ fn one_item_body(action: &str, index: &str, id: Option<&str>, doc: Option<&Value
 
 /// Run a one-item bulk and unwrap the item into the ES single-document
 /// response shape (the item body, with its `status` as the HTTP status).
-async fn run_one(state: AppState, body: String) -> Response {
-    let result = match execute_bulk(state, None, body).await {
+async fn run_one(state: AppState, body: String, refresh: bool) -> Response {
+    let result = match execute_bulk(state, None, body, refresh).await {
         Ok(result) => result,
         Err(response) => return response,
     };
@@ -100,33 +105,35 @@ pub async fn put_doc(
             );
         }
     };
-    run_one(state, one_item_body(action, &index, Some(&id), Some(&doc))).await
+    run_one(state, one_item_body(action, &index, Some(&id), Some(&doc)), params.refresh()).await
 }
 
 /// POST /{index}/_doc — index a document under a generated id.
 pub async fn post_doc(
     State(state): State<AppState>,
     Path(index): Path<String>,
+    Query(params): Query<DocParams>,
     body: String,
 ) -> Response {
     let doc = match parse_doc(&body) {
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("index", &index, None, Some(&doc))).await
+    run_one(state, one_item_body("index", &index, None, Some(&doc)), params.refresh()).await
 }
 
 /// PUT/POST /{index}/_create/{id} — create-only write.
 pub async fn create_doc(
     State(state): State<AppState>,
     Path((index, id)): Path<(String, String)>,
+    Query(params): Query<DocParams>,
     body: String,
 ) -> Response {
     let doc = match parse_doc(&body) {
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("create", &index, Some(&id), Some(&doc))).await
+    run_one(state, one_item_body("create", &index, Some(&id), Some(&doc)), params.refresh()).await
 }
 
 /// POST /{index}/_update/{id} — partial update (`doc`, `doc_as_upsert`,
@@ -134,21 +141,25 @@ pub async fn create_doc(
 pub async fn update_doc(
     State(state): State<AppState>,
     Path((index, id)): Path<(String, String)>,
+    Query(params): Query<DocParams>,
     body: String,
 ) -> Response {
     let body = match parse_doc(&body) {
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("update", &index, Some(&id), Some(&body))).await
+    run_one(state, one_item_body("update", &index, Some(&id), Some(&body)), params.refresh()).await
 }
 
 /// DELETE /{index}/_doc/{id}
 pub async fn delete_doc(
     State(state): State<AppState>,
     Path((index, id)): Path<(String, String)>,
+    Query(params): Query<DocParams>,
 ) -> Response {
-    run_one(state, one_item_body("delete", &index, Some(&id), None)).await
+    // A delete is a tombstone: visible on this node at once, so there is
+    // no buffer to cut — but honoring the flag keeps clients uniform.
+    run_one(state, one_item_body("delete", &index, Some(&id), None), params.refresh()).await
 }
 
 fn lookup_error(e: SearchError, index: &str) -> Response {
@@ -297,7 +308,7 @@ pub async fn delete_by_query(
         for id in &ids {
             bulk.push_str(&one_item_body("delete", &index, Some(id), None));
         }
-        let result = match execute_bulk(state.clone(), None, bulk).await {
+        let result = match execute_bulk(state.clone(), None, bulk, false).await {
             Ok(result) => result,
             Err(response) => return response,
         };

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -1,0 +1,337 @@
+//! ES document APIs (`/{index}/_doc/{id}` and friends) for document-mode
+//! streams. Writes are one-item bulk requests under the hood, so they
+//! share routing, peer handoff, WAL durability, and tombstone semantics
+//! with `_bulk`; reads go through the document lookup (newest live
+//! version by `_id`).
+
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::{Value, json};
+
+use rsearch_search::{SearchError, SearchRequest};
+
+use crate::bulk_api::{error_response, execute_bulk};
+use crate::state::AppState;
+
+/// Query parameters the document routes understand.
+#[derive(serde::Deserialize, Default)]
+pub struct DocParams {
+    /// `create` makes PUT/POST `_doc/{id}` behave like `_create/{id}`.
+    op_type: Option<String>,
+    /// `true` | `wait_for` | `false` (see phase 14.5).
+    #[allow(dead_code)]
+    refresh: Option<String>,
+}
+
+/// Render the ES action line + body for a one-item bulk request.
+fn one_item_body(action: &str, index: &str, id: Option<&str>, doc: Option<&Value>) -> String {
+    let mut meta = json!({"_index": index});
+    if let Some(id) = id {
+        meta["_id"] = json!(id);
+    }
+    let mut body = json!({ action: meta }).to_string();
+    body.push('\n');
+    if let Some(doc) = doc {
+        body.push_str(&doc.to_string());
+        body.push('\n');
+    }
+    body
+}
+
+/// Run a one-item bulk and unwrap the item into the ES single-document
+/// response shape (the item body, with its `status` as the HTTP status).
+async fn run_one(state: AppState, body: String) -> Response {
+    let result = match execute_bulk(state, None, body).await {
+        Ok(result) => result,
+        Err(response) => return response,
+    };
+    let Some(item) = result["items"]
+        .as_array()
+        .and_then(|items| items.first())
+        .and_then(Value::as_object)
+        .and_then(|o| o.values().next())
+        .cloned()
+    else {
+        return error_response(StatusCode::INTERNAL_SERVER_ERROR, "bulk returned no item");
+    };
+    let status = item["status"]
+        .as_u64()
+        .and_then(|s| StatusCode::from_u16(s as u16).ok())
+        .unwrap_or(StatusCode::OK);
+    let mut body = item;
+    if let Some(obj) = body.as_object_mut() {
+        obj.remove("status");
+    }
+    (status, Json(body)).into_response()
+}
+
+fn parse_doc(body: &str) -> Result<Value, Response> {
+    match serde_json::from_str::<Value>(body) {
+        Ok(doc) if doc.is_object() => Ok(doc),
+        Ok(_) => Err(error_response(StatusCode::BAD_REQUEST, "document must be a JSON object")),
+        Err(e) => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            &format!("document is not valid JSON: {e}"),
+        )),
+    }
+}
+
+/// PUT/POST /{index}/_doc/{id} — index (replace) a document; with
+/// `?op_type=create`, create-only.
+pub async fn put_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+    Query(params): Query<DocParams>,
+    body: String,
+) -> Response {
+    let doc = match parse_doc(&body) {
+        Ok(doc) => doc,
+        Err(response) => return response,
+    };
+    let action = match params.op_type.as_deref() {
+        Some("create") => "create",
+        Some("index") | None => "index",
+        Some(other) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                &format!("unsupported op_type [{other}]"),
+            );
+        }
+    };
+    run_one(state, one_item_body(action, &index, Some(&id), Some(&doc))).await
+}
+
+/// POST /{index}/_doc — index a document under a generated id.
+pub async fn post_doc(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    body: String,
+) -> Response {
+    let doc = match parse_doc(&body) {
+        Ok(doc) => doc,
+        Err(response) => return response,
+    };
+    run_one(state, one_item_body("index", &index, None, Some(&doc))).await
+}
+
+/// PUT/POST /{index}/_create/{id} — create-only write.
+pub async fn create_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+    body: String,
+) -> Response {
+    let doc = match parse_doc(&body) {
+        Ok(doc) => doc,
+        Err(response) => return response,
+    };
+    run_one(state, one_item_body("create", &index, Some(&id), Some(&doc))).await
+}
+
+/// POST /{index}/_update/{id} — partial update (`doc`, `doc_as_upsert`,
+/// `upsert`; no scripts).
+pub async fn update_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+    body: String,
+) -> Response {
+    let body = match parse_doc(&body) {
+        Ok(doc) => doc,
+        Err(response) => return response,
+    };
+    run_one(state, one_item_body("update", &index, Some(&id), Some(&body))).await
+}
+
+/// DELETE /{index}/_doc/{id}
+pub async fn delete_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+) -> Response {
+    run_one(state, one_item_body("delete", &index, Some(&id), None)).await
+}
+
+fn lookup_error(e: SearchError, index: &str) -> Response {
+    match e {
+        SearchError::Metastore(rsearch_metastore::MetastoreError::StreamNotFound(_)) => {
+            crate::search_api::index_not_found(index)
+        }
+        SearchError::BadRequest(reason) => error_response(StatusCode::BAD_REQUEST, &reason),
+        other => error_response(StatusCode::INTERNAL_SERVER_ERROR, &other.to_string()),
+    }
+}
+
+/// GET /{index}/_doc/{id}
+pub async fn get_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+) -> Response {
+    let Some(lookup) = &state.doc_lookup else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "this node runs neither the search nor the ingest role",
+        );
+    };
+    match lookup.get_document(&index, &id).await {
+        Ok(Some(found)) => Json(json!({
+            "_index": index,
+            "_id": id,
+            "_version": found.version,
+            "found": true,
+            "_source": found.source,
+        }))
+        .into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"_index": index, "_id": id, "found": false})),
+        )
+            .into_response(),
+        Err(e) => lookup_error(e, &index),
+    }
+}
+
+/// HEAD /{index}/_doc/{id}
+pub async fn head_doc(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+) -> Response {
+    let Some(lookup) = &state.doc_lookup else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    match lookup.get_document(&index, &id).await {
+        Ok(Some(_)) => StatusCode::OK.into_response(),
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(SearchError::Metastore(rsearch_metastore::MetastoreError::StreamNotFound(_))) => {
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+/// GET /{index}/_source/{id} — just the source.
+pub async fn get_source(
+    State(state): State<AppState>,
+    Path((index, id)): Path<(String, String)>,
+) -> Response {
+    let Some(lookup) = &state.doc_lookup else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "this node runs neither the search nor the ingest role",
+        );
+    };
+    match lookup.get_document(&index, &id).await {
+        Ok(Some(found)) => Json(found.source).into_response(),
+        Ok(None) => (
+            StatusCode::NOT_FOUND,
+            Json(json!({"_index": index, "_id": id, "found": false})),
+        )
+            .into_response(),
+        Err(e) => lookup_error(e, &index),
+    }
+}
+
+/// Max documents deleted per search round of `_delete_by_query` (the
+/// result window); rounds repeat until the query is dry.
+const DELETE_BY_QUERY_PAGE: usize = 10_000;
+/// Safety bound on rounds (100M documents).
+const DELETE_BY_QUERY_MAX_ROUNDS: usize = 10_000;
+
+/// POST /{index}/_delete_by_query — tombstone every live document the
+/// query matches. Each round searches (ids only) and deletes a page; the
+/// tombstones take effect on this node immediately, so the next round
+/// sees only what's left.
+pub async fn delete_by_query(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    body: String,
+) -> Response {
+    let started = std::time::Instant::now();
+    let Some(lookup) = state.doc_lookup.clone() else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "this node runs neither the search nor the ingest role",
+        );
+    };
+    let body: Value = if body.trim().is_empty() {
+        json!({})
+    } else {
+        match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return error_response(StatusCode::BAD_REQUEST, &format!("invalid body: {e}"));
+            }
+        }
+    };
+    let query = body.get("query").cloned().unwrap_or_else(|| json!({"match_all": {}}));
+    let mut deleted = 0usize;
+    let mut rounds = 0usize;
+    loop {
+        rounds += 1;
+        if rounds > DELETE_BY_QUERY_MAX_ROUNDS {
+            break;
+        }
+        let request = SearchRequest {
+            stream: index.clone(),
+            query: query.clone(),
+            from: 0,
+            size: DELETE_BY_QUERY_PAGE,
+            sort_desc: true,
+            aggs: None,
+            include_source: false,
+            track_total_hits: Some(0),
+        };
+        let response = match lookup.search(request).await {
+            Ok(response) => response,
+            Err(e) => return lookup_error(e, &index),
+        };
+        let ids: Vec<String> = response["hits"]["hits"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|h| h["_id"].as_str().map(str::to_string))
+            .collect();
+        if ids.is_empty() {
+            break;
+        }
+        let mut bulk = String::new();
+        for id in &ids {
+            bulk.push_str(&one_item_body("delete", &index, Some(id), None));
+        }
+        let result = match execute_bulk(state.clone(), None, bulk).await {
+            Ok(result) => result,
+            Err(response) => return response,
+        };
+        let mut failures = Vec::new();
+        for item in result["items"].as_array().into_iter().flatten() {
+            let body = item.get("delete").cloned().unwrap_or(Value::Null);
+            if body["status"].as_u64().unwrap_or(500) < 300 {
+                deleted += 1;
+            } else {
+                failures.push(body);
+            }
+        }
+        if !failures.is_empty() {
+            // A log-mode stream (or a metastore error) fails every item
+            // the same way; report the first reason as the request error.
+            let reason = failures[0]["error"]["reason"]
+                .as_str()
+                .unwrap_or("delete failed")
+                .to_string();
+            return error_response(StatusCode::BAD_REQUEST, &reason);
+        }
+        if ids.len() < DELETE_BY_QUERY_PAGE {
+            break;
+        }
+    }
+    Json(json!({
+        "took": started.elapsed().as_millis() as u64,
+        "timed_out": false,
+        "total": deleted,
+        "deleted": deleted,
+        "batches": rounds,
+        "version_conflicts": 0,
+        "noops": 0,
+        "failures": [],
+    }))
+    .into_response()
+}

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -75,7 +75,10 @@ async fn run_one(state: AppState, body: String, refresh: bool) -> Response {
 fn parse_doc(body: &str) -> Result<Value, Response> {
     match serde_json::from_str::<Value>(body) {
         Ok(doc) if doc.is_object() => Ok(doc),
-        Ok(_) => Err(error_response(StatusCode::BAD_REQUEST, "document must be a JSON object")),
+        Ok(_) => Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "document must be a JSON object",
+        )),
         Err(e) => Err(error_response(
             StatusCode::BAD_REQUEST,
             &format!("document is not valid JSON: {e}"),
@@ -105,7 +108,12 @@ pub async fn put_doc(
             );
         }
     };
-    run_one(state, one_item_body(action, &index, Some(&id), Some(&doc)), params.refresh()).await
+    run_one(
+        state,
+        one_item_body(action, &index, Some(&id), Some(&doc)),
+        params.refresh(),
+    )
+    .await
 }
 
 /// POST /{index}/_doc — index a document under a generated id.
@@ -119,7 +127,12 @@ pub async fn post_doc(
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("index", &index, None, Some(&doc)), params.refresh()).await
+    run_one(
+        state,
+        one_item_body("index", &index, None, Some(&doc)),
+        params.refresh(),
+    )
+    .await
 }
 
 /// PUT/POST /{index}/_create/{id} — create-only write.
@@ -133,7 +146,12 @@ pub async fn create_doc(
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("create", &index, Some(&id), Some(&doc)), params.refresh()).await
+    run_one(
+        state,
+        one_item_body("create", &index, Some(&id), Some(&doc)),
+        params.refresh(),
+    )
+    .await
 }
 
 /// POST /{index}/_update/{id} — partial update (`doc`, `doc_as_upsert`,
@@ -148,7 +166,12 @@ pub async fn update_doc(
         Ok(doc) => doc,
         Err(response) => return response,
     };
-    run_one(state, one_item_body("update", &index, Some(&id), Some(&body)), params.refresh()).await
+    run_one(
+        state,
+        one_item_body("update", &index, Some(&id), Some(&body)),
+        params.refresh(),
+    )
+    .await
 }
 
 /// DELETE /{index}/_doc/{id}
@@ -159,7 +182,12 @@ pub async fn delete_doc(
 ) -> Response {
     // A delete is a tombstone: visible on this node at once, so there is
     // no buffer to cut — but honoring the flag keeps clients uniform.
-    run_one(state, one_item_body("delete", &index, Some(&id), None), params.refresh()).await
+    run_one(
+        state,
+        one_item_body("delete", &index, Some(&id), None),
+        params.refresh(),
+    )
+    .await
 }
 
 fn lookup_error(e: SearchError, index: &str) -> Response {
@@ -273,7 +301,10 @@ pub async fn delete_by_query(
             }
         }
     };
-    let query = body.get("query").cloned().unwrap_or_else(|| json!({"match_all": {}}));
+    let query = body
+        .get("query")
+        .cloned()
+        .unwrap_or_else(|| json!({"match_all": {}}));
     let mut deleted = 0usize;
     let mut rounds = 0usize;
     loop {

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -307,6 +307,10 @@ pub async fn delete_by_query(
         .unwrap_or_else(|| json!({"match_all": {}}));
     let mut deleted = 0usize;
     let mut rounds = 0usize;
+    // Progress guard: a round whose ids were all seen in the previous round
+    // means the tombstones are not taking effect (a node ahead in sequence,
+    // or ids this node cannot hide); stop rather than spin.
+    let mut previous: std::collections::HashSet<String> = std::collections::HashSet::new();
     loop {
         rounds += 1;
         if rounds > DELETE_BY_QUERY_MAX_ROUNDS {
@@ -335,6 +339,14 @@ pub async fn delete_by_query(
         if ids.is_empty() {
             break;
         }
+        if !ids.is_empty() && ids.iter().all(|id| previous.contains(id)) {
+            return error_response(
+                StatusCode::CONFLICT,
+                "delete_by_query made no progress: the matched documents are not being hidden \
+                 (retry, or check cluster clock synchronization)",
+            );
+        }
+        previous = ids.iter().cloned().collect();
         let mut bulk = String::new();
         for id in &ids {
             bulk.push_str(&one_item_body("delete", &index, Some(id), None));

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -158,6 +158,7 @@ async fn main() -> anyhow::Result<()> {
             PipelineConfig {
                 max_batch_docs: config.ingest.max_batch_docs,
                 max_batch_secs: config.ingest.max_batch_secs,
+                document_max_batch_secs: config.ingest.document_max_batch_secs,
                 queue_capacity: config.ingest.queue_capacity,
                 work_dir: data_dir.join("staging"),
                 memory_budget: config.ingest.memory_budget_mb << 20,

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -8,6 +8,7 @@ mod auth_api;
 mod bulk_api;
 mod bulk_forward;
 mod control;
+mod doc_api;
 mod internal_api;
 mod loki_api;
 mod metrics;
@@ -194,7 +195,12 @@ async fn main() -> anyhow::Result<()> {
     // cache_max_mb is the node's whole budget, so two roles must not each
     // claim it in full (issue #18). Sharing also lets control-side merge
     // reads warm the cache search serves from.
-    let split_cache = if roles.contains(&Role::Search) || roles.contains(&Role::Control) {
+    // Ingest nodes need it too: document-mode read-modify-write ops
+    // (update, create, GET /_doc) look documents up through a searcher.
+    let needs_cache = roles.contains(&Role::Search)
+        || roles.contains(&Role::Control)
+        || roles.contains(&Role::Ingest);
+    let split_cache = if needs_cache {
         let cache_dir = PathBuf::from(&config.node.data_dir).join("cache");
         // Earlier releases gave control its own budget-sized cache here;
         // reclaim the dead directory rather than let it sit at up to a
@@ -215,13 +221,20 @@ async fn main() -> anyhow::Result<()> {
         None
     };
 
-    // Search role: stateless search service over the shared cache.
-    let search = if roles.contains(&Role::Search) {
+    // Stateless search service over the shared cache: serves /_search on
+    // search nodes and document lookups (update/create/GET) on ingest
+    // nodes — the same instance when a node runs both roles.
+    let lookup = if roles.contains(&Role::Search) || roles.contains(&Role::Ingest) {
         Some(std::sync::Arc::new(rsearch_search::SearchService::new(
             metastore.clone(),
             storage.clone(),
-            split_cache.clone().expect("split cache exists for search role"),
+            split_cache.clone().expect("split cache exists for search/ingest roles"),
         )))
+    } else {
+        None
+    };
+    let search = if roles.contains(&Role::Search) {
+        lookup.clone()
     } else {
         None
     };
@@ -278,6 +291,7 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let mut state = AppState::new(&config, &roles, metastore, pipeline, search);
+    state.doc_lookup = lookup;
     state.draining = draining_flag;
     state.control = control_metrics;
     // Bulk handoff between ingest peers needs the cluster token both to

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -32,6 +32,8 @@ pub struct ControlMetrics {
     pub compacted_docs: AtomicU64,
     /// Tombstone rows purged from the metastore.
     pub tombstones_purged: AtomicU64,
+    /// Tombstone rows pending (as of the last compaction scan).
+    pub tombstones_pending: AtomicU64,
 }
 
 fn counter(out: &mut String, name: &str, help: &str, value: u64) {
@@ -156,6 +158,12 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
             "rsearch_compacted_docs_total",
             "Document versions physically removed by compaction.",
             control.compacted_docs.load(Ordering::Relaxed),
+        );
+        gauge(
+            &mut out,
+            "rsearch_tombstones_pending",
+            "Tombstone rows in the metastore as of the last compaction scan.",
+            control.tombstones_pending.load(Ordering::Relaxed),
         );
         counter(
             &mut out,

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -26,6 +26,12 @@ pub struct ControlMetrics {
     pub repair_failures: AtomicU64,
     pub drain_copies_moved: AtomicU64,
     pub drain_failures: AtomicU64,
+    /// Document-mode compaction: splits rewritten without hidden versions.
+    pub compactions: AtomicU64,
+    /// Documents physically removed by compaction rewrites.
+    pub compacted_docs: AtomicU64,
+    /// Tombstone rows purged from the metastore.
+    pub tombstones_purged: AtomicU64,
 }
 
 fn counter(out: &mut String, name: &str, help: &str, value: u64) {
@@ -138,6 +144,24 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
             "rsearch_drain_failures_total",
             "Drain copy attempts that failed or timed out.",
             control.drain_failures.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_compactions_total",
+            "Document-mode splits rewritten without their tombstoned versions.",
+            control.compactions.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_compacted_docs_total",
+            "Document versions physically removed by compaction.",
+            control.compacted_docs.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_tombstones_purged_total",
+            "Tombstone rows purged once no split could still hold a hidden version.",
+            control.tombstones_purged.load(Ordering::Relaxed),
         );
     }
 

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -72,7 +72,13 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/loki/api/v1/tail", get(crate::loki_api::tail))
         .route("/{index}/_mapping", get(search_api::get_mapping))
-        .route("/{index}", axum::routing::put(search_api::put_index))
+        .route("/{index}/_settings", get(search_api::get_settings))
+        .route(
+            "/{index}",
+            axum::routing::put(search_api::put_index)
+                .get(search_api::get_index)
+                .head(search_api::head_index),
+        )
         .route("/_cat/indices", get(crate::admin_api::cat_indices))
         .route("/_rsearch/routing_rules", get(crate::admin_api::list_rules))
         .route(

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -71,6 +71,27 @@ pub fn router(state: AppState) -> Router {
             get(crate::loki_api::volume_range).post(crate::loki_api::volume_range),
         )
         .route("/loki/api/v1/tail", get(crate::loki_api::tail))
+        // Document APIs (document-mode streams, #34): ES clients reach for
+        // these before _bulk.
+        .route(
+            "/{index}/_doc",
+            post(crate::doc_api::post_doc),
+        )
+        .route(
+            "/{index}/_doc/{id}",
+            axum::routing::put(crate::doc_api::put_doc)
+                .post(crate::doc_api::put_doc)
+                .get(crate::doc_api::get_doc)
+                .head(crate::doc_api::head_doc)
+                .delete(crate::doc_api::delete_doc),
+        )
+        .route(
+            "/{index}/_create/{id}",
+            axum::routing::put(crate::doc_api::create_doc).post(crate::doc_api::create_doc),
+        )
+        .route("/{index}/_update/{id}", post(crate::doc_api::update_doc))
+        .route("/{index}/_source/{id}", get(crate::doc_api::get_source))
+        .route("/{index}/_delete_by_query", post(crate::doc_api::delete_by_query))
         .route("/{index}/_mapping", get(search_api::get_mapping))
         .route("/{index}/_settings", get(search_api::get_settings))
         .route(

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -279,8 +279,14 @@ pub async fn put_index(
             // Existing stream with a different mode: allowed only while it
             // is still empty (e.g. auto-created by a first _bulk).
             state.metastore.set_stream_mode(&index, mode).await?;
+            // This node's caches see the change now; other nodes within
+            // their 10s TTLs (a mode can only change while the stream is
+            // empty, so nothing written in that window is affected yet).
             if let Some(pipeline) = &state.pipeline {
                 pipeline.forget_stream(&index);
+            }
+            for service in [&state.search, &state.doc_lookup].into_iter().flatten() {
+                service.invalidate_stream(&index);
             }
         }
         if let Some(mapping) = &mapping {

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -4,7 +4,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde_json::{Value, json};
 
-use rsearch_metastore::MetastoreError;
+use rsearch_metastore::{MetastoreError, StreamMode};
 use rsearch_search::{SearchError, SearchRequest};
 
 use crate::state::AppState;
@@ -204,24 +204,8 @@ fn glob_match(pattern: &str, name: &str) -> bool {
 /// GET /{index}/_mapping — Grafana fetches this to discover fields.
 pub async fn get_mapping(State(state): State<AppState>, Path(index): Path<String>) -> Response {
     match state.metastore.get_stream(&index).await {
-        Ok(stream) => {
-            let mut properties = stream
-                .mapping
-                .get("properties")
-                .cloned()
-                .unwrap_or_else(|| json!({}));
-            // The timestamp field is always present and always a date.
-            properties["@timestamp"] = json!({"type": "date"});
-            Json(json!({
-                index: {"mappings": {"properties": properties}}
-            }))
-            .into_response()
-        }
-        Err(MetastoreError::StreamNotFound(_)) => es_error(
-            StatusCode::NOT_FOUND,
-            "index_not_found_exception",
-            &format!("no such index [{index}]"),
-        ),
+        Ok(stream) => Json(json!({ index: {"mappings": mappings_json(&stream)} })).into_response(),
+        Err(MetastoreError::StreamNotFound(_)) => index_not_found(&index),
         Err(e) => es_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_error",
@@ -230,7 +214,24 @@ pub async fn get_mapping(State(state): State<AppState>, Path(index): Path<String
     }
 }
 
-/// PUT /{index} — create (or update the mapping of) a stream.
+/// Read the stream mode out of a `PUT /{index}` body: ES-shaped
+/// `settings.index.mode`, `settings.mode`, or a top-level `mode`.
+fn mode_from_body(body: &Value) -> Result<Option<StreamMode>, String> {
+    let raw = body
+        .pointer("/settings/index/mode")
+        .or_else(|| body.pointer("/settings/mode"))
+        .or_else(|| body.get("mode"));
+    match raw {
+        None => Ok(None),
+        Some(Value::String(s)) => StreamMode::parse(s)
+            .map(Some)
+            .ok_or_else(|| format!("unknown index mode '{s}' (expected 'log' or 'document')")),
+        Some(other) => Err(format!("index mode must be a string, got {other}")),
+    }
+}
+
+/// PUT /{index} — create a stream (optionally with `settings.index.mode`)
+/// or update its mapping. The mode is fixed once the stream holds data.
 pub async fn put_index(
     State(state): State<AppState>,
     Path(index): Path<String>,
@@ -250,9 +251,17 @@ pub async fn put_index(
             }
         }
     };
-    let mapping = body_json.get("mappings").cloned().unwrap_or(json!({}));
+    let mode = match mode_from_body(&body_json) {
+        Ok(mode) => mode,
+        Err(reason) => {
+            return es_error(StatusCode::BAD_REQUEST, "illegal_argument_exception", &reason);
+        }
+    };
+    let mapping = body_json.get("mappings").cloned();
     // Validate before storing.
-    if let Err(e) = rsearch_index::IndexMapping::from_json(&mapping) {
+    if let Some(mapping) = &mapping
+        && let Err(e) = rsearch_index::IndexMapping::from_json(mapping)
+    {
         return es_error(
             StatusCode::BAD_REQUEST,
             "mapper_parsing_exception",
@@ -260,8 +269,21 @@ pub async fn put_index(
         );
     }
     let result = async {
-        state.metastore.ensure_stream(&index).await?;
-        state.metastore.update_stream_mapping(&index, &mapping).await
+        let record = match mode {
+            Some(mode) => state.metastore.ensure_stream_with_mode(&index, mode).await?,
+            None => state.metastore.ensure_stream(&index).await?,
+        };
+        if let Some(mode) = mode
+            && record.mode() != mode
+        {
+            // Existing stream with a different mode: allowed only while it
+            // is still empty (e.g. auto-created by a first _bulk).
+            state.metastore.set_stream_mode(&index, mode).await?;
+        }
+        if let Some(mapping) = &mapping {
+            state.metastore.update_stream_mapping(&index, mapping).await?;
+        }
+        Ok::<_, MetastoreError>(())
     }
     .await;
     match result {
@@ -271,12 +293,84 @@ pub async fn put_index(
             "index": index,
         }))
         .into_response(),
+        Err(MetastoreError::StreamModeFixed(_)) => es_error(
+            StatusCode::CONFLICT,
+            "illegal_argument_exception",
+            &format!("index [{index}] already holds data; its mode cannot be changed"),
+        ),
         Err(e) => es_error(
             StatusCode::INTERNAL_SERVER_ERROR,
             "internal_error",
             &e.to_string(),
         ),
     }
+}
+
+/// ES-shaped settings block for a stream.
+fn settings_json(stream: &rsearch_metastore::StreamRecord) -> Value {
+    json!({
+        "index": {
+            "mode": stream.mode,
+            "retention_hours": stream.retention_hours,
+            "number_of_shards": "1",
+            "number_of_replicas": "0",
+        }
+    })
+}
+
+/// ES-shaped mappings block for a stream.
+fn mappings_json(stream: &rsearch_metastore::StreamRecord) -> Value {
+    let mut properties = stream
+        .mapping
+        .get("properties")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+    // The timestamp field is always present and always a date.
+    properties["@timestamp"] = json!({"type": "date"});
+    json!({"properties": properties})
+}
+
+/// GET /{index}/_settings
+pub async fn get_settings(State(state): State<AppState>, Path(index): Path<String>) -> Response {
+    match state.metastore.get_stream(&index).await {
+        Ok(stream) => Json(json!({ index: {"settings": settings_json(&stream)} })).into_response(),
+        Err(MetastoreError::StreamNotFound(_)) => index_not_found(&index),
+        Err(e) => es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string()),
+    }
+}
+
+/// GET /{index} — settings + mappings (what stock clients call to
+/// discover an index).
+pub async fn get_index(State(state): State<AppState>, Path(index): Path<String>) -> Response {
+    match state.metastore.get_stream(&index).await {
+        Ok(stream) => Json(json!({
+            index: {
+                "aliases": {},
+                "mappings": mappings_json(&stream),
+                "settings": settings_json(&stream),
+            }
+        }))
+        .into_response(),
+        Err(MetastoreError::StreamNotFound(_)) => index_not_found(&index),
+        Err(e) => es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string()),
+    }
+}
+
+/// HEAD /{index} — 200 if the index exists, 404 otherwise.
+pub async fn head_index(State(state): State<AppState>, Path(index): Path<String>) -> Response {
+    match state.metastore.get_stream(&index).await {
+        Ok(_) => StatusCode::OK.into_response(),
+        Err(MetastoreError::StreamNotFound(_)) => StatusCode::NOT_FOUND.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+fn index_not_found(index: &str) -> Response {
+    es_error(
+        StatusCode::NOT_FOUND,
+        "index_not_found_exception",
+        &format!("no such index [{index}]"),
+    )
 }
 
 /// GET / — the version handshake clients and shippers probe.

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -368,7 +368,7 @@ pub async fn head_index(State(state): State<AppState>, Path(index): Path<String>
     }
 }
 
-fn index_not_found(index: &str) -> Response {
+pub(crate) fn index_not_found(index: &str) -> Response {
     es_error(
         StatusCode::NOT_FOUND,
         "index_not_found_exception",

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -279,6 +279,9 @@ pub async fn put_index(
             // Existing stream with a different mode: allowed only while it
             // is still empty (e.g. auto-created by a first _bulk).
             state.metastore.set_stream_mode(&index, mode).await?;
+            if let Some(pipeline) = &state.pipeline {
+                pipeline.forget_stream(&index);
+            }
         }
         if let Some(mapping) = &mapping {
             state.metastore.update_stream_mapping(&index, mapping).await?;

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -17,6 +17,10 @@ pub struct AppState {
     pub pipeline: Option<IngestPipeline>,
     /// Present only on nodes running the search role.
     pub search: Option<Arc<SearchService>>,
+    /// Document lookups for the write path (update/create/GET /_doc):
+    /// present on ingest and search nodes (the same instance as `search`
+    /// when both roles run).
+    pub doc_lookup: Option<Arc<SearchService>>,
     pub auth: crate::auth::AuthState,
     /// Mirror of control.allow_insecure_webhooks for the alerts API.
     pub allow_insecure_webhooks: bool,
@@ -63,6 +67,7 @@ impl AppState {
             metastore,
             pipeline,
             search,
+            doc_lookup: None,
             auth: crate::auth::AuthState::default(),
             allow_insecure_webhooks: config.control.allow_insecure_webhooks,
             cors_allow_origin: config.http.cors_allow_origin.clone(),

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -89,6 +89,15 @@ gc_grace_secs = 600         # delay before deleting marked-for-delete splits
 staged_orphan_secs = 3600   # sweep splits stuck in 'staged' after a crash
 repair_stale_secs = 300     # replicated backend: holder silence before re-replication
 allow_insecure_webhooks = false  # require https + block private IPs for alerts
+# Document-mode streams: tombstoned versions are hidden at query time and
+# removed physically by compaction, which runs when a stream accumulates
+# compact_min_tombstones or its oldest tombstone passes compact_max_age_secs
+# (the bound on how long a deleted document survives in storage).
+compact_min_tombstones = 1000
+compact_max_age_secs = 3600
+compact_splits_per_tick = 8
+tombstone_purge_grace_secs = 3600  # keep tombstones at least this long after
+                                   # every split has applied them
 
 # Network log inputs (disabled by default). Each routes to a stream and is
 # subject to routing rules.

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -69,6 +69,8 @@ max_connections = 10
 [ingest]
 max_batch_docs = 500000  # cut a split at this many buffered docs...
 max_batch_secs = 30      # ...or when the oldest doc reaches this age
+document_max_batch_secs = 5  # age bound for document-mode streams (tighter
+                         # time-to-searchable; ?refresh=wait_for forces a cut)
 queue_capacity = 100000  # per-stream in-flight bound before 429s
 memory_budget_mb = 256   # tantivy writer heap per stream worker
 wal_segment_mb = 64      # WAL segment rotation size

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -97,7 +97,8 @@ compact_min_tombstones = 1000
 compact_max_age_secs = 3600
 compact_splits_per_tick = 8
 tombstone_purge_grace_secs = 3600  # keep tombstones at least this long after
-                                   # every split has applied them
+                                   # every split has applied them (covers docs
+                                   # still buffered/unreplayed on ingest nodes)
 
 # Network log inputs (disabled by default). Each routes to a stream and is
 # subject to routing rules.

--- a/tests/cluster/run-document-mode-test.sh
+++ b/tests/cluster/run-document-mode-test.sh
@@ -101,6 +101,14 @@ curl -s -XPOST "$U/logs/_bulk" -H "$ND" --data-binary $'{"index":{"_id":"x"}}\n{
 code=$(curl -s -o /dev/null -w '%{http_code}' -XDELETE "$U/logs/_doc/x")
 [ "$code" = 400 ] || fail "_doc delete on log stream -> 400 (got $code)"
 
+say "delete/update on a missing index are 404 (no implicit creation)"
+curl -s -XPOST "$U/_bulk" -H "$ND" --data-binary $'{"delete":{"_index":"nope","_id":"1"}}\n' | jq -e '.items[0].delete.status == 404' >/dev/null || fail "bulk delete on missing index -> 404"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XDELETE "$U/nope/_doc/1")
+[ "$code" = 404 ] || fail "DELETE _doc on missing index -> 404 (got $code)"
+[ "$(curl -s "$U/_cat/indices" | jq -r '[.[] | select(.index=="nope")] | length')" = 0 ] || fail "missing index was not created"
+curl -s -XPOST "$U/recs/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":42}}\n{"title":"numeric"}\n' | jq -e '.items[0].index._id == "42"' >/dev/null || fail "numeric _id coerced"
+curl -s -XDELETE "$U/recs/_doc/42" >/dev/null
+
 say "delete_by_query"
 curl -s -XPOST "$U/recs/_delete_by_query" -H "$J" -d '{"query":{"term":{"title":"e1"}}}' | jq -e '.deleted == 1' >/dev/null || fail "delete_by_query"
 [ "$(ids recs)" = "a,buffered,c,d" ] || fail "ids after delete_by_query: $(ids recs)"

--- a/tests/cluster/run-document-mode-test.sh
+++ b/tests/cluster/run-document-mode-test.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Document-mode end-to-end test (phase 14, issue #34): one all-roles node
+# on the fs storage backend + Postgres (DATABASE_URL from .env).
+# Proves: mode at creation, index/replace/delete by _id, ES _doc routes,
+# update/create semantics, ?refresh=wait_for, log streams unaffected,
+# compaction making deletes physical, tombstone purge, and least-privilege
+# keys (stream-scoped ingest key can create its index and write documents).
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+BIN=./target/release/rsearch
+LOGDIR=/tmp/rsearch-docmode
+PORT=9260
+U="http://127.0.0.1:$PORT"
+say() { echo "==> $*"; }
+pause() { perl -e "select(undef,undef,undef,$1)"; }
+fail() { echo "FAIL: $*"; exit 1; }
+
+PID=""
+cleanup() { [ -n "$PID" ] && kill -9 "$PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+set -a; source .env; set +a
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+psql "$DATABASE_URL" -qc "DELETE FROM streams; DELETE FROM nodes; DELETE FROM users; DELETE FROM api_keys; DELETE FROM sessions;" >/dev/null
+
+say "starting node (document batches 1s, compaction after 5s, purge grace 5s)"
+env DATABASE_URL="$DATABASE_URL" \
+  RSEARCH_NODE__ID=docmode-1 \
+  RSEARCH_NODE__DATA_DIR="$LOGDIR/node" \
+  RSEARCH_HTTP__BIND_ADDR="127.0.0.1:$PORT" \
+  RSEARCH_STORAGE__BACKEND=fs \
+  RSEARCH_STORAGE__ROOT="$LOGDIR/store" \
+  RSEARCH_INGEST__MAX_BATCH_SECS=30 \
+  RSEARCH_INGEST__DOCUMENT_MAX_BATCH_SECS=1 \
+  RSEARCH_INGEST__BALANCE_BULK=false \
+  RSEARCH_CONTROL__INTERVAL_SECS=2 \
+  RSEARCH_CONTROL__MERGE_MIN_MB=0 \
+  RSEARCH_CONTROL__GC_GRACE_SECS=2 \
+  RSEARCH_CONTROL__COMPACT_MAX_AGE_SECS=5 \
+  RSEARCH_CONTROL__TOMBSTONE_PURGE_GRACE_SECS=5 \
+  "$BIN" --roles ingest,search,control >"$LOGDIR/node.log" 2>&1 &
+PID=$!
+for i in $(seq 1 60); do curl -sf "$U/health" >/dev/null && break; pause 0.25; done
+curl -sf "$U/health" >/dev/null || fail "node did not come up"
+
+J='Content-Type: application/json'
+ND='Content-Type: application/x-ndjson'
+total() { curl -s -XPOST "$U/$1/_search" -H "$J" -d '{"size":0}' | jq -r '.hits.total.value'; }
+ids() { curl -s -XPOST "$U/$1/_search" -H "$J" -d '{"size":100,"_source":false}' | jq -r '[.hits.hits[]._id] | sort | join(",")'; }
+sql() { psql "$DATABASE_URL" -Atc "$1"; }
+
+say "index modes"
+curl -s -XPUT "$U/recs" -H "$J" -d '{"settings":{"index":{"mode":"document"}},"mappings":{"properties":{"title":{"type":"keyword"}}}}' | jq -e '.acknowledged' >/dev/null || fail "create document index"
+[ "$(curl -s "$U/recs/_settings" | jq -r '.recs.settings.index.mode')" = document ] || fail "settings mode"
+curl -s -XPUT "$U/logs" -H "$J" -d '{}' >/dev/null
+[ "$(curl -s "$U/_cat/indices" | jq -r '.[] | select(.index=="logs") | .mode')" = log ] || fail "log default mode"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/recs" -H "$J" -d '{"settings":{"index":{"mode":"log"}}}')
+[ "$code" = 200 ] || fail "empty stream may still switch mode (got $code)"
+curl -s -XPUT "$U/recs" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}' >/dev/null
+
+say "bulk index with explicit ids, replace, delete"
+curl -s -XPOST "$U/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_index":"recs","_id":"a"}}\n{"title":"a1","v":1}\n{"index":{"_index":"recs","_id":"b"}}\n{"title":"b1","v":1}\n{"index":{"_index":"recs","_id":"c"}}\n{"title":"c1","v":1}\n' | jq -e '.errors == false' >/dev/null || fail "bulk index"
+[ "$(total recs)" = 3 ] || fail "3 docs visible after refresh"
+curl -s -XPOST "$U/recs/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"a"}}\n{"title":"a2","v":2}\n{"delete":{"_id":"b"}}\n' | jq -e '.errors == false' >/dev/null || fail "bulk replace/delete"
+[ "$(total recs)" = 2 ] || fail "replace+delete -> 2 visible (got $(total recs))"
+[ "$(ids recs)" = "a,c" ] || fail "ids after delete: $(ids recs)"
+[ "$(curl -s "$U/recs/_doc/a" | jq -r '._source.v')" = 2 ] || fail "GET returns newest version"
+[ "$(curl -s -XPOST "$U/recs/_search" -H "$J" -d '{"aggs":{"t":{"terms":{"field":"title"}}}}' | jq -r '[.aggregations.t.buckets[].key] | sort | join(",")')" = "a2,c1" ] || fail "aggregations skip hidden versions"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/recs" -H "$J" -d '{"settings":{"index":{"mode":"log"}}}')
+[ "$code" = 409 ] || fail "mode is fixed once data exists (got $code)"
+
+say "document routes"
+curl -s -XPUT "$U/recs/_doc/d?refresh=wait_for" -H "$J" -d '{"title":"d1"}' | jq -e '._id == "d"' >/dev/null || fail "PUT _doc"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/recs/_create/d" -H "$J" -d '{"title":"dup"}')
+[ "$code" = 409 ] || fail "_create on existing id -> 409 (got $code)"
+curl -s -XPOST "$U/recs/_update/d?refresh=wait_for" -H "$J" -d '{"doc":{"n":1,"nested":{"x":1}}}' | jq -e '.result == "updated"' >/dev/null || fail "_update"
+[ "$(curl -s "$U/recs/_source/d" | jq -c '.')" = '{"n":1,"nested":{"x":1},"title":"d1"}' ] || fail "_update merged: $(curl -s "$U/recs/_source/d")"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPOST "$U/recs/_update/ghost" -H "$J" -d '{"doc":{"n":1}}')
+[ "$code" = 404 ] || fail "_update missing -> 404 (got $code)"
+curl -s -XPOST "$U/recs/_update/ghost?refresh=wait_for" -H "$J" -d '{"doc":{"n":1},"doc_as_upsert":true}' | jq -e '.result == "created"' >/dev/null || fail "doc_as_upsert"
+curl -s -XDELETE "$U/recs/_doc/ghost" | jq -e '.result == "deleted"' >/dev/null || fail "DELETE _doc"
+code=$(curl -s -o /dev/null -w '%{http_code}' "$U/recs/_doc/ghost")
+[ "$code" = 404 ] || fail "GET after delete -> 404 (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -I "$U/recs/_doc/a")
+[ "$code" = 200 ] || fail "HEAD existing -> 200 (got $code)"
+gen=$(curl -s -XPOST "$U/recs/_doc?refresh=wait_for" -H "$J" -d '{"title":"gen"}' | jq -r '._id')
+[ "${#gen}" = 32 ] || fail "POST _doc generates an id"
+curl -s -XDELETE "$U/recs/_doc/$gen" >/dev/null
+
+say "refresh semantics"
+curl -s -XPUT "$U/recs/_doc/buffered" -H "$J" -d '{"title":"buf"}' >/dev/null
+code=$(curl -s -o /dev/null -w '%{http_code}' "$U/recs/_doc/buffered")
+[ "$code" = 404 ] || fail "write without refresh is not visible yet (got $code)"
+curl -s -XPOST "$U/_bulk?refresh=true" -H "$ND" --data-binary $'{"index":{"_index":"recs","_id":"e"}}\n{"title":"e1"}\n' >/dev/null
+code=$(curl -s -o /dev/null -w '%{http_code}' "$U/recs/_doc/buffered")
+[ "$code" = 200 ] || fail "refresh=true flushed the earlier write too (got $code)"
+
+say "log streams are unaffected"
+curl -s -XPOST "$U/logs/_bulk" -H "$ND" --data-binary $'{"index":{"_id":"x"}}\n{"message":"one"}\n{"index":{"_id":"x"}}\n{"message":"two"}\n{"delete":{"_id":"x"}}\n' | jq -e '.items[2].delete.status == 400 and (.items[2].delete.error.reason | test("log-mode"))' >/dev/null || fail "log stream rejects delete with guidance"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XDELETE "$U/logs/_doc/x")
+[ "$code" = 400 ] || fail "_doc delete on log stream -> 400 (got $code)"
+
+say "delete_by_query"
+curl -s -XPOST "$U/recs/_delete_by_query" -H "$J" -d '{"query":{"term":{"title":"e1"}}}' | jq -e '.deleted == 1' >/dev/null || fail "delete_by_query"
+[ "$(ids recs)" = "a,buffered,c,d" ] || fail "ids after delete_by_query: $(ids recs)"
+
+say "compaction makes deletes physical; tombstones purge"
+# Log ingest of the 'x' docs above happens on the 30s window — irrelevant here.
+before=$(sql "SELECT COALESCE(SUM(doc_count),0) FROM splits s JOIN streams st ON st.id=s.stream_id WHERE st.name='recs' AND s.state='published'")
+[ "$before" -gt 4 ] || fail "hidden versions still physically present before compaction ($before)"
+for i in $(seq 1 60); do
+  physical=$(sql "SELECT COALESCE(SUM(doc_count),0) FROM splits s JOIN streams st ON st.id=s.stream_id WHERE st.name='recs' AND s.state='published'")
+  left=$(sql "SELECT count(*) FROM doc_tombstones t JOIN streams st ON st.id=t.stream_id WHERE st.name='recs'")
+  [ "$physical" = 4 ] && [ "$left" = 0 ] && break
+  pause 1
+done
+[ "$physical" = 4 ] || fail "compaction did not remove hidden versions (physical=$physical)"
+[ "$left" = 0 ] || fail "tombstones not purged ($left left)"
+[ "$(ids recs)" = "a,buffered,c,d" ] || fail "ids after compaction: $(ids recs)"
+[ "$(curl -s "$U/recs/_doc/a" | jq -r '._source.v')" = 2 ] || fail "newest version survives compaction"
+grep -q "compacting split" "$LOGDIR/node.log" || fail "no compaction logged"
+
+say "least-privilege key: stream-scoped ingest creates its index and writes"
+curl -s -XPUT "$U/_rsearch/users/admin" -H "$J" -d '{"password":"adminpassword123","role":"admin"}' | jq -e '.acknowledged' >/dev/null || fail "create admin"
+TOKEN=$(curl -s -XPOST "$U/_rsearch/login" -H "$J" -d '{"username":"admin","password":"adminpassword123"}' | jq -r '.token')
+KEY=$(curl -s -XPOST "$U/_rsearch/api_keys" -H "Authorization: Bearer $TOKEN" -H "$J" -d '{"name":"app","actions":["ingest","search"],"streams":["app-items"]}' | jq -r '.key')
+[ -n "$KEY" ] && [ "$KEY" != null ] || fail "create api key"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app-items" -H "Authorization: Bearer $KEY" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}')
+[ "$code" = 200 ] || fail "scoped ingest key creates its index (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app-items/_doc/1?refresh=wait_for" -H "Authorization: Bearer $KEY" -H "$J" -d '{"name":"one"}')
+[ "$code" = 200 ] || fail "scoped key writes a document (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' "$U/app-items/_doc/1" -H "Authorization: Bearer $KEY")
+[ "$code" = 200 ] || fail "scoped key reads a document (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/other/_doc/1" -H "Authorization: Bearer $KEY" -H "$J" -d '{}')
+[ "$code" = 403 ] || fail "scoped key is denied outside its streams (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' "$U/_rsearch/users" -H "Authorization: Bearer $KEY")
+[ "$code" = 403 ] || fail "scoped key is not admin (got $code)"
+
+say "PASS: document mode end to end"

--- a/working-plan.md
+++ b/working-plan.md
@@ -389,7 +389,7 @@ tombstones in the metastore since splits are immutable shared objects):
       splits with pending tombstones (`compact_min_tombstones`,
       `compact_max_age_secs`); tombstone purge once no published split
       can hold a hidden doc; metrics for tombstones pending/purged.
-- [ ] 14.7 Tests + docs: unit tests (WAL v2 + legacy replay, bulk parse
+- [x] 14.7 Tests + docs: unit tests (WAL v2 + legacy replay, bulk parse
       of delete/update, exclusion query, tombstone applicability), an
       ignored Postgres test for tombstone SQL, a `tests/cluster/
       run-document-mode-test.sh` end-to-end (index → replace → delete →
@@ -397,6 +397,12 @@ tombstones in the metastore since splits are immutable shared objects):
       auth doc leading with `Authorization: Bearer`; reply on #34.
 
 ## Deferred (explicitly out of v1)
+
+- Document mode follow-ups (phase 14): a per-node recent-writes buffer so
+  `update`/`create`/GET see documents before their split is cut (today:
+  use `?refresh=wait_for`); glob patterns in API-key stream scopes
+  (`app-*`); `_mget`; `_update` scripts; `_version`-based optimistic
+  concurrency (`if_seq_no`)
 
 - Distributed search fan-out across searchers (any searcher answers alone in v1)
 - Replicated ingest WAL; Kafka/Kinesis sources

--- a/working-plan.md
+++ b/working-plan.md
@@ -384,7 +384,7 @@ tombstones in the metastore since splits are immutable shared objects):
       stream's current batch and resolves once it is published; bulk
       handoff forwards the flag. Document the default window
       (`ingest.max_batch_secs` / `document_max_batch_secs`).
-- [ ] 14.6 Compaction + purge: merge applies tombstones and stamps
+- [x] 14.6 Compaction + purge: merge applies tombstones and stamps
       `tombstone_seq_applied`; new control job rewrites document-mode
       splits with pending tombstones (`compact_min_tombstones`,
       `compact_max_age_secs`); tombstone purge once no published split

--- a/working-plan.md
+++ b/working-plan.md
@@ -300,6 +300,102 @@ Design decisions (locked):
       range clamping; L4 drain deletes the file on the draining node via
       peer DELETE (row-only fallback if unreachable)
 
+## Phase 14 — Document mode: index/update/delete by `_id` (issue #34)
+
+Goal: let an application use rSearch as a search index for *records it
+edits* — delete by `_id`, `index` on an existing `_id` replaces, stock ES
+client `_doc` routes, and a bounded/forced visibility window — without
+changing the log path's cost model. Design (Lucene live-docs in cache form,
+tombstones in the metastore since splits are immutable shared objects):
+
+- Every new split stores two reserved fields: `_id` (STRING|STORED, the
+  client's id or a generated UUID) and `_seq` (i64 INDEXED|FAST, a
+  node-local monotonic micros-since-epoch stamp taken when the write is
+  accepted). `SplitMeta.schema_version = 1` marks such splits; `0`/absent
+  = legacy (no ids — treated as never tombstoned).
+- A stream has `mode` ∈ {`log` (default), `document`}. Only document-mode
+  streams accept `delete`/`update`, write tombstones, and pay the
+  exclusion filter at query time. Log streams are untouched.
+- `doc_tombstones(seq BIGSERIAL, stream_id, doc_id, before_seq)`: "hide
+  every doc with this `_id` whose `_seq < before_seq`". `delete` inserts
+  (`before_seq = now`); `index`/`create`/`update` in document mode insert
+  (`before_seq = the new doc's _seq`) then WAL-append the doc, so reads
+  see exactly the newest version. Tombstone rows are written *before* the
+  WAL so a crash can't leave a replayed doc without its tombstone.
+- Search (every path funnels through `SearchService::search`): per
+  document-mode stream, the tombstone list is loaded incrementally (by
+  `seq`) into a short-TTL cache; per split the applicable tombstones are
+  resolved to an excluded doc set (term lookup on `_id` + `_seq` fast
+  column) and cached on the `SplitReader` (incremental by tombstone seq —
+  splits are immutable so the set only grows). The main query is wrapped
+  as `bool{must: q, must_not: ExcludeDocs}` so counts and aggregations
+  are correct; the H3 doc_count/skip_count fast paths are disabled when a
+  split has exclusions.
+- Compaction makes erasure physical: the merge job applies tombstones when
+  it re-indexes, records `tombstone_seq_applied` on the new split, and a
+  document-mode split with pending tombstones is rewritten on its own once
+  enough have accumulated or the oldest is past `compact_max_age_secs`
+  (bounded erasure latency). Tombstones are purged once no published split
+  can still contain a doc they hide.
+
+- [x] 14.1 Persist `_id` + `_seq` end to end: reserved schema fields
+      (appended after mapped fields so legacy split ordinals are
+      unchanged), `SplitMeta.schema_version`, `SplitBuilder::add_document
+      (doc, source, id, seq, fallback_ts)`, WAL payload v2 (flagged
+      stream_len high bit; legacy records replay with a generated id and
+      seq 0), `WorkItem{source,id,seq,pos}`, bulk/syslog/GELF/replay paths
+      carry them, merge re-indexes preserving id/seq, search hits return
+      the real `_id` (page fetch reads it from the doc store; legacy
+      splits keep the synthetic `split:seg:doc` id), `term`/`terms` on
+      `_id` and the `ids` query resolve `_id` by name against each split's
+      own schema. Per-split query translation uses the split's own
+      mapping (fixes ordinal drift after mapping changes).
+- [ ] 14.2 Stream `mode`: migration adds `streams.mode TEXT NOT NULL
+      DEFAULT 'log' CHECK (mode IN ('log','document'))`; `StreamRecord.mode`
+      + all column lists; `PUT /{index}` accepts `{"settings":{"index":
+      {"mode":"document"}}}` (also top-level `"mode"`); mode is fixed at
+      creation (409 on change); `GET /{index}/_settings`, `GET /{index}`
+      (settings+mappings), `_cat/indices` show mode; `ingest.
+      document_max_batch_secs` (default 5) bounds time-to-searchable for
+      document-mode streams; `PUT /{index}` classifies as
+      `Ingest(index)` (ingest keys already create streams via `_bulk`).
+- [ ] 14.3 Tombstones + deletion semantics: migration `doc_tombstones`
+      (+ `splits.seq_min/seq_max/tombstone_seq_applied`); metastore
+      upsert-batch / list-since-seq / stats; bulk `delete` accepted on
+      document-mode streams (rejected with the existing message on log
+      streams), `index`/`create` on document-mode streams tombstone older
+      versions; `_version` in responses = `_seq`; search-side exclusion
+      (ExcludeDocs query, per-reader excluded-doc cache, per-stream
+      tombstone cache with TTL + local invalidation on write, fast paths
+      disabled when exclusions apply). GET-by-id helper (term on `_id`,
+      exclusions applied, newest `_seq` wins) used by 14.4.
+- [ ] 14.4 ES document routes: `PUT/POST /{index}/_doc/{id}`, `POST
+      /{index}/_doc` (generated id), `GET/HEAD /{index}/_doc/{id}`,
+      `DELETE /{index}/_doc/{id}`, `PUT/POST /{index}/_create/{id}`
+      (409 if a live doc exists — checked against published splits, see
+      visibility caveat), `POST /{index}/_update/{id}` (`doc` merge,
+      `doc_as_upsert`; no scripts), bulk `update` (same semantics),
+      `POST /{index}/_delete_by_query`; all on document-mode streams
+      only (log streams 400 with a clear reason); `classify()` arms:
+      `_doc`/`_create`/`_update`/`_delete_by_query` writes →
+      `Ingest(index)`, reads → `Search(index)`.
+- [ ] 14.5 `?refresh=true|wait_for` on `_bulk` and the document routes
+      (document-mode streams): pipeline `flush_stream(stream)` cuts the
+      stream's current batch and resolves once it is published; bulk
+      handoff forwards the flag. Document the default window
+      (`ingest.max_batch_secs` / `document_max_batch_secs`).
+- [ ] 14.6 Compaction + purge: merge applies tombstones and stamps
+      `tombstone_seq_applied`; new control job rewrites document-mode
+      splits with pending tombstones (`compact_min_tombstones`,
+      `compact_max_age_secs`); tombstone purge once no published split
+      can hold a hidden doc; metrics for tombstones pending/purged.
+- [ ] 14.7 Tests + docs: unit tests (WAL v2 + legacy replay, bulk parse
+      of delete/update, exclusion query, tombstone applicability), an
+      ignored Postgres test for tombstone SQL, a `tests/cluster/
+      run-document-mode-test.sh` end-to-end (index → replace → delete →
+      refresh → compaction → GET 404); README document-mode section +
+      auth doc leading with `Authorization: Bearer`; reply on #34.
+
 ## Deferred (explicitly out of v1)
 
 - Distributed search fan-out across searchers (any searcher answers alone in v1)

--- a/working-plan.md
+++ b/working-plan.md
@@ -350,7 +350,7 @@ tombstones in the metastore since splits are immutable shared objects):
       `_id` and the `ids` query resolve `_id` by name against each split's
       own schema. Per-split query translation uses the split's own
       mapping (fixes ordinal drift after mapping changes).
-- [ ] 14.2 Stream `mode`: migration adds `streams.mode TEXT NOT NULL
+- [x] 14.2 Stream `mode`: migration adds `streams.mode TEXT NOT NULL
       DEFAULT 'log' CHECK (mode IN ('log','document'))`; `StreamRecord.mode`
       + all column lists; `PUT /{index}` accepts `{"settings":{"index":
       {"mode":"document"}}}` (also top-level `"mode"`); mode is fixed at

--- a/working-plan.md
+++ b/working-plan.md
@@ -379,7 +379,7 @@ tombstones in the metastore since splits are immutable shared objects):
       only (log streams 400 with a clear reason); `classify()` arms:
       `_doc`/`_create`/`_update`/`_delete_by_query` writes →
       `Ingest(index)`, reads → `Search(index)`.
-- [ ] 14.5 `?refresh=true|wait_for` on `_bulk` and the document routes
+- [x] 14.5 `?refresh=true|wait_for` on `_bulk` and the document routes
       (document-mode streams): pipeline `flush_stream(stream)` cuts the
       stream's current batch and resolves once it is published; bulk
       handoff forwards the flag. Document the default window

--- a/working-plan.md
+++ b/working-plan.md
@@ -359,7 +359,7 @@ tombstones in the metastore since splits are immutable shared objects):
       document_max_batch_secs` (default 5) bounds time-to-searchable for
       document-mode streams; `PUT /{index}` classifies as
       `Ingest(index)` (ingest keys already create streams via `_bulk`).
-- [ ] 14.3 Tombstones + deletion semantics: migration `doc_tombstones`
+- [x] 14.3 Tombstones + deletion semantics: migration `doc_tombstones`
       (+ `splits.seq_min/seq_max/tombstone_seq_applied`); metastore
       upsert-batch / list-since-seq / stats; bulk `delete` accepted on
       document-mode streams (rejected with the existing message on log

--- a/working-plan.md
+++ b/working-plan.md
@@ -369,7 +369,7 @@ tombstones in the metastore since splits are immutable shared objects):
       tombstone cache with TTL + local invalidation on write, fast paths
       disabled when exclusions apply). GET-by-id helper (term on `_id`,
       exclusions applied, newest `_seq` wins) used by 14.4.
-- [ ] 14.4 ES document routes: `PUT/POST /{index}/_doc/{id}`, `POST
+- [x] 14.4 ES document routes: `PUT/POST /{index}/_doc/{id}`, `POST
       /{index}/_doc` (generated id), `GET/HEAD /{index}/_doc/{id}`,
       `DELETE /{index}/_doc/{id}`, `PUT/POST /{index}/_create/{id}`
       (409 if a live doc exists — checked against published splits, see


### PR DESCRIPTION
Closes #34.

Adds a per-index **document mode** so an application can use rSearch as a search index for records it edits — delete by `_id`, `index` replaces, the stock ES `_doc` routes, and `?refresh=wait_for` — while log indices stay append-only with no extra cost. Phase 14 in `working-plan.md` has the design; README gains a "Document mode" section and an applications-auth section.

## What's in it

- **`_id` / `_seq` persisted** on every document (reserved fields appended after mapped fields so legacy split ordinals are unchanged; `schema_version` in split footers; WAL v2 payload with legacy replay). Hits return the real `_id` and `_version` (= write sequence); queries translate against each split's own schema; `ids` query.
- **Stream `mode`** (`log` default | `document`) set at creation via `PUT /{index}` `settings.index.mode`, fixed once the index holds data; `GET/HEAD /{index}`, `GET /{index}/_settings`, mode in `_cat/indices`; `ingest.document_max_batch_secs` (5s).
- **Tombstones** (one metastore row per index + `_id`: "hide versions older than this write"): `delete` and explicit-id `index`/`create` write them; search applies them inside the query (custom Tantivy `must_not` clause, per-reader incrementally extended excluded-doc set) so hits, counts and aggregations agree.
- **ES document routes**: `PUT/POST/GET/HEAD/DELETE /{index}/_doc/{id}`, `POST /{index}/_doc`, `_create` (409 if live), `_update` (`doc`/`doc_as_upsert`/`upsert`), `_source`, `_delete_by_query`, plus bulk `update`/`create` — one-item bulk requests underneath (shared routing, peer handoff, WAL).
- **`?refresh=true|wait_for`** on `_bulk` and the document routes: cuts the split now and returns once published (travels with handoff).
- **Compaction + purge**: merges apply tombstones; a compaction job rewrites document-mode splits (or just marks them up to date) once an index hits `compact_min_tombstones` / `compact_max_age_secs`; tombstones purge once every split has applied them and a grace has passed. Metrics: `rsearch_compactions_total`, `rsearch_compacted_docs_total`, `rsearch_tombstones_pending`, `rsearch_tombstones_purged_total`.
- **Auth**: `PUT /{index}` and document writes classify as stream-scoped `ingest`, document reads / `GET /{index}` / `_settings` as stream-scoped `search` — a key with `{"actions":["ingest","search"],"streams":["items"]}` can create its index, write and read, nothing else.
- **Review pass applied** (last two commits): hybrid logical clock for `_seq` (observes per-id tombstone bounds + stream max before stamping), replacement tombstones written after the write is durable (WAL flag + replay re-issue), per-stream advisory lock so tombstone seqs commit in order, index-driven purge, batched RMW lookups, seeded reader exclusion state, bounded compaction scan, `_delete_by_query` progress guard, and assorted ES-compat fixes (numeric `_id`, 404 on missing index).

## Migrations

Three new migrations in `crates/rsearch-metastore/migrations` (`streams.mode`, `doc_tombstones` + split `seq_min/seq_max/tombstone_seq_applied`, indexes). Applied automatically at startup.

## Testing

- Unit tests across index/ingest/search/server (WAL v2 + legacy replay, bulk parsing of all four actions, exclusion application + seeding, identity round-trip, auth classification, `SeqClock`).
- Postgres-backed tests (`RSEARCH_TEST_DATABASE_URL=... cargo test -p rsearch-metastore -- --ignored`): stream mode fixing, tombstone upsert/paging/bounds, purge floor + grace.
- `tests/cluster/run-document-mode-test.sh`: single fs-backed node end to end — modes, replace/delete, aggs, `_doc` routes, refresh, log-stream rejection, missing-index 404, `_delete_by_query`, compaction making deletes physical + purge, least-privilege key.

## Known limits (documented)

`update`/`create`/GET read published splits only (use `refresh=wait_for` on RMW chains; a per-node recent-writes buffer is a follow-up); other search nodes see a delete within ~1s; drain an ingest node's WAL before downtime longer than `compact_max_age_secs + tombstone_purge_grace_secs`; old splits keep synthetic ids until merged.
