### PR TITLE
query_string fields, simple_query_string, glob stream scopes (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ and IMDS are never touched.
 | Observability | `GET /metrics` (Prometheus), `GET /_rsearch/stats` (JSON) |
 
 Query DSL subset: `match_all`, `bool`, `term`, `terms`, `ids`, `range`,
-`exists`, `match`, `match_phrase`, `query_string`. Aggregations pass
+`exists`, `match`, `match_phrase`, `query_string`, `simple_query_string`
+(the same lenient parser — a typo never 400s; `fields` with `^boost`,
+`default_field`, and `default_operator` are honored, `flags` is accepted
+and ignored; bare terms search the mapped text fields, unmapped fields by
+`name:term` or via `fields`). Aggregations pass
 through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 
@@ -287,6 +291,11 @@ already redact) or `X-Api-Key: <key>`. A key carries an action set and a
 stream list, so an application can hold a least-privilege key: with
 `{"actions": ["ingest", "search"], "streams": ["items"]}` it can create
 its index (`PUT /items`), write and read documents, and nothing else.
+Stream entries are exact names or globs (`*` matches any run of
+characters): `"streams": ["acme-*"]` scopes a multi-tenant application to
+the indices it derives from its tenant names without `*` or an up-front
+list; `*` alone still means every stream (required for `/_bulk` without
+an index in the URL, `/_msearch`, and the Loki API).
 `PUT /{index}`, the document writes and `_delete_by_query` classify as
 stream-scoped `ingest`; document reads, `GET /{index}` and `_settings`
 as stream-scoped `search`. Everything under `/_rsearch/` stays admin.

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -279,9 +279,13 @@ pub fn translate_query(
         "match" => translate_match(index, schema, body, false),
         "match_phrase" => translate_match(index, schema, body, true),
         "query_string" => translate_query_string(index, schema, body),
+        // Same engine: our query_string parse is already lenient (never a
+        // 400 on a typo), which is the property simple_query_string exists
+        // for; `flags` is accepted and ignored.
+        "simple_query_string" => translate_query_string(index, schema, body),
         other => Err(SearchError::BadRequest(format!(
             "unsupported query type '{other}' (supported: match_all, bool, term, terms, \
-             ids, range, exists, match, match_phrase, query_string)"
+             ids, range, exists, match, match_phrase, query_string, simple_query_string)"
         ))),
     }
 }
@@ -632,6 +636,11 @@ fn translate_match(
     }
 }
 
