### PR TITLE
Bare query_string searches every dynamic path

### DIFF
--- a/crates/rsearch-index/src/dynamic_paths.rs
+++ b/crates/rsearch-index/src/dynamic_paths.rs
@@ -1,0 +1,116 @@
+//! Discovery of the JSON paths present in the `_dynamic` field.
+//!
+//! A bare `query_string` must search every field, but Tantivy's parser
+//! cannot fan a term across the paths of a JSON field — each path has to
+//! be named explicitly (issue #42). This module lists the string-valued
+//! paths a segment actually contains so the query layer can do that.
+
+use std::collections::BTreeSet;
+
+use tantivy::schema::{Field, Type};
+use tantivy::{Searcher, TantivyError};
+
+/// Byte layout of a JSON field's term-dictionary keys
+/// (`tantivy_common::json_path_writer`):
+/// `[path segments, separated by 0x01][0x00][value type code][value bytes]`.
+const JSON_PATH_SEGMENT_SEP: u8 = 1;
+const JSON_END_OF_PATH: u8 = 0;
+
+/// List every JSON path in `dynamic` that holds at least one string term,
+/// in query-parser form: segments joined with `.`, literal dots escaped
+/// as `\.`. Sorted and deduplicated across segments.
+///
+/// Skip-scans the term dictionary: one seek per (path, probe) pair rather
+/// than a walk of every term, so cost is proportional to the number of
+/// distinct paths, not the number of terms. Call from a blocking context
+/// (term dictionaries may be fetched from storage on first touch).
+pub fn dynamic_string_paths(
+    searcher: &Searcher,
+    dynamic: Field,
+) -> tantivy::Result<Vec<String>> {
+    let mut paths = BTreeSet::new();
+    for segment in searcher.segment_readers() {
+        let inverted = segment.inverted_index(dynamic)?;
+        let dict = inverted.terms();
+        let mut bound: Option<Vec<u8>> = None;
+        loop {
+            let mut stream = match &bound {
+                None => dict.stream()?,
+                Some(b) => dict.range().ge(b).into_stream()?,
+            };
+            if !stream.advance() {
+                break;
+            }
+            let key = stream.key();
+            let Some(end) = key.iter().position(|&b| b == JSON_END_OF_PATH) else {
+                return Err(TantivyError::InternalError(format!(
+                    "malformed JSON term key in field {dynamic:?}: no end-of-path byte"
+                )));
+            };
+            let path = key[..end].to_vec();
+            drop(stream);
+            // Terms of one path sort by value type code after the 0x00, so
+            // the first term seen may be numeric while string terms for the
+            // same path sit further on — probe for the string block directly.
+            let mut probe = path.clone();
+            probe.push(JSON_END_OF_PATH);
+            probe.push(Type::Str.to_code());
+            let mut probe_stream = dict.range().ge(&probe).into_stream()?;
+            if probe_stream.advance() && probe_stream.key().starts_with(&probe) {
+                paths.insert(decode_path(&path));
+            }
+            drop(probe_stream);
+            // 0x00 (end-of-path) sorts below 0x01, so this bound skips the
+            // rest of this path's terms while keeping nested child paths
+            // (`path ++ 0x01 ++ …`) in range for the next iteration.
+            let mut next = path;
+            next.push(JSON_PATH_SEGMENT_SEP);
+            bound = Some(next);
+        }
+    }
+    Ok(paths.into_iter().collect())
+}
+
+/// Encoded path bytes → query-parser path: segments joined with `.`,
+/// literal dots inside a segment escaped (`_dynamic` does not expand
+/// dots, so `log.level` as one key must be queried as `log\.level`).
+fn decode_path(bytes: &[u8]) -> String {
+    bytes
+        .split(|&b| b == JSON_PATH_SEGMENT_SEP)
+        .map(|segment| String::from_utf8_lossy(segment).replace('.', "\\."))
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mapping::{IndexMapping, MappedSchema};
+
+    #[test]
+    fn lists_string_paths_only() {
+        let schema = MappedSchema::build(
+            IndexMapping::from_json(&serde_json::json!({
+                "properties": {"message": {"type": "text"}}
+            }))
+            .unwrap(),
+        );
+        let index = tantivy::Index::create_in_ram(schema.schema.clone());
+        let mut writer = index.writer(15_000_000).unwrap();
+        let converter = crate::document::DocumentConverter::new(schema.clone());
+        for doc in [
+            serde_json::json!({"message": "mapped stays out", "level": "info", "count": 7}),
+            serde_json::json!({"ctx": {"job": "cleanup"}, "log.level": "warn"}),
+        ] {
+            let (doc, _) = converter
+                .convert(doc, tantivy::DateTime::from_timestamp_millis(0))
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        let reader = index.reader().unwrap();
+        let paths = dynamic_string_paths(&reader.searcher(), schema.dynamic).unwrap();
+        // `count` is numeric-only; `message` is mapped, not dynamic.
+        assert_eq!(paths, vec!["ctx.job", "level", "log\\.level"]);
+    }
+}

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -5,6 +5,7 @@
 mod builder;
 mod cache;
 mod document;
+mod dynamic_paths;
 mod error;
 mod exclusions;
 mod mapping;
@@ -12,6 +13,7 @@ mod reader;
 mod split_file;
 
 pub use builder::{PackagedSplit, SplitBuilder};
+pub use dynamic_paths::dynamic_string_paths;
 pub use tantivy::DateTime;
 pub use cache::SplitCache;
 pub use reader::{ReadDoc, SplitReader};

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -43,6 +43,10 @@ pub struct SplitReader {
     schema: Arc<MappedSchema>,
     /// Tombstone exclusions applied so far (see `apply_tombstones`).
     pub(crate) exclusions: std::sync::Mutex<Arc<crate::exclusions::ExclusionSet>>,
+    /// String-valued `_dynamic` paths, computed on first bare
+    /// `query_string` and reused: splits are immutable, so the term
+    /// dictionary never changes under us.
+    dynamic_paths: OnceLock<Vec<String>>,
 }
 
 impl SplitReader {
@@ -120,6 +124,7 @@ impl SplitReader {
             exclusions: std::sync::Mutex::new(Arc::new(
                 crate::exclusions::ExclusionSet::empty(segment_ids),
             )),
+            dynamic_paths: OnceLock::new(),
         })
     }
 
