### PR TITLE
query_string default_operator is OR (ES/OpenSearch compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,10 @@ and IMDS are never touched.
 Query DSL subset: `match_all`, `bool`, `term`, `terms`, `ids`, `range`,
 `exists`, `match`, `match_phrase`, `query_string`, `simple_query_string`
 (the same lenient parser — a typo never 400s; `fields` with `^boost`,
-`default_field`, and `default_operator` are honored, `flags` is accepted
-and ignored; bare terms search the mapped text fields, unmapped fields by
-`name:term` or via `fields`). Aggregations pass
+`default_field`, and `default_operator` are honored — OR by default as in
+Elasticsearch/OpenSearch, `"and"` to require every term; `flags` is
+accepted and ignored; bare terms search the mapped text fields, unmapped
+fields by `name:term` or via `fields`). Aggregations pass
 through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 

--- a/crates/rsearch-metastore/migrations/20260819205605_alerts_query_string_and.sql
+++ b/crates/rsearch-metastore/migrations/20260819205605_alerts_query_string_and.sql
@@ -1,0 +1,8 @@
+-- query_string's default_operator became OR (Elasticsearch/OpenSearch
+-- compatible). Alerts saved by the console before that relied on the old
+-- implicit AND; pin it on them so their meaning does not change.
+UPDATE alerts
+SET query = jsonb_set(query, '{query_string,default_operator}', '"and"'::jsonb)
+WHERE query ? 'query_string'
+  AND jsonb_typeof(query->'query_string') = 'object'
+  AND NOT (query->'query_string' ? 'default_operator');

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -639,8 +639,9 @@ fn translate_match(
 /// `query_string` / `simple_query_string`. Honors `fields` (with ES `^boost`
 /// suffixes and a bare `*`) or `default_field`; without either, every
 /// mapped text field plus the dynamic catch-all is searched, so bare
-/// terms search everything tokenized. `default_operator` defaults to
-/// AND (log-search convention); pass `"or"` for ES's default.
+/// terms search everything tokenized. `default_operator` defaults to OR,
+/// as in Elasticsearch/OpenSearch; pass `"and"` to require every term
+/// (what a log-search box usually wants — the bundled console does).
 fn translate_query_string(
     index: &tantivy::Index,
     schema: &MappedSchema,
@@ -650,9 +651,9 @@ fn translate_query_string(
         .get("query")
         .and_then(Value::as_str)
         .ok_or_else(|| SearchError::BadRequest("query_string needs 'query'".into()))?;
-    let conjunction = !matches!(
+    let conjunction = matches!(
         body.get("default_operator").and_then(Value::as_str),
-        Some(op) if op.eq_ignore_ascii_case("or")
+        Some(op) if op.eq_ignore_ascii_case("and")
     );
 
     // Requested fields: `fields: [..]` wins, else `default_field`, else
@@ -842,10 +843,10 @@ mod tests {
             hits(&serde_json::json!({"query_string": {"query": "api", "fields": ["service"]}})),
             2
         );
-        // `*` means everything; AND is the default operator, OR opt-in.
+        // `*` means everything; OR is the default operator (ES), AND opt-in.
         assert_eq!(
             hits(&serde_json::json!({"query_string": {"query": "ada engine", "fields": ["*"]}})),
-            0
+            2
         );
         assert_eq!(
             hits(&serde_json::json!({"query_string": {"query": "ada", "fields": ["message", "name"]}})),
@@ -853,15 +854,20 @@ mod tests {
         );
         assert_eq!(
             hits(&serde_json::json!({"query_string": {
-                "query": "ada engine", "fields": ["message"], "default_operator": "or"}})),
-            2
+                "query": "ada engine", "fields": ["message"], "default_operator": "and"}})),
+            0
+        );
+        assert_eq!(
+            hits(&serde_json::json!({"query_string": {
+                "query": "ada lovelace", "fields": ["message"], "default_operator": "AND"}})),
+            1
         );
         // simple_query_string is the same engine, and never a 400 on typos
         // (the broken clause is parsed leniently, not rejected).
         assert_eq!(
             hits(&serde_json::json!({"simple_query_string": {
                 "query": "lovelace \"unbalanced AND", "fields": ["message", "name"],
-                "default_operator": "or", "flags": "ALL"}})),
+                "flags": "ALL"}})),
             2
         );
         // A field list naming nothing searchable is an error, not silence.

--- a/ui/app/alerts/page.tsx
+++ b/ui/app/alerts/page.tsx
@@ -50,7 +50,9 @@ export default function AlertsPage() {
     try {
       let query: unknown = {};
       if (form.query.trim())
-        query = { query_string: { query: form.query.trim() } };
+        query = {
+          query_string: { query: form.query.trim(), default_operator: "and" },
+        };
       await rq(`/_rsearch/alerts/${encodeURIComponent(form.name)}`, {
         method: "PUT",
         body: JSON.stringify({ ...form, query }),

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -81,7 +81,11 @@ export async function search(
   if (fromMillis)
     filters.push({ range: { "@timestamp": { gte: fromMillis, lte: "now" } } });
   if (query.trim())
-    filters.push({ query_string: { query: query.trim() } });
+    // A log-search box wants every typed word to match; the API's
+    // default_operator is OR (ES-compatible), so ask for AND explicitly.
+    filters.push({
+      query_string: { query: query.trim(), default_operator: "and" },
+    });
   const body = {
     size,
     query: filters.length ? { bool: { filter: filters } } : { match_all: {} },


### PR DESCRIPTION
Behavior change, flagged for 0.3.1.

`query_string`/`simple_query_string` have always defaulted to AND (pre-existing `set_conjunction_by_default`, carried into 0.3.0 and documented there as the default). Elasticsearch/OpenSearch default to **OR**, so a stock client or Grafana's Elasticsearch datasource sending `"query": "foo bar"` got narrower results than it asked for.

- Default is now OR; `"default_operator": "and"` requires every term (case-insensitive).
- The web console's search box and alert editor send `default_operator: "and"` explicitly — the console's log-search UX is unchanged.
- Migration `20260819205605_alerts_query_string_and` pins `default_operator: "and"` on alerts saved before this change (top-level `query_string` without one), so existing alerts keep firing on the same condition. Verified against representative rows (plain, already-OR, non-query_string).
- README updated; unit tests flipped accordingly.

Upgrade note for the release: API callers that relied on the implicit AND must now pass `default_operator: "and"`.