### PR TITLE
Cut v0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.3.1" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.3.1" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.3.1" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.3.1" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.3.1" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.3.1" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.3.2" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.3.2" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.3.2" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.3.2" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.3.2" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.3.2" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }

--- a/tests/cluster/run-cluster-test.sh
+++ b/tests/cluster/run-cluster-test.sh
@@ -69,9 +69,13 @@ published_splits() { # index
 
 # ---------- setup ----------
 set -a; source .env; set +a
+# Point the cluster at a dedicated test database (must be the one inside
+# the rsearch-pg container) when .env's DATABASE_URL is a shared dev
+# instance.
+DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
 rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
 pkill -x rsearch 2>/dev/null || true; pause 0.5
-docker exec rsearch-pg psql -U rsearch -qc "DELETE FROM splits; DELETE FROM streams; DELETE FROM nodes;" >/dev/null
+docker exec rsearch-pg psql -U rsearch -qc "DELETE FROM splits; DELETE FROM streams; DELETE FROM nodes; DELETE FROM users; DELETE FROM api_keys; DELETE FROM sessions;" >/dev/null
 docker run --rm --network host --entrypoint sh minio/mc:latest -c \
   "mc alias set m http://127.0.0.1:9000 minioadmin minioadmin >/dev/null && mc rb --force m/rsearch-cluster >/dev/null 2>&1; mc mb -p m/rsearch-cluster >/dev/null" \
   || fail "minio bucket setup"

--- a/tests/cluster/run-document-mode-test.sh
+++ b/tests/cluster/run-document-mode-test.sh
@@ -21,6 +21,9 @@ cleanup() { [ -n "$PID" ] && kill -9 "$PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
 set -a; source .env; set +a
+# Point the node at a dedicated test database when .env's DATABASE_URL
+# is a shared dev instance (the table wipe below is destructive).
+DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
 rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
 psql "$DATABASE_URL" -qc "DELETE FROM streams; DELETE FROM nodes; DELETE FROM users; DELETE FROM api_keys; DELETE FROM sessions;" >/dev/null
 

--- a/tests/cluster/run-replicated-test.sh
+++ b/tests/cluster/run-replicated-test.sh
@@ -89,7 +89,8 @@ DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
 rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
 pkill -x rsearch 2>/dev/null || true; pause 0.5
 docker exec "$PG_CONTAINER" psql -U rsearch -qc \
-  "DELETE FROM object_locations; DELETE FROM splits; DELETE FROM streams; DELETE FROM nodes;" >/dev/null
+  "DELETE FROM object_locations; DELETE FROM splits; DELETE FROM streams; DELETE FROM nodes;
+   DELETE FROM users; DELETE FROM api_keys; DELETE FROM sessions;" >/dev/null
 
 say "starting 3 replicated all-role nodes"
 start_node node-1 9311


### PR DESCRIPTION
Version bump to 0.3.2 (workspace.package + workspace.dependencies) plus test-harness hardening found during release pre-flight: cluster test scripts honor `RSEARCH_TEST_DATABASE_URL` for a dedicated test database, and each suite wipes auth tables so suites are order-independent on a shared DB.

Pre-flight: cargo check/test clean (including Postgres-backed `--include-ignored`), `scripts/ci.sh` (fmt + deny) green, migrations applied, document-mode, S3/MinIO cluster, and replicated cluster suites all pass. `run-ha-compose-test.sh` skipped on this host per its own warning (it would wipe the live `rsearch-ha` project volumes).