@@ -139,6 +144,21 @@ impl SplitReader {
     /// blocking context.
     pub fn searcher(&self) -> IndexResult<tantivy::Searcher> {
         Ok(self.reader.searcher())
+    }
+
+    /// The string-valued JSON paths present in this split's `_dynamic`
+    /// field, for fanning a bare `query_string` across unmapped fields.
+    /// Computed once per split (skip-scan of the term dictionary) and
+    /// cached. Call from a blocking context.
+    pub fn dynamic_string_paths(&self) -> IndexResult<&[String]> {
+        if let Some(paths) = self.dynamic_paths.get() {
+            return Ok(paths);
+        }
+        let paths = crate::dynamic_paths::dynamic_string_paths(
+            &self.reader.searcher(),
+            self.schema.dynamic,
+        )?;
+        Ok(self.dynamic_paths.get_or_init(|| paths))
     }
 
     /// Visit every document — used by the merge/compaction jobs to

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -853,7 +853,9 @@ fn search_one_split(
     // Translate against the split's own schema: field ordinals follow the
     // mapping the split was built with, which can differ from the stream's
     // current mapping (PUT /{index} after the split was written).
-    let mut query = translate_query(index, reader.mapped_schema(), query_json)?;
+    let mut query = translate_query(index, reader.mapped_schema(), query_json, &|| {
+        Ok(reader.dynamic_string_paths()?.to_vec())
+    })?;
     // Tombstoned versions are excluded inside the query so every collector
     // (top-k, Count, aggregations) agrees; the doc_count shortcut below
     // subtracts them instead of scanning.

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -247,12 +247,19 @@ fn scan_time_bounds(node: &Value, start: &mut Option<i64>, end: &mut Option<i64>
     }
 }
 
+/// Lazily lists the string-valued `_dynamic` paths of the split being
+/// searched, so a bare `query_string` can fan out across unmapped fields
+/// (issue #42). Only invoked when a query actually needs it; the split
+/// reader caches the underlying term-dictionary scan.
+pub type DynamicPathsFn<'a> = dyn Fn() -> SearchResult<Vec<String>> + 'a;
+
 /// Translate an ES query object into a Tantivy query against `schema`.
 /// `index` supplies tokenizers for match/query_string queries.
 pub fn translate_query(
     index: &tantivy::Index,
     schema: &MappedSchema,
     query: &Value,
+    dynamic_paths: &DynamicPathsFn,
 ) -> SearchResult<Box<dyn Query>> {
     let obj = query
         .as_object()
@@ -270,7 +277,7 @@ pub fn translate_query(
 
     match kind.as_str() {
         "match_all" => Ok(Box::new(AllQuery)),
-        "bool" => translate_bool(index, schema, body),
+        "bool" => translate_bool(index, schema, body, dynamic_paths),
         "term" => translate_term(schema, body),
         "terms" => translate_terms(schema, body),
         "ids" => translate_ids(schema, body),
@@ -278,11 +285,11 @@ pub fn translate_query(
         "exists" => translate_exists(schema, body),
         "match" => translate_match(index, schema, body, false),
         "match_phrase" => translate_match(index, schema, body, true),
-        "query_string" => translate_query_string(index, schema, body),
+        "query_string" => translate_query_string(index, schema, body, dynamic_paths),
         // Same engine: our query_string parse is already lenient (never a
         // 400 on a typo), which is the property simple_query_string exists
         // for; `flags` is accepted and ignored.
-        "simple_query_string" => translate_query_string(index, schema, body),
+        "simple_query_string" => translate_query_string(index, schema, body, dynamic_paths),
         other => Err(SearchError::BadRequest(format!(
             "unsupported query type '{other}' (supported: match_all, bool, term, terms, \
              ids, range, exists, match, match_phrase, query_string, simple_query_string)"
@@ -294,6 +301,7 @@ fn translate_bool(
     index: &tantivy::Index,
     schema: &MappedSchema,
     body: &Value,
+    dynamic_paths: &DynamicPathsFn,
 ) -> SearchResult<Box<dyn Query>> {
     let obj = body
         .as_object()
@@ -311,7 +319,7 @@ fn translate_bool(
                 single => vec![single],
             };
             for item in items {
-                clauses.push((occur, translate_query(index, schema, item)?));
+                clauses.push((occur, translate_query(index, schema, item, dynamic_paths)?));
             }
         }
     }
@@ -638,14 +646,17 @@ fn translate_match(
 
 /// `query_string` / `simple_query_string`. Honors `fields` (with ES `^boost`
 /// suffixes and a bare `*`) or `default_field`; without either, every
-/// mapped text field plus the dynamic catch-all is searched, so bare
-/// terms search everything tokenized. `default_operator` defaults to OR,
-/// as in Elasticsearch/OpenSearch; pass `"and"` to require every term
-/// (what a log-search box usually wants — the bundled console does).
+/// mapped text field plus every string-valued `_dynamic` path is
+/// searched, so bare terms search everything tokenized — matching ES,
+/// where `default_field` defaults to `*` (issue #42). `default_operator`
+/// defaults to OR, as in Elasticsearch/OpenSearch; pass `"and"` to
+/// require every term (what a log-search box usually wants — the bundled
+/// console does).
 fn translate_query_string(
     index: &tantivy::Index,
     schema: &MappedSchema,
     body: &Value,
+    all_dynamic_paths: &DynamicPathsFn,
 ) -> SearchResult<Box<dyn Query>> {
     let query_text = body
         .get("query")
@@ -689,7 +700,14 @@ fn translate_query_string(
                 .filter(|(_, ty)| *ty == FieldType::Text)
                 .map(|(field, _)| *field),
         );
+        // Kept as a parser default so explicit `path:term` syntax inside
+        // the query text resolves into `_dynamic`. A bare term against a
+        // JSON field only probes the empty path, though — the parser
+        // cannot fan it across every path (issue #42), so each
+        // string-valued path the split actually contains gets its own
+        // clause below.
         default_fields.push(schema.dynamic);
+        dynamic_paths.extend(all_dynamic_paths()?.into_iter().map(|path| (path, 1.0)));
     } else {
         for spec in &requested {
             let (name, boost) = match spec.rsplit_once('^') {
@@ -764,6 +782,16 @@ mod tests {
         tantivy::Index::create_in_ram(schema.schema.clone())
     }
 
+    /// Path provider for tests: scans the in-RAM index the way the real
+    /// executor's split reader does (minus the per-split cache).
+    fn paths_of<'a>(idx: &'a tantivy::Index, schema: &'a MappedSchema) -> impl Fn() -> SearchResult<Vec<String>> + 'a {
+        move || {
+            let searcher = idx.reader().map_err(SearchError::Tantivy)?.searcher();
+            rsearch_index::dynamic_string_paths(&searcher, schema.dynamic)
+                .map_err(SearchError::Tantivy)
+        }
+    }
+
     #[test]
     fn translates_supported_queries() {
         let s = schema();
@@ -787,7 +815,7 @@ mod tests {
             }}),
             serde_json::json!({"term": {"unmapped_field": "value"}}),
         ] {
-            translate_query(&idx, &s, &query)
+            translate_query(&idx, &s, &query, &paths_of(&idx, &s))
                 .unwrap_or_else(|e| panic!("query {query} failed: {e}"));
         }
     }
@@ -813,16 +841,17 @@ mod tests {
         }
         writer.commit().unwrap();
         let searcher = idx.reader().unwrap().searcher();
-        let q = translate_query(&idx, &s, query).unwrap_or_else(|e| panic!("{query}: {e}"));
+        let q = translate_query(&idx, &s, query, &paths_of(&idx, &s))
+            .unwrap_or_else(|e| panic!("{query}: {e}"));
         searcher.search(&q, &Count).unwrap()
     }
 
     #[test]
     fn query_string_honors_fields_and_default_field() {
-        // Bare terms search the mapped text fields; unmapped values are
-        // reachable by path (`name:lovelace`) or via `fields` — Tantivy's
-        // parser can't fan a bare term across every JSON path.
-        assert_eq!(hits(&serde_json::json!({"query_string": {"query": "lovelace"}})), 1);
+        // Bare terms search mapped text fields AND every string-valued
+        // dynamic path (issue #42): "lovelace" is in doc 1's message and
+        // doc 2's unmapped name.
+        assert_eq!(hits(&serde_json::json!({"query_string": {"query": "lovelace"}})), 2);
         assert_eq!(hits(&serde_json::json!({"query_string": {"query": "name:lovelace"}})), 1);
         // Only the mapped text field.
         assert_eq!(
@@ -874,8 +903,78 @@ mod tests {
         let s = schema();
         let idx = index(&s);
         assert!(
-            translate_query(&idx, &s, &serde_json::json!({"query_string": {"query": "x", "fields": ["status"]}}))
-                .is_err()
+            translate_query(
+                &idx,
+                &s,
+                &serde_json::json!({"query_string": {"query": "x", "fields": ["status"]}}),
+                &paths_of(&idx, &s),
+            )
+            .is_err()
+        );
+    }
+
+    /// Issue #42: an index whose mapping declares no text fields (the
+    /// default for indices that documents are simply posted into) must
+    /// still match bare `query_string` terms — everything lives in
+    /// `_dynamic`, and each string-valued path gets fanned out.
+    #[test]
+    fn bare_query_string_searches_dynamic_paths() {
+        use rsearch_index::DocumentConverter;
+        use tantivy::collector::Count;
+        let s = MappedSchema::build(rsearch_index::IndexMapping::default());
+        let idx = index(&s);
+        let converter = DocumentConverter::new(s.clone());
+        let mut writer = idx.writer_with_num_threads(1, 20 << 20).unwrap();
+        for doc in [
+            serde_json::json!({"message": "23 jobs scheduled", "ctx": {"queue": "default"}}),
+            serde_json::json!({"message": "idle worker", "log.level": "error", "code": 500}),
+        ] {
+            let (doc, _) = converter
+                .convert(doc, tantivy::DateTime::from_timestamp_millis(0))
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        let searcher = idx.reader().unwrap().searcher();
+        let count = |query: &serde_json::Value| {
+            let q = translate_query(&idx, &s, query, &paths_of(&idx, &s))
+                .unwrap_or_else(|e| panic!("{query}: {e}"));
+            searcher.search(&q, &Count).unwrap()
+        };
+        // Bare term, top-level path.
+        assert_eq!(count(&serde_json::json!({"query_string": {"query": "jobs"}})), 1);
+        // Nested path and a dotted literal key both participate.
+        assert_eq!(count(&serde_json::json!({"query_string": {"query": "queue"}})), 0);
+        assert_eq!(count(&serde_json::json!({"query_string": {"query": "default"}})), 1);
+        assert_eq!(count(&serde_json::json!({"query_string": {"query": "error"}})), 1);
+        // `fields: ["*"]` is the same path (Grafana sends this shape).
+        assert_eq!(
+            count(&serde_json::json!({"query_string": {"query": "jobs", "fields": ["*"]}})),
+            1
+        );
+        // OR across docs; AND narrows within a path.
+        assert_eq!(
+            count(&serde_json::json!({"query_string": {"query": "jobs idle"}})),
+            2
+        );
+        assert_eq!(
+            count(&serde_json::json!({"query_string": {
+                "query": "jobs scheduled", "default_operator": "and"}})),
+            1
+        );
+        // Known divergence from ES: each path is its own parse, so AND
+        // does not span different unmapped fields ("idle" in message,
+        // "error" in log.level — ES would match doc 2). Same pre-existing
+        // limitation as an explicit multi-path `fields` list.
+        assert_eq!(
+            count(&serde_json::json!({"query_string": {
+                "query": "idle error", "default_operator": "and"}})),
+            0
+        );
+        // simple_query_string rides the same engine.
+        assert_eq!(
+            count(&serde_json::json!({"simple_query_string": {"query": "jobs"}})),
+            1
         );
     }
 
@@ -887,6 +986,7 @@ mod tests {
             &idx,
             &s,
             &serde_json::json!({"fuzzy": {"message": "opps"}}),
+            &paths_of(&idx, &s),
         )
         .unwrap_err();
         assert!(matches!(err, SearchError::BadRequest(_)));


### PR DESCRIPTION
Fixes #42.

## Problem

A `query_string` with no `fields` and no `default_field` (or `fields: ["*"]`) returned 0 hits on any index whose fields aren't explicitly mapped. Tantivy's `QueryParser` cannot fan a bare term across the paths of a JSON field — with `_dynamic` as a parser default, a bare term only probes the empty path. On an index whose mapping declares only `@timestamp` (the default for indices documents are simply posted into), that meant every bare search — including the exact shape Grafana's Elasticsearch datasource sends — matched nothing.

## Fix

- **`rsearch-index/src/dynamic_paths.rs`** (new): `dynamic_string_paths()` lists the JSON paths in `_dynamic` that hold string terms. Seek-based skip-scan of the term dictionary — one seek to find each path, one probe for its string-typed term block, one seek past its remaining terms — so cost scales with the number of distinct paths, not the number of terms. Paths are returned in query-parser form (literal dots escaped: `log\.level`).
- **`SplitReader::dynamic_string_paths()`**: caches the scan in a `OnceLock` — splits are immutable, so it runs at most once per split, and only when a bare `query_string` actually executes.
- **`query_dsl`**: `translate_query` takes a lazy `DynamicPathsFn` provider. The bare/`*` branch of `translate_query_string` fans the query out as one `_dynamic.<path>:(…)` clause per discovered path — the mechanism that already worked for explicit `default_field` — OR'd with the mapped-text-fields clause. `_dynamic` stays a parser default so explicit `path:term` syntax keeps resolving. `simple_query_string` shares the engine, so both are fixed.

This matches the ES/OpenSearch contract where `default_field` defaults to `*` ("extract all fields eligible for term query").

## Known divergence (documented + pinned in a test)

With `default_operator: and`, terms spread across *different* unmapped fields don't match — each path is a separate parse, so AND applies within a path, whereas ES ANDs per-term dis-max groups across fields. This limitation pre-existed for explicit multi-path `fields` lists; the OR default (and the Grafana shape from the issue) behaves correctly.

## Tests

- New `bare_query_string_searches_dynamic_paths`: unmapped index, bare term, `fields: ["*"]`, nested keys, dotted literal keys, OR/AND operators, `simple_query_string`.
- New `lists_string_paths_only`: path discovery skips numeric-only paths and mapped fields, handles nested and dotted keys.
- Updated the prior assertion that a bare term misses dynamic content — it now asserts the hit.

Full workspace suite green (86 passed, 0 failed).