+/// `query_string` / `simple_query_string`. Honors `fields` (with ES `^boost`
+/// suffixes and a bare `*`) or `default_field`; without either, every
+/// mapped text field plus the dynamic catch-all is searched, so bare
+/// terms search everything tokenized. `default_operator` defaults to
+/// AND (log-search convention); pass `"or"` for ES's default.
 fn translate_query_string(
     index: &tantivy::Index,
     schema: &MappedSchema,
@@ -641,22 +650,95 @@ fn translate_query_string(
         .get("query")
         .and_then(Value::as_str)
         .ok_or_else(|| SearchError::BadRequest("query_string needs 'query'".into()))?;
+    let conjunction = !matches!(
+        body.get("default_operator").and_then(Value::as_str),
+        Some(op) if op.eq_ignore_ascii_case("or")
+    );
 
-    // Default search fields: every mapped text field plus the dynamic
-    // catch-all, so bare terms search everything tokenized.
-    let mut default_fields: Vec<Field> = schema
-        .fields
-        .values()
-        .filter(|(_, ty)| *ty == FieldType::Text)
-        .map(|(field, _)| *field)
-        .collect();
-    default_fields.push(schema.dynamic);
+    // Requested fields: `fields: [..]` wins, else `default_field`, else
+    // everything. `*` (alone) means everything too.
+    let requested: Vec<String> = match (body.get("fields"), body.get("default_field")) {
+        (Some(Value::Array(items)), _) => items
+            .iter()
+            .filter_map(Value::as_str)
+            .map(str::to_string)
+            .collect(),
+        (_, Some(Value::String(name))) => vec![name.clone()],
+        (Some(other), _) => {
+            return Err(SearchError::BadRequest(format!(
+                "query_string 'fields' must be an array of names, got {other}"
+            )));
+        }
+        _ => Vec::new(),
+    };
+    let all = requested.is_empty() || requested.iter().any(|f| f.trim_end_matches('^') == "*");
 
-    let mut parser = QueryParser::for_index(index, default_fields);
-    parser.set_conjunction_by_default();
-    // Lenient parse: log queries from UIs often contain minor syntax slips.
-    let (query, _errors) = parser.parse_query_lenient(query_text);
-    Ok(query)
+    // Mapped fields go to the parser as default fields (with boosts);
+    // unmapped names live under paths of the dynamic JSON field, which the
+    // parser can only target through `_dynamic.path:(…)` syntax, so each
+    // of those gets its own parse of the wrapped text.
+    let mut default_fields: Vec<Field> = Vec::new();
+    let mut boosts: Vec<(Field, f32)> = Vec::new();
+    let mut dynamic_paths: Vec<(String, f32)> = Vec::new();
+    if all {
+        default_fields.extend(
+            schema
+                .fields
+                .values()
+                .filter(|(_, ty)| *ty == FieldType::Text)
+                .map(|(field, _)| *field),
+        );
+        default_fields.push(schema.dynamic);
+    } else {
+        for spec in &requested {
+            let (name, boost) = match spec.rsplit_once('^') {
+                Some((name, b)) => (name, b.parse::<f32>().unwrap_or(1.0)),
+                None => (spec.as_str(), 1.0),
+            };
+            match resolve(schema, name) {
+                Resolved::Typed(field, FieldType::Text | FieldType::Keyword) => {
+                    default_fields.push(field);
+                    if boost != 1.0 {
+                        boosts.push((field, boost));
+                    }
+                }
+                // Numeric/date/ip/timestamp fields can't take free text.
+                Resolved::Typed(..) | Resolved::Timestamp(_) => {}
+                Resolved::Dynamic(_, path) => dynamic_paths.push((path, boost)),
+            }
+        }
+        if default_fields.is_empty() && dynamic_paths.is_empty() {
+            return Err(SearchError::BadRequest(
+                "query_string 'fields' names no searchable field".into(),
+            ));
+        }
+    }
+
+    let parse = |fields: Vec<Field>, boosts: &[(Field, f32)], text: &str| {
+        let mut parser = QueryParser::for_index(index, fields);
+        if conjunction {
+            parser.set_conjunction_by_default();
+        }
+        for (field, boost) in boosts {
+            parser.set_field_boost(*field, *boost);
+        }
+        // Lenient parse: queries from UIs often contain minor syntax slips.
+        let (query, _errors) = parser.parse_query_lenient(text);
+        query
+    };
+    let mut clauses: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+    if !default_fields.is_empty() {
+        clauses.push((Occur::Should, parse(default_fields, &boosts, query_text)));
+    }
+    for (path, boost) in dynamic_paths {
+        let wrapped = format!("{}.{path}:({query_text})", rsearch_index::DYNAMIC_FIELD);
+        let boosts = if boost != 1.0 { vec![(schema.dynamic, boost)] } else { Vec::new() };
+        clauses.push((Occur::Should, parse(vec![schema.dynamic], &boosts, &wrapped)));
+    }
+    Ok(match clauses.len() {
+        1 => clauses.pop().map(|(_, q)| q).expect("one clause"),
+        _ => Box::new(BooleanQuery::new(clauses)),
+    })
 }
 
 #[cfg(test)]
@@ -707,6 +789,88 @@ mod tests {
             translate_query(&idx, &s, &query)
                 .unwrap_or_else(|e| panic!("query {query} failed: {e}"));
         }
+    }
+
+    /// Index three docs and count hits for a query: exercises field
+    /// targeting end to end (mapped text, keyword, and unmapped/dynamic).
+    fn hits(query: &serde_json::Value) -> usize {
+        use rsearch_index::DocumentConverter;
+        use tantivy::collector::Count;
+        let s = schema();
+        let idx = index(&s);
+        let converter = DocumentConverter::new(s.clone());
+        let mut writer = idx.writer_with_num_threads(1, 20 << 20).unwrap();
+        for doc in [
+            serde_json::json!({"message": "ada lovelace wrote notes", "service": "api", "name": "Ada"}),
+            serde_json::json!({"message": "charles babbage engine", "service": "worker", "name": "Lovelace"}),
+            serde_json::json!({"message": "unrelated text", "service": "api", "name": "Nobody"}),
+        ] {
+            let (doc, _) = converter
+                .convert(doc, tantivy::DateTime::from_timestamp_millis(0))
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        let searcher = idx.reader().unwrap().searcher();
+        let q = translate_query(&idx, &s, query).unwrap_or_else(|e| panic!("{query}: {e}"));
+        searcher.search(&q, &Count).unwrap()
+    }
+
+    #[test]
+    fn query_string_honors_fields_and_default_field() {
+        // Bare terms search the mapped text fields; unmapped values are
+        // reachable by path (`name:lovelace`) or via `fields` — Tantivy's
+        // parser can't fan a bare term across every JSON path.
+        assert_eq!(hits(&serde_json::json!({"query_string": {"query": "lovelace"}})), 1);
+        assert_eq!(hits(&serde_json::json!({"query_string": {"query": "name:lovelace"}})), 1);
+        // Only the mapped text field.
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "lovelace", "fields": ["message"]}})),
+            1
+        );
+        // Only the unmapped (dynamic) field, with a boost suffix.
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "lovelace", "fields": ["name^2"]}})),
+            1
+        );
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "Lovelace", "default_field": "name"}})),
+            1
+        );
+        // Keyword field is exact.
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "api", "fields": ["service"]}})),
+            2
+        );
+        // `*` means everything; AND is the default operator, OR opt-in.
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "ada engine", "fields": ["*"]}})),
+            0
+        );
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {"query": "ada", "fields": ["message", "name"]}})),
+            1
+        );
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {
+                "query": "ada engine", "fields": ["message"], "default_operator": "or"}})),
+            2
+        );
+        // simple_query_string is the same engine, and never a 400 on typos
+        // (the broken clause is parsed leniently, not rejected).
+        assert_eq!(
+            hits(&serde_json::json!({"simple_query_string": {
+                "query": "lovelace \"unbalanced AND", "fields": ["message", "name"],
+                "default_operator": "or", "flags": "ALL"}})),
+            2
+        );
+        // A field list naming nothing searchable is an error, not silence.
+        let s = schema();
+        let idx = index(&s);
+        assert!(
+            translate_query(&idx, &s, &serde_json::json!({"query_string": {"query": "x", "fields": ["status"]}}))
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -152,8 +152,33 @@ pub struct Identity {
 
 impl Identity {
     fn allows_stream(&self, stream: &str) -> bool {
-        self.streams.iter().any(|s| s == "*" || s == stream)
+        self.streams.iter().any(|s| stream_glob_matches(s, stream))
     }
+}
+
+/// Stream-scope matching: an entry is an exact name or a glob where `*`
+/// matches any run of characters (`acme-*`, `*-audit`, `tenant-*-logs`),
+/// so a multi-tenant application can be scoped to a prefix it derives
+/// index names from instead of needing `*` or an up-front list.
+pub fn stream_glob_matches(pattern: &str, stream: &str) -> bool {
+    if !pattern.contains('*') {
+        return pattern == stream;
+    }
+    let parts: Vec<&str> = pattern.split('*').collect();
+    let (first, last) = (parts[0], parts[parts.len() - 1]);
+    if !stream.starts_with(first) {
+        return false;
+    }
+    let mut rest = &stream[first.len()..];
+    // Middle pieces must appear in order; the final piece must end the
+    // name (and not overlap what the earlier pieces consumed).
+    for piece in &parts[1..parts.len() - 1] {
+        match rest.find(piece) {
+            Some(at) => rest = &rest[at + piece.len()..],
+            None => return false,
+        }
+    }
+    rest.ends_with(last) && rest.len() >= last.len()
 }
 
 #[derive(Debug, PartialEq)]
@@ -418,6 +443,32 @@ fn forbidden(reason: &str) -> Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_globs() {
+        let id = |streams: &[&str]| Identity {
+            name: "k".into(),
+            is_admin: false,
+            actions: HashSet::new(),
+            streams: streams.iter().map(|s| s.to_string()).collect(),
+        };
+        assert!(id(&["*"]).allows_stream("anything"));
+        assert!(id(&["items"]).allows_stream("items"));
+        assert!(!id(&["items"]).allows_stream("items-2"));
+        assert!(id(&["acme-*"]).allows_stream("acme-orders"));
+        assert!(id(&["acme-*"]).allows_stream("acme-"));
+        assert!(!id(&["acme-*"]).allows_stream("acmeorders"));
+        assert!(!id(&["acme-*"]).allows_stream("other-acme-x"));
+        assert!(id(&["*-audit"]).allows_stream("acme-audit"));
+        assert!(!id(&["*-audit"]).allows_stream("audit"));
+        assert!(id(&["t-*-logs"]).allows_stream("t-1-logs"));
+        assert!(id(&["t-*-logs"]).allows_stream("t-a-b-logs"));
+        assert!(!id(&["t-*-logs"]).allows_stream("t-logs"));
+        assert!(!id(&["t-*-logs"]).allows_stream("t-1-logsx"));
+        assert!(id(&["a*b*c"]).allows_stream("a1b2c"));
+        assert!(!id(&["a*b*c"]).allows_stream("acb"));
+        assert!(id(&["x", "acme-*"]).allows_stream("acme-y"));
+    }
 
     #[test]
     fn classifies_routes() {

--- a/tests/cluster/run-document-mode-test.sh
+++ b/tests/cluster/run-document-mode-test.sh
@@ -129,10 +129,17 @@ done
 [ "$(curl -s "$U/recs/_doc/a" | jq -r '._source.v')" = 2 ] || fail "newest version survives compaction"
 grep -q "compacting split" "$LOGDIR/node.log" || fail "no compaction logged"
 
+say "query_string fields / simple_query_string"
+curl -s -XPOST "$U/recs/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"q1"}}\n{"title":"lovelace","note":"ada wrote notes"}\n{"index":{"_id":"q2"}}\n{"title":"babbage","note":"lovelace annotated"}\n' >/dev/null
+[ "$(curl -s -XPOST "$U/recs/_search" -H "$J" -d '{"query":{"query_string":{"query":"lovelace","fields":["title"]}}}' | jq -r '.hits.total.value')" = 1 ] || fail "query_string fields narrows"
+[ "$(curl -s -XPOST "$U/recs/_search" -H "$J" -d '{"query":{"simple_query_string":{"query":"lovelace","fields":["title","note"]}}}' | jq -r '.hits.total.value')" = 2 ] || fail "simple_query_string across fields"
+[ "$(curl -s -o /dev/null -w '%{http_code}' -XPOST "$U/recs/_search" -H "$J" -d '{"query":{"simple_query_string":{"query":"lovelace \"oops AND","fields":["note"],"default_operator":"or"}}}')" = 200 ] || fail "simple_query_string never 400s on typos"
+curl -s -XPOST "$U/recs/_delete_by_query" -H "$J" -d '{"query":{"ids":{"values":["q1","q2"]}}}' >/dev/null
+
 say "least-privilege key: stream-scoped ingest creates its index and writes"
 curl -s -XPUT "$U/_rsearch/users/admin" -H "$J" -d '{"password":"adminpassword123","role":"admin"}' | jq -e '.acknowledged' >/dev/null || fail "create admin"
 TOKEN=$(curl -s -XPOST "$U/_rsearch/login" -H "$J" -d '{"username":"admin","password":"adminpassword123"}' | jq -r '.token')
-KEY=$(curl -s -XPOST "$U/_rsearch/api_keys" -H "Authorization: Bearer $TOKEN" -H "$J" -d '{"name":"app","actions":["ingest","search"],"streams":["app-items"]}' | jq -r '.key')
+KEY=$(curl -s -XPOST "$U/_rsearch/api_keys" -H "Authorization: Bearer $TOKEN" -H "$J" -d '{"name":"app","actions":["ingest","search"],"streams":["app-*"]}' | jq -r '.key')
 [ -n "$KEY" ] && [ "$KEY" != null ] || fail "create api key"
 code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app-items" -H "Authorization: Bearer $KEY" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}')
 [ "$code" = 200 ] || fail "scoped ingest key creates its index (got $code)"
@@ -140,8 +147,12 @@ code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app-items/_doc/1?refresh
 [ "$code" = 200 ] || fail "scoped key writes a document (got $code)"
 code=$(curl -s -o /dev/null -w '%{http_code}' "$U/app-items/_doc/1" -H "Authorization: Bearer $KEY")
 [ "$code" = 200 ] || fail "scoped key reads a document (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app-orders/_doc/1?refresh=wait_for" -H "Authorization: Bearer $KEY" -H "$J" -d '{"n":1}')
+[ "$code" = 201 ] || fail "glob scope covers a new tenant index (got $code)"
 code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/other/_doc/1" -H "Authorization: Bearer $KEY" -H "$J" -d '{}')
 [ "$code" = 403 ] || fail "scoped key is denied outside its streams (got $code)"
+code=$(curl -s -o /dev/null -w '%{http_code}' -XPUT "$U/app/_doc/1" -H "Authorization: Bearer $KEY" -H "$J" -d '{}')
+[ "$code" = 403 ] || fail "glob needs the full prefix (got $code)"
 code=$(curl -s -o /dev/null -w '%{http_code}' "$U/_rsearch/users" -H "Authorization: Bearer $KEY")
 [ "$code" = 403 ] || fail "scoped key is not admin (got $code)"
 


### PR DESCRIPTION
Closes #35.

Re-lands #37 on `main`: it was merged into `feat/document-mode-issue-34` seven minutes *after* that branch had merged as #36, so its commit never reached `main`. Cherry-pick of e329e65's content, no other changes; see #37 for the finding-by-finding table.