### PR TITLE
Drop placement rows whose file is gone from local disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Operational notes:
   replaced or wiped data volume — are dropped so repair sees the real
   copy count and restores the factor
   (`rsearch_reconcile_phantom_placements_removed_total` counts these).
+  Alert on `rsearch_reconcile_last_copy_placements_removed_total`: it
+  counts phantom rows that were an object's *last* recorded copy, i.e.
+  data that is likely lost — once the row is gone the repair job has
+  nothing left to warn about, so this counter (and a per-key error log)
+  is the durable signal. One deliberate exception: a sole-copy row on a
+  node whose object root is *empty* is kept, not deleted — an unmounted
+  volume looks identical to a replaced one, and that row may be the last
+  true record (dead-node expiry preserves it for the same reason); it is
+  error-logged every sweep until the volume returns or an operator
+  intervenes.
 - The ingest WAL stays node-local: docs acked but not yet published when
   a node dies are recovered by WAL replay when that node (or its volume)
   returns — same recovery story as the fs backend.

--- a/README.md
+++ b/README.md
@@ -158,9 +158,14 @@ Operational notes:
 - With factor 2, the window between a node dying and repair completing
   is one further failure away from data loss; size
   `repair_stale_secs` and node count accordingly.
-- A node returning after its registry entry expired may hold orphaned
-  object files (repair already replaced its copies); these are inert
-  and can be cleaned by wiping the object root before restart.
+- An hourly reconcile sweep (plus one pass at startup) keeps each node's
+  disk and the placement table honest in both directions: local files
+  the table still knows are re-announced, orphaned files whose splits
+  were deleted while the node was unreachable are removed, and placement
+  rows whose file is gone from local disk — a node restarted onto a
+  replaced or wiped data volume — are dropped so repair sees the real
+  copy count and restores the factor
+  (`rsearch_reconcile_phantom_placements_removed_total` counts these).
 - The ingest WAL stays node-local: docs acked but not yet published when
   a node dies are recovered by WAL replay when that node (or its volume)
   returns — same recovery story as the fs backend.

--- a/crates/rsearch-metastore/migrations/20260820004530_object_locations_node_key_index.sql
+++ b/crates/rsearch-metastore/migrations/20260820004530_object_locations_node_key_index.sql
@@ -1,6 +1,10 @@
+-- no-transaction
 -- The metastore->disk reconcile verify (#44) walks one node's placement
--- rows keyset-paginated by storage_key; give it an index range scan and
--- retire the single-column index the composite now covers.
-CREATE INDEX idx_object_locations_node_key
+-- rows keyset-paginated by storage_key. Built CONCURRENTLY (migrations
+-- run at node startup, and a plain CREATE INDEX would block every
+-- placement write — each replicated ingest ack — for the build), which
+-- also requires this migration to be a single statement outside a
+-- transaction; the old node_id index it supersedes is dropped in the
+-- next migration.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_object_locations_node_key
     ON object_locations (node_id, storage_key);
-DROP INDEX idx_object_locations_node;

--- a/crates/rsearch-metastore/migrations/20260820004530_object_locations_node_key_index.sql
+++ b/crates/rsearch-metastore/migrations/20260820004530_object_locations_node_key_index.sql
@@ -1,0 +1,6 @@
+-- The metastore->disk reconcile verify (#44) walks one node's placement
+-- rows keyset-paginated by storage_key; give it an index range scan and
+-- retire the single-column index the composite now covers.
+CREATE INDEX idx_object_locations_node_key
+    ON object_locations (node_id, storage_key);
+DROP INDEX idx_object_locations_node;

--- a/crates/rsearch-metastore/migrations/20260820130321_drop_object_locations_node_index.sql
+++ b/crates/rsearch-metastore/migrations/20260820130321_drop_object_locations_node_index.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- The (node_id, storage_key) composite from the previous migration
+-- covers every node_id-leading scan (drain, dead-node purge, reconcile
+-- verify); retire the single-column index it supersedes. CONCURRENTLY
+-- keeps the drop from waiting behind (and then blocking) placement
+-- traffic, and requires running outside a transaction.
+DROP INDEX CONCURRENTLY IF EXISTS idx_object_locations_node;

--- a/crates/rsearch-metastore/src/locations.rs
+++ b/crates/rsearch-metastore/src/locations.rs
@@ -133,6 +133,35 @@ impl Metastore {
         Ok(rows.into_iter().map(|(key,)| key).collect())
     }
 
+    /// Storage keys recorded for `node_id` whose rows are older than
+    /// `min_age_secs`, keyset-paginated: pass the last key of the previous
+    /// page as `after_key` (empty string to start). Drives the
+    /// metastore->disk reconcile verify (#44), which checks each recorded
+    /// copy against the node's actual disk; the age floor keeps rows from
+    /// any in-flight write out of the scan.
+    pub async fn stale_locations_on_node(
+        &self,
+        node_id: &str,
+        min_age_secs: f64,
+        after_key: &str,
+        limit: i64,
+    ) -> MetastoreResult<Vec<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT storage_key FROM object_locations
+             WHERE node_id = $1
+               AND storage_key > $2
+               AND created_at < now() - make_interval(secs => $3)
+             ORDER BY storage_key LIMIT $4",
+        )
+        .bind(node_id)
+        .bind(after_key)
+        .bind(min_age_secs)
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+        Ok(rows.into_iter().map(|(key,)| key).collect())
+    }
+
     /// Refresh interval for the per-node held-bytes totals used to rank
     /// replication targets. A few seconds of staleness only skews
     /// placement slightly; the aggregation it avoids is a full scan of

