### PR TITLE
Cut v0.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.3.0" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.3.0" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.3.0" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.3.0" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.3.0" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.3.0" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.3.1" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.3.1" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.3.1" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.3.1" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.3.1" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.3.1" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
Patch release for #40 (query_string default_operator is OR, ES/OpenSearch compatible) and #42 (bare query_string searches every dynamic path, PR #43). Version 0.3.0 → 0.3.1 in both places; lockfile only re-stamps the workspace crates (no dependency refresh this time). Branch updated with main so the release tree includes the #42 fix.

Pre-flight on this branch (re-run after merging main in):
- `RUSTFLAGS="-D warnings"` `cargo check --workspace --all-targets` clean (stable)
- `cargo test --workspace -- --include-ignored` green against Postgres (95 tests, includes the Postgres-gated metastore tests)
- `cargo deny check bans licenses` green
- Release build green
- Migrations untouched since the original pre-flight (the #42 fix changes no schema), so the fresh-database migration-chain run from the first pass still stands
- `run-document-mode-test.sh` and Docker-based cluster scripts not re-run this pass (script not present in this checkout; same caveat as 0.3.0)

Release notes to carry:
- **API callers that relied on the implicit AND in `query_string` must now pass `"default_operator": "and"`** (#40); the bundled console and existing alerts are unaffected.
- **Bare `query_string` / `simple_query_string` (no `fields`, no `default_field`, or `fields: ["*"]`) now searches every string-valued unmapped field** instead of returning 0 hits on dynamically-mapped indices (#42). Queries that were silently matching nothing — including bare-word searches from Grafana's Elasticsearch datasource — will start returning results. Known divergence: with `default_operator: and`, terms must co-occur within a single unmapped field, not across different ones.