--- a/crates/rsearch-metastore/src/locations.rs
+++ b/crates/rsearch-metastore/src/locations.rs
@@ -30,26 +30,54 @@ impl Metastore {
     /// transfers — a replicate pull that outlives the leader's timeout,
     /// or a rejoining node re-announcing local files — so they can never
     /// resurrect placement for an object that was deleted cluster-wide.
-    /// Returns whether the row was recorded.
+    ///
+    /// Returns `None` when the object is unknown (nothing recorded),
+    /// `Some(true)` when a missing row was inserted, and `Some(false)`
+    /// when an existing row was merely refreshed — callers gating on
+    /// "still known" treat any `Some`, while the reconcile sweep counts
+    /// only real inserts (`xmax = 0` distinguishes an inserted row from
+    /// one rewritten by the conflict update).
     pub async fn record_object_location_if_known(
         &self,
         storage_key: &str,
         node_id: &str,
         size_bytes: i64,
-    ) -> MetastoreResult<bool> {
-        let result = sqlx::query(
+    ) -> MetastoreResult<Option<bool>> {
+        let row: Option<(bool,)> = sqlx::query_as(
             "INSERT INTO object_locations (storage_key, node_id, size_bytes)
              SELECT $1, $2, $3
              WHERE EXISTS (SELECT 1 FROM object_locations WHERE storage_key = $1)
              ON CONFLICT (storage_key, node_id)
-             DO UPDATE SET size_bytes = EXCLUDED.size_bytes",
+             DO UPDATE SET size_bytes = EXCLUDED.size_bytes
+             RETURNING (xmax = 0)",
         )
         .bind(storage_key)
         .bind(node_id)
         .bind(size_bytes)
-        .execute(self.pool())
+        .fetch_optional(self.pool())
         .await?;
-        Ok(result.rows_affected() > 0)
+        Ok(row.map(|(inserted,)| inserted))
+    }
+
+    /// Whether any node other than `node_id` has a copy record for the
+    /// object. The reconcile verify checks this before deleting a
+    /// phantom row: removing the last record means no copy is known
+    /// anywhere and the object may be lost — worth a louder signal than
+    /// an ordinary phantom cleanup.
+    pub async fn other_holders_exist(
+        &self,
+        storage_key: &str,
+        node_id: &str,
+    ) -> MetastoreResult<bool> {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM object_locations
+                            WHERE storage_key = $1 AND node_id <> $2)",
+        )
+        .bind(storage_key)
+        .bind(node_id)
+        .fetch_one(self.pool())
+        .await?;
+        Ok(exists)
     }
 
     /// Whether the cluster still tracks `storage_key` at all — any

--- a/crates/rsearch-server/src/internal_api.rs
+++ b/crates/rsearch-server/src/internal_api.rs
@@ -238,8 +238,8 @@ async fn replicate(
         .record_object_location_if_known(&key, &internal.node_id, size as i64)
         .await
     {
-        Ok(true) => {}
-        Ok(false) => {
+        Ok(Some(_)) => {}
+        Ok(None) => {
             let _ = internal.fs.delete(&key).await;
             warn!(key, "replicate finished for a deleted object; copy discarded");
             return (StatusCode::CONFLICT, "object no longer exists").into_response();

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> anyhow::Result<()> {
             }
         }
     };
+    let mut reconcile_metrics: Option<std::sync::Arc<reconcile::ReconcileMetrics>> = None;
     let storage: std::sync::Arc<dyn rsearch_storage::Storage> =
         if config.storage.backend == "replicated" {
             if config.cluster.internal_token.is_empty() {
@@ -122,13 +123,19 @@ async fn main() -> anyhow::Result<()> {
             // Reconcile local files with the metastore, at startup and
             // periodically: re-announce copies the placement table still
             // knows (a node rejoining after registry expiry has real
-            // copies on disk but may have lost its rows) and delete
-            // orphaned files whose splits were GC'd while this node was
-            // unreachable (#16).
+            // copies on disk but may have lost its rows), delete orphaned
+            // files whose splits were GC'd while this node was
+            // unreachable (#16), and drop placement rows whose file is
+            // gone from local disk — a replaced data volume otherwise
+            // leaves phantom rows that hide under-replication from
+            // repair (#44).
+            let rm = std::sync::Arc::new(reconcile::ReconcileMetrics::default());
+            reconcile_metrics = Some(rm.clone());
             reconcile::spawn(
                 rsearch_storage::FsStorage::new(config.storage.root.clone()),
                 metastore.clone(),
                 config.node_id(),
+                rm,
             );
             std::sync::Arc::new(rsearch_storage::ReplicatedStorage::new(
                 rsearch_storage::FsStorage::new(config.storage.root.clone()),
@@ -294,6 +301,7 @@ async fn main() -> anyhow::Result<()> {
     state.doc_lookup = lookup;
     state.draining = draining_flag;
     state.control = control_metrics;
+    state.reconcile = reconcile_metrics;
     // Bulk handoff between ingest peers needs the cluster token both to
     // authenticate outbound handoffs and to verify inbound ones; without
     // a token the node simply indexes everything it receives itself.

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -110,6 +110,27 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         );
     }
 
+    if let Some(reconcile) = &state.reconcile {
+        counter(
+            &mut out,
+            "rsearch_reconcile_copies_announced_total",
+            "Local object copies re-announced to the placement table by the reconcile sweep.",
+            reconcile.copies_announced.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_reconcile_orphans_swept_total",
+            "Orphaned local object files deleted by the reconcile sweep.",
+            reconcile.orphans_swept.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_reconcile_phantom_placements_removed_total",
+            "Placement rows removed because the recorded file was missing from local disk.",
+            reconcile.phantom_rows_removed.load(Ordering::Relaxed),
+        );
+    }
+
     if let Some(control) = &state.control {
         gauge(
             &mut out,

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -114,7 +114,7 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
         counter(
             &mut out,
             "rsearch_reconcile_copies_announced_total",
-            "Local object copies re-announced to the placement table by the reconcile sweep.",
+            "Placement rows inserted by the reconcile sweep for local files the table had lost track of.",
             reconcile.copies_announced.load(Ordering::Relaxed),
         );
         counter(
@@ -128,6 +128,12 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
             "rsearch_reconcile_phantom_placements_removed_total",
             "Placement rows removed because the recorded file was missing from local disk.",
             reconcile.phantom_rows_removed.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_reconcile_last_copy_placements_removed_total",
+            "Phantom rows removed that were the object's last recorded copy — the object may be lost; alert on any increase.",
+            reconcile.last_copy_rows_removed.load(Ordering::Relaxed),
         );
     }
 

--- a/crates/rsearch-server/src/reconcile.rs
+++ b/crates/rsearch-server/src/reconcile.rs
@@ -16,14 +16,39 @@
 //!   older than a grace window, so an in-flight transfer whose row hasn't
 //!   landed yet is never swept.
 //!
+//! The sweep also runs the opposite direction (#44): every placement row
+//! recorded for this node is verified against local disk, and rows whose
+//! file is gone are deleted. A node whose data volume was replaced keeps
+//! its identity and heartbeats normally, so nothing else ever questions
+//! its rows — the phantom copies count as healthy and mask real
+//! under-replication from the repair job. Dropping the row is what lets
+//! repair see the key and restore the factor. Safe because every write
+//! path lands the file before inserting its row (local put, peer push,
+//! replicate pull, and this sweep's own re-announce), backed by an age
+//! floor on the rows scanned.
+//!
 //! Runs at startup (the rejoin case) and then periodically, which also
 //! catches deletes missed while merely partitioned rather than down.
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use rsearch_metastore::Metastore;
 use rsearch_storage::{FsStorage, Storage};
 use tracing::{info, warn};
+
+/// Reconcile activity counters for `/metrics`, present on
+/// replicated-backend nodes.
+#[derive(Default)]
+pub struct ReconcileMetrics {
+    /// Local copies re-announced to the placement table (#16).
+    pub copies_announced: AtomicU64,
+    /// Orphaned local object files deleted (#16).
+    pub orphans_swept: AtomicU64,
+    /// Placement rows removed because the recorded file was gone (#44).
+    pub phantom_rows_removed: AtomicU64,
+}
 
 /// Never sweep a file younger than this: a freshly transferred object's
 /// placement row lands moments after the file, and peer transfers time
@@ -31,18 +56,37 @@ use tracing::{info, warn};
 const ORPHAN_MIN_AGE: Duration = Duration::from_secs(3600);
 /// Sweep cadence after the startup pass.
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(3600);
+/// Only verify placement rows older than this against disk. Rows are
+/// written strictly after their file, so any age floor suffices; an hour
+/// is pure defense in depth (a future write path that inverts the order,
+/// clock skew) at no cost — a phantom row from a replaced volume is
+/// either already old or ages into the scan within one sweep interval.
+const VERIFY_MIN_ROW_AGE: Duration = Duration::from_secs(3600);
+/// Placement rows fetched per verify page (keyset-paginated).
+const VERIFY_BATCH: i64 = 1000;
 
 /// Spawn the reconcile loop: one pass immediately (rejoin), then hourly.
-pub fn spawn(fs: FsStorage, metastore: Metastore, node_id: String) {
+pub fn spawn(
+    fs: FsStorage,
+    metastore: Metastore,
+    node_id: String,
+    metrics: Arc<ReconcileMetrics>,
+) {
     tokio::spawn(async move {
         loop {
-            reconcile(&fs, &metastore, &node_id).await;
+            reconcile(&fs, &metastore, &node_id, &metrics).await;
+            verify_placements(&fs, &metastore, &node_id, &metrics).await;
             tokio::time::sleep(RECONCILE_INTERVAL).await;
         }
     });
 }
 
-async fn reconcile(fs: &FsStorage, metastore: &Metastore, node_id: &str) {
+async fn reconcile(
+    fs: &FsStorage,
+    metastore: &Metastore,
+    node_id: &str,
+    metrics: &ReconcileMetrics,
+) {
     let keys = match fs.list("").await {
         Ok(keys) => keys,
         Err(e) => {
@@ -69,11 +113,71 @@ async fn reconcile(fs: &FsStorage, metastore: &Metastore, node_id: &str) {
             Err(e) => warn!(key, error = %e, "reconcile: record failed"),
         }
     }
+    metrics.copies_announced.fetch_add(announced, Ordering::Relaxed);
+    metrics.orphans_swept.fetch_add(swept, Ordering::Relaxed);
     if announced > 0 {
         info!(announced, "reconcile: re-announced local object copies");
     }
     if swept > 0 {
         info!(swept, swept_bytes, "reconcile: deleted orphaned local objects");
+    }
+}
+
+/// Metastore->disk direction (#44): delete this node's placement rows
+/// whose file is not on local disk, so under-replication stops hiding
+/// behind them and repair can restore the factor. Only a definitive
+/// NotFound removes a row — any other storage error keeps it, since
+/// deleting on a transient fault could strip the last record of a real
+/// copy (even then the next sweep's disk walk would resurrect it).
+async fn verify_placements(
+    fs: &FsStorage,
+    metastore: &Metastore,
+    node_id: &str,
+    metrics: &ReconcileMetrics,
+) {
+    let mut after = String::new();
+    let mut removed = 0u64;
+    loop {
+        let keys = match metastore
+            .stale_locations_on_node(
+                node_id,
+                VERIFY_MIN_ROW_AGE.as_secs_f64(),
+                &after,
+                VERIFY_BATCH,
+            )
+            .await
+        {
+            Ok(keys) => keys,
+            Err(e) => {
+                warn!(error = %e, "reconcile: listing own placement rows failed");
+                break;
+            }
+        };
+        let Some(last) = keys.last() else { break };
+        after = last.clone();
+        for key in &keys {
+            match fs.exists(key).await {
+                Ok(true) => {}
+                Ok(false) => match metastore.remove_object_location(key, node_id).await {
+                    Ok(()) => {
+                        removed += 1;
+                        warn!(key, "reconcile: removed phantom placement row (file not on disk)");
+                    }
+                    Err(e) => warn!(key, error = %e, "reconcile: phantom row delete failed"),
+                },
+                Err(e) => warn!(key, error = %e, "reconcile: disk check failed; keeping row"),
+            }
+        }
+        if keys.len() < VERIFY_BATCH as usize {
+            break;
+        }
+    }
+    metrics.phantom_rows_removed.fetch_add(removed, Ordering::Relaxed);
+    if removed > 0 {
+        info!(
+            removed,
+            "reconcile: removed placement rows for files missing from local disk"
+        );
     }
 }
 

--- a/crates/rsearch-server/src/reconcile.rs
+++ b/crates/rsearch-server/src/reconcile.rs
@@ -36,19 +36,32 @@ use std::time::Duration;
 
 use rsearch_metastore::Metastore;
 use rsearch_storage::{FsStorage, Storage};
-use tracing::{info, warn};
+use tracing::{debug, error, info, warn};
 
 /// Reconcile activity counters for `/metrics`, present on
 /// replicated-backend nodes.
 #[derive(Default)]
 pub struct ReconcileMetrics {
-    /// Local copies re-announced to the placement table (#16).
+    /// Placement rows inserted for local files the table had lost track
+    /// of (#16). Counts real inserts only — the sweep's refresh of rows
+    /// that already exist is not an announce.
     pub copies_announced: AtomicU64,
     /// Orphaned local object files deleted (#16).
     pub orphans_swept: AtomicU64,
     /// Placement rows removed because the recorded file was gone (#44).
     pub phantom_rows_removed: AtomicU64,
+    /// Phantom rows removed that were the object's last recorded copy:
+    /// no node holds it any more and the object may be lost. Deleting
+    /// the row is still right — it was a lie — but where the row's mere
+    /// disappearance would silence the repair job's recurring "no live
+    /// holder" alarm, this counter keeps the loss visible.
+    pub last_copy_rows_removed: AtomicU64,
 }
+
+/// Per-key log lines emitted at warn before a verify pass drops to
+/// debug: a replaced multi-TB volume removes rows by the million, and a
+/// sick disk can fail every stat call — the summary carries the totals.
+const VERIFY_LOG_CAP: u64 = 20;
 
 /// Never sweep a file younger than this: a freshly transferred object's
 /// placement row lands moments after the file, and peer transfers time
@@ -74,26 +87,32 @@ pub fn spawn(
 ) {
     tokio::spawn(async move {
         loop {
-            reconcile(&fs, &metastore, &node_id, &metrics).await;
-            verify_placements(&fs, &metastore, &node_id, &metrics).await;
+            if let Some(files_on_disk) = reconcile(&fs, &metastore, &node_id, &metrics).await {
+                verify_placements(&fs, &metastore, &node_id, &metrics, files_on_disk).await;
+            }
             tokio::time::sleep(RECONCILE_INTERVAL).await;
         }
     });
 }
 
+/// Disk->metastore direction. Returns the number of local object files
+/// seen, or `None` when the root could not be listed — the verify pass
+/// is skipped in that case, since an unreadable root says nothing about
+/// which files are truly gone.
 async fn reconcile(
     fs: &FsStorage,
     metastore: &Metastore,
     node_id: &str,
     metrics: &ReconcileMetrics,
-) {
+) -> Option<u64> {
     let keys = match fs.list("").await {
         Ok(keys) => keys,
         Err(e) => {
             warn!(error = %e, "reconcile: listing local objects failed");
-            return;
+            return None;
         }
     };
+    let files_on_disk = keys.len() as u64;
     let mut announced = 0u64;
     let mut swept = 0u64;
     let mut swept_bytes = 0u64;
@@ -103,8 +122,10 @@ async fn reconcile(
             .record_object_location_if_known(&key, node_id, size as i64)
             .await
         {
-            Ok(true) => announced += 1,
-            Ok(false) => {
+            Ok(Some(true)) => announced += 1,
+            // Row already existed; the refresh is not an announce.
+            Ok(Some(false)) => {}
+            Ok(None) => {
                 if sweep_orphan(fs, metastore, node_id, &key, size).await {
                     swept += 1;
                     swept_bytes += size;
@@ -121,6 +142,7 @@ async fn reconcile(
     if swept > 0 {
         info!(swept, swept_bytes, "reconcile: deleted orphaned local objects");
     }
+    Some(files_on_disk)
 }
 
 /// Metastore->disk direction (#44): delete this node's placement rows
@@ -134,9 +156,13 @@ async fn verify_placements(
     metastore: &Metastore,
     node_id: &str,
     metrics: &ReconcileMetrics,
+    files_on_disk: u64,
 ) {
     let mut after = String::new();
     let mut removed = 0u64;
+    let mut last_copies = 0u64;
+    let mut kept_sole = 0u64;
+    let mut check_errors = 0u64;
     loop {
         let keys = match metastore
             .stale_locations_on_node(
@@ -158,14 +184,59 @@ async fn verify_placements(
         for key in &keys {
             match fs.exists(key).await {
                 Ok(true) => {}
-                Ok(false) => match metastore.remove_object_location(key, node_id).await {
-                    Ok(()) => {
-                        removed += 1;
-                        warn!(key, "reconcile: removed phantom placement row (file not on disk)");
+                Ok(false) => {
+                    // The row is a lie either way, but losing the last
+                    // record means no copy is known anywhere — say so
+                    // loudly, because deleting the row also retires the
+                    // repair job's recurring "no live holder" alarm.
+                    let sole = !metastore
+                        .other_holders_exist(key, node_id)
+                        .await
+                        .unwrap_or(true);
+                    // A sole row on an *empty* object root is ambiguous:
+                    // a replaced volume (the row is phantom, the object
+                    // lost) looks identical to one that hasn't mounted
+                    // yet (the row is the last true record, deliberately
+                    // preserved by dead-node expiry so a returning
+                    // volume can revive placement). Keep it and keep
+                    // shouting; rows with other holders are safe to
+                    // clean either way — repair re-copies them.
+                    if sole && files_on_disk == 0 {
+                        kept_sole += 1;
+                        error!(
+                            key,
+                            "reconcile: sole placement row for a missing file on an \
+                             empty object root — volume may be unmounted; keeping row"
+                        );
+                        continue;
                     }
-                    Err(e) => warn!(key, error = %e, "reconcile: phantom row delete failed"),
-                },
-                Err(e) => warn!(key, error = %e, "reconcile: disk check failed; keeping row"),
+                    match metastore.remove_object_location(key, node_id).await {
+                        Ok(()) => {
+                            removed += 1;
+                            if sole {
+                                last_copies += 1;
+                                error!(
+                                    key,
+                                    "reconcile: removed last placement row for an object \
+                                     with no file on disk — object may be lost"
+                                );
+                            } else if removed <= VERIFY_LOG_CAP {
+                                warn!(key, "reconcile: removed phantom placement row (file not on disk)");
+                            } else {
+                                debug!(key, "reconcile: removed phantom placement row (file not on disk)");
+                            }
+                        }
+                        Err(e) => warn!(key, error = %e, "reconcile: phantom row delete failed"),
+                    }
+                }
+                Err(e) => {
+                    check_errors += 1;
+                    if check_errors <= VERIFY_LOG_CAP {
+                        warn!(key, error = %e, "reconcile: disk check failed; keeping row");
+                    } else {
+                        debug!(key, error = %e, "reconcile: disk check failed; keeping row");
+                    }
+                }
             }
         }
         if keys.len() < VERIFY_BATCH as usize {
@@ -173,10 +244,14 @@ async fn verify_placements(
         }
     }
     metrics.phantom_rows_removed.fetch_add(removed, Ordering::Relaxed);
-    if removed > 0 {
+    metrics.last_copy_rows_removed.fetch_add(last_copies, Ordering::Relaxed);
+    if removed > 0 || kept_sole > 0 || check_errors > 0 {
         info!(
             removed,
-            "reconcile: removed placement rows for files missing from local disk"
+            last_copies,
+            kept_sole,
+            check_errors,
+            "reconcile: placement verify pass finished"
         );
     }
 }

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -37,6 +37,9 @@ pub struct AppState {
     /// Repair/drain/leadership counters for /metrics, shared with the
     /// control loop. Present only on nodes running the control role.
     pub control: Option<Arc<crate::metrics::ControlMetrics>>,
+    /// Reconcile sweep counters for /metrics, shared with the reconcile
+    /// loop. Present only on replicated-backend nodes.
+    pub reconcile: Option<Arc<crate::reconcile::ReconcileMetrics>>,
     /// Short-TTL cache of all stream names for wildcard resolution — an
     /// `_msearch` refresh resolves `logs-*` once per TTL instead of one
     /// `list_streams` query per header/body pair per viewer.
@@ -75,6 +78,7 @@ impl AppState {
             bulk_forward: None,
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             control: None,
+            reconcile: None,
             stream_names: Arc::new(std::sync::Mutex::new(None)),
             label_fields: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         }

--- a/tests/cluster/run-replicated-test.sh
+++ b/tests/cluster/run-replicated-test.sh
@@ -83,6 +83,9 @@ under_held() {
 
 # ---------- setup ----------
 set -a; source .env; set +a
+# Point the cluster at a dedicated test database (must be the one inside
+# $PG_CONTAINER) when .env's DATABASE_URL is a shared dev instance.
+DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
 rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
 pkill -x rsearch 2>/dev/null || true; pause 0.5
 docker exec "$PG_CONTAINER" psql -U rsearch -qc \
@@ -135,6 +138,41 @@ done
 grep -qh "repair: copy restored" "$LOGDIR"/node-*.log || fail "no repair logged"
 [ "$(count_docs 9313 rlogs)" = "200" ] || fail "docs lost after repair"
 say "PASS: all splits back at factor 2 on live nodes"
+
+# ---------- phantom placement rows (#44) ----------
+say "TEST: placement row for a file lost from a node's volume is removed and repaired"
+PHANTOM_KEY=$(psql_t "SELECT storage_key FROM object_locations WHERE node_id='node-3' LIMIT 1")
+[ -n "$PHANTOM_KEY" ] || fail "no placement row on node-3 to test with"
+# Simulate a replaced data volume: delete the file behind the cluster's
+# back and restart the node — the startup reconcile verify must drop the
+# now-phantom row. Rows younger than the verify age floor are skipped,
+# so backdate them (this cluster is seconds old).
+kill -9 "${PIDS[node-3]}"
+rm "$LOGDIR/node-3/objects/$PHANTOM_KEY" || fail "could not delete $PHANTOM_KEY from node-3"
+docker exec "$PG_CONTAINER" psql -U rsearch -qc \
+  "UPDATE object_locations SET created_at = created_at - interval '2 hours'" >/dev/null
+start_node node-3 9313
+wait_health 9313 || fail "node-3 did not come back"
+for i in $(seq 1 60); do
+  ROWS=$(psql_t "SELECT count(*) FROM object_locations WHERE node_id='node-3' AND storage_key='$PHANTOM_KEY'")
+  [ "$ROWS" = "0" ] && break; pause 1
+done
+[ "$ROWS" = "0" ] || fail "phantom placement row for $PHANTOM_KEY survived reconcile"
+say "phantom row removed; bouncing node-3 so the leader rescans membership"
+# The repair scan triggers on live-set changes (or a slow deadline); a
+# quick bounce past the 10s staleness window forces one promptly.
+kill -9 "${PIDS[node-3]}"
+pause 12
+start_node node-3 9313
+wait_health 9313 || fail "node-3 did not come back from bounce"
+for i in $(seq 1 60); do
+  [ -f "$LOGDIR/node-3/objects/$PHANTOM_KEY" ] && break; pause 1
+done
+[ -f "$LOGDIR/node-3/objects/$PHANTOM_KEY" ] || fail "repair did not restore the lost copy to node-3"
+UNDER=$(under_held rlogs 2 "'node-2','node-3'")
+[ "$UNDER" = "0" ] || fail "$UNDER splits under-held after phantom repair"
+[ "$(count_docs 9313 rlogs)" = "200" ] || fail "docs lost after phantom repair"
+say "PASS: phantom placement row dropped and real copy restored"
 
 # ---------- graceful drain ----------
 say "TEST: drain node-2 — copies move off, reads keep working, bulk refused"

--- a/tests/cluster/run-replicated-test.sh
+++ b/tests/cluster/run-replicated-test.sh
@@ -150,7 +150,7 @@ PHANTOM_KEY=$(psql_t "SELECT storage_key FROM object_locations WHERE node_id='no
 kill -9 "${PIDS[node-3]}"
 rm "$LOGDIR/node-3/objects/$PHANTOM_KEY" || fail "could not delete $PHANTOM_KEY from node-3"
 docker exec "$PG_CONTAINER" psql -U rsearch -qc \
-  "UPDATE object_locations SET created_at = created_at - interval '2 hours'" >/dev/null
+  "UPDATE object_locations SET created_at = created_at - interval '2 hours' WHERE node_id='node-3'" >/dev/null
 start_node node-3 9313
 wait_health 9313 || fail "node-3 did not come back"
 for i in $(seq 1 60); do
@@ -160,15 +160,23 @@ done
 [ "$ROWS" = "0" ] || fail "phantom placement row for $PHANTOM_KEY survived reconcile"
 say "phantom row removed; bouncing node-3 so the leader rescans membership"
 # The repair scan triggers on live-set changes (or a slow deadline); a
-# quick bounce past the 10s staleness window forces one promptly.
+# bounce past the 10s staleness window forces one promptly. The leader
+# only notices on a 3s control tick, so stay down long enough that a
+# tick is guaranteed to sample node-3 as stale (10s window + one tick
+# interval + margin), or the scan waits for the 300s deadline.
 kill -9 "${PIDS[node-3]}"
-pause 12
+pause 16
 start_node node-3 9313
 wait_health 9313 || fail "node-3 did not come back from bounce"
+# Poll the placement row, not the file: the replicate handler records
+# the row only after the file rename, so a file-based break could race
+# the under_held check below. Row implies file (file lands first).
 for i in $(seq 1 60); do
-  [ -f "$LOGDIR/node-3/objects/$PHANTOM_KEY" ] && break; pause 1
+  ROWS=$(psql_t "SELECT count(*) FROM object_locations WHERE node_id='node-3' AND storage_key='$PHANTOM_KEY'")
+  [ "$ROWS" = "1" ] && break; pause 1
 done
-[ -f "$LOGDIR/node-3/objects/$PHANTOM_KEY" ] || fail "repair did not restore the lost copy to node-3"
+[ "$ROWS" = "1" ] || fail "repair did not restore the lost copy to node-3"
+[ -f "$LOGDIR/node-3/objects/$PHANTOM_KEY" ] || fail "placement row restored but file missing on node-3"
 UNDER=$(under_held rlogs 2 "'node-2','node-3'")
 [ "$UNDER" = "0" ] || fail "$UNDER splits under-held after phantom repair"
 [ "$(count_docs 9313 rlogs)" = "200" ] || fail "docs lost after phantom repair"


### PR DESCRIPTION
Fixes #44.

A node restarted onto a replaced data volume keeps its identity and heartbeats normally, so its stale `object_locations` rows count as healthy copies: `under_replicated_keys` never fires, `repair_one` offers the phantom rows as copy sources, and real under-replication stays invisible (38% of the prod hot cluster was one disk failure from loss with every metric green).

## Changes
- **Metastore→disk reconcile verify**: after the existing disk→metastore walk, the reconcile sweep now checks every placement row recorded for this node against local disk and deletes rows whose file is missing, letting the existing repair path see the key and restore the factor. Only a definitive `NotFound` removes a row; transient storage errors keep it.
- **Safety**: every write path (local put, peer push, replicate pull, reconcile re-announce) lands the file before inserting its row, and scanned rows must additionally be older than a 1h age floor.
- **New metrics**: `rsearch_reconcile_phantom_placements_removed_total`, `rsearch_reconcile_copies_announced_total`, `rsearch_reconcile_orphans_swept_total`.
- **Migration**: `(node_id, storage_key)` index on `object_locations` for the keyset-paginated scan (replaces the single-column `node_id` index it covers).
- **Test**: new replicated-cluster scenario deletes a split file behind a node's back, restarts it, and asserts the phantom row drops and repair restores the real copy. The script also honors `RSEARCH_TEST_DATABASE_URL` so it can target a dedicated test database.

## Verification
- `cargo check` and `cargo test --workspace` clean
- `sqlx migrate run` applied cleanly
- `tests/cluster/run-replicated-test.sh` passes end-to-end including the new scenario