### PR TITLE
Merge toward a target size; sweep stray placement rows (#49, #50)

### DIFF
--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -134,7 +134,15 @@ impl Default for GelfInputConfig {
 pub struct ControlConfig {
     /// Seconds between control-job ticks on the leader.
     pub interval_secs: u64,
-    /// Published splits smaller than this are merge candidates (MB).
+    /// Merged splits aim for this size (MB): published splits smaller
+    /// than this are merge candidates, and a merge group is cut once its
+    /// combined size crosses it, so the output is immediately ineligible
+    /// for further merging (#49). Splits at or above it are left alone.
+    pub merge_target_mb: i64,
+    /// Deprecated older name for the merge-candidate ceiling. The
+    /// effective target is `max(merge_target_mb, merge_min_mb)`, so a
+    /// config that raised this keeps its behavior; prefer
+    /// `merge_target_mb`.
     pub merge_min_mb: i64,
     /// Max splits combined per merge operation.
     pub merge_max_group: usize,
@@ -179,6 +187,7 @@ impl Default for ControlConfig {
     fn default() -> Self {
         Self {
             interval_secs: 15,
+            merge_target_mb: 512,
             merge_min_mb: 100,
             merge_max_group: 8,
             gc_grace_secs: 600.0,

--- a/crates/rsearch-metastore/src/locations.rs
+++ b/crates/rsearch-metastore/src/locations.rs
@@ -97,6 +97,35 @@ impl Metastore {
         Ok(known)
     }
 
+    /// Distinct keys that have placement rows but no `splits` row of any
+    /// state (#50): a crash between the storage put and the split-row
+    /// insert — or a partial cluster delete — leaves rows and files that
+    /// no other collector visits. GC walks `splits`, and the node-local
+    /// reconcile sweep skips any key that still has a placement row, so
+    /// the row keeps the file alive and the file keeps the row alive.
+    /// Keys whose newest row is younger than `min_age_secs` are skipped:
+    /// a fresh flush lands its placement rows moments before staging the
+    /// split row.
+    pub async fn stray_object_keys(
+        &self,
+        min_age_secs: f64,
+        limit: i64,
+    ) -> MetastoreResult<Vec<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "SELECT ol.storage_key FROM object_locations ol
+             WHERE NOT EXISTS (SELECT 1 FROM splits s WHERE s.storage_key = ol.storage_key)
+             GROUP BY ol.storage_key
+             HAVING MAX(ol.created_at) < now() - make_interval(secs => $1)
+             ORDER BY ol.storage_key
+             LIMIT $2",
+        )
+        .bind(min_age_secs)
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+        Ok(rows.into_iter().map(|(key,)| key).collect())
+    }
+
     /// Remove one node's copy record for an object.
     pub async fn remove_object_location(
         &self,

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -390,3 +390,51 @@ async fn tombstones_upsert_and_page_by_seq() {
     assert!(remaining(&ms, stream.id).await.is_empty());
     ms.delete_stream(&stream.name).await.unwrap();
 }
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn stray_object_keys_finds_placements_without_split_rows() {
+    let Some(ms) = metastore().await else { return };
+    let stream = ms.ensure_stream(&unique("stray")).await.unwrap();
+
+    // Tracked: placement rows plus a split row (any state protects it).
+    let tracked_key = format!("streams/test/{}.split", unique("tracked"));
+    let split_id = unique("split");
+    ms.stage_split(&NewSplit {
+        split_id: &split_id,
+        stream_id: stream.id,
+        storage_key: &tracked_key,
+        doc_count: 1,
+        size_bytes: 10,
+        time_start_millis: 0,
+        time_end_millis: 0,
+        footer_len: 0,
+        created_by: None,
+        seq_min: None,
+        seq_max: None,
+        tombstone_seq_applied: 0,
+    })
+    .await
+    .unwrap();
+    ms.record_object_location(&tracked_key, "stray-node-a", 10).await.unwrap();
+
+    // Stray: placement rows on two nodes, no split row — the crash
+    // window between the storage put and the split-row insert (#50).
+    let stray_key = format!("streams/test/{}.split", unique("stray"));
+    ms.record_object_location(&stray_key, "stray-node-a", 10).await.unwrap();
+    ms.record_object_location(&stray_key, "stray-node-b", 10).await.unwrap();
+
+    let strays = ms.stray_object_keys(0.0, 10_000).await.unwrap();
+    assert!(strays.contains(&stray_key));
+    assert!(!strays.contains(&tracked_key));
+    // Distinct keys: two placement rows surface the key once.
+    assert_eq!(strays.iter().filter(|k| *k == &stray_key).count(), 1);
+
+    // The age floor keeps fresh put->stage windows out of the sweep.
+    let fresh = ms.stray_object_keys(3600.0, 10_000).await.unwrap();
+    assert!(!fresh.contains(&stray_key));
+
+    ms.remove_object_locations(&stray_key).await.unwrap();
+    ms.remove_object_locations(&tracked_key).await.unwrap();
+    ms.delete_stream(&stream.name).await.unwrap();
+}

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -185,6 +185,12 @@ impl ControlPlane {
         if let Err(e) = self.staged_orphan_job().await {
             error!(error = %e, "staged-orphan sweep failed");
         }
+        // Needs the settled membership view: with peers' heartbeat rows
+        // still stale, every remote copy would be skipped and needlessly
+        // orphaned on its node.
+        if settled && let Err(e) = self.stray_object_job().await {
+            error!(error = %e, "stray-object sweep failed");
+        }
         if let Err(e) = self.gc_job().await {
             error!(error = %e, "gc job failed");
         }
@@ -570,12 +576,14 @@ impl ControlPlane {
         }
     }
 
-    /// Combine the first group of >= 2 small published splits in one
-    /// stream into a single split. One merge per tick bounds the work.
+    /// Combine the first group of >= 2 published splits below the merge
+    /// target in one stream into a single split. One merge per tick
+    /// bounds the work.
     async fn merge_job(&self) -> anyhow::Result<()> {
+        let target_bytes = self.merge_target_bytes();
         let small = self
             .metastore
-            .small_published_splits(self.config.merge_min_mb << 20, 200)
+            .small_published_splits(target_bytes, 200)
             .await?;
         let mut by_stream: BTreeMap<i64, Vec<&SplitRecord>> = BTreeMap::new();
         for split in &small {
@@ -585,10 +593,8 @@ impl ControlPlane {
             .into_iter()
             .find_map(|(id, group)| {
                 let group = merge_candidates(group);
-                (group.len() >= 2).then(|| {
-                    let take = group.len().min(self.config.merge_max_group);
-                    (id, group[..take].to_vec())
-                })
+                let take = merge_take(&group, target_bytes, self.config.merge_max_group);
+                (take >= 2).then(|| (id, group[..take].to_vec()))
             })
         else {
             return Ok(());
@@ -938,6 +944,47 @@ impl ControlPlane {
         Ok(())
     }
 
+    /// Merged splits aim for this size; splits at or above it are never
+    /// merge candidates (#49). `merge_min_mb` is the deprecated older
+    /// name for the ceiling — the max keeps configs that raised it
+    /// behaving as before.
+    fn merge_target_bytes(&self) -> i64 {
+        self.config.merge_target_mb.max(self.config.merge_min_mb) << 20
+    }
+
+    /// Delete objects whose placement rows outlived their split row
+    /// (#50). A crash between the storage put and the split-row insert —
+    /// or a partial cluster delete — leaves `object_locations` rows and
+    /// real files that nothing else collects: GC walks `splits`, and the
+    /// node-local reconcile sweep skips any key that still has a
+    /// placement row, so the row pins the file and the file pins the
+    /// row. The storage delete drops peer copies, the local file, and
+    /// every placement row; copies on currently-dead nodes become plain
+    /// orphans their own reconcile sweep removes after its grace.
+    /// Replicated backend only; `staged_orphan_secs` doubles as the age
+    /// floor since it already bounds the same crashed-flush window.
+    async fn stray_object_job(&self) -> anyhow::Result<()> {
+        if self.replication.is_none() {
+            return Ok(());
+        }
+        let strays = self
+            .metastore
+            .stray_object_keys(self.config.staged_orphan_secs, 50)
+            .await?;
+        for key in strays {
+            match self.storage.delete(&key).await {
+                Ok(()) => {
+                    self.metrics
+                        .stray_objects_deleted
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    info!(key, "stray sweep: deleted object whose placement rows had no split row");
+                }
+                Err(e) => warn!(key, error = %e, "stray sweep: delete failed"),
+            }
+        }
+        Ok(())
+    }
+
     async fn gc_job(&self) -> anyhow::Result<()> {
         let candidates = self
             .metastore
@@ -962,9 +1009,9 @@ const MERGE_SKEW_FACTOR: i64 = 10;
 
 /// Drop dominant splits from a stream's merge group (#15). Merging is a
 /// full rewrite of every source, so folding a trickle of tiny splits into
-/// one dominant under-threshold split re-wrote its bytes every tick —
+/// one dominant under-target split re-wrote its bytes every tick —
 /// quadratic write amplification (plus re-replication, GC churn, and
-/// cache pressure) until it finally crossed `merge_min_mb`. Excluding a
+/// cache pressure) until it finally crossed the merge target. Excluding a
 /// split that is more than [`MERGE_SKEW_FACTOR`]× the sum of its smaller
 /// peers lets the small splits merge among themselves; the dominant one
 /// rejoins once they have accumulated to comparable size, so each byte is
@@ -997,6 +1044,24 @@ fn merge_candidates(group: Vec<&SplitRecord>) -> Vec<&SplitRecord> {
         .into_iter()
         .filter(|s| s.size_bytes < threshold)
         .collect()
+}
+
+/// How many leading (time-ordered) splits of a stream's merge group to
+/// combine: enough for the output to reach `target_bytes` — the crossing
+/// split is included, so the result lands at or above the target and is
+/// immediately ineligible for further merging (#49) — capped at
+/// `max_group`. A group that can't reach the target merges whole; the
+/// skew filter above already keeps such prompt merges from re-writing a
+/// dominant split every tick.
+fn merge_take(group: &[&SplitRecord], target_bytes: i64, max_group: usize) -> usize {
+    let mut sum = 0i64;
+    for (i, split) in group.iter().take(max_group).enumerate() {
+        sum = sum.saturating_add(split.size_bytes);
+        if sum >= target_bytes {
+            return i + 1;
+        }
+    }
+    group.len().min(max_group)
 }
 
 #[cfg(test)]
@@ -1076,5 +1141,42 @@ mod tests {
         // check is what keeps it from merging with itself.
         let splits = [split(1, 1 << 20)];
         assert_eq!(candidate_ids(&splits), vec![1]);
+    }
+
+    fn take_of(splits: &[SplitRecord], target_mb: i64, max_group: usize) -> usize {
+        let group: Vec<&SplitRecord> = splits.iter().collect();
+        merge_take(&group, target_mb << 20, max_group)
+    }
+
+    #[test]
+    fn take_stops_at_the_split_that_crosses_the_target() {
+        // The #49 shape: flushes born just under the target keep merging.
+        // 60 + 60 + 60 crosses 150 at the third split; the fourth waits.
+        let splits: Vec<SplitRecord> =
+            (1..=4).map(|id| split(id, 60 << 20)).collect();
+        assert_eq!(take_of(&splits, 150, 8), 3);
+    }
+
+    #[test]
+    fn take_is_capped_at_max_group() {
+        let splits: Vec<SplitRecord> =
+            (1..=20).map(|id| split(id, 1 << 20)).collect();
+        assert_eq!(take_of(&splits, 512, 8), 8);
+    }
+
+    #[test]
+    fn group_below_target_merges_whole() {
+        // Tiny trickle streams still merge promptly instead of waiting to
+        // accumulate a full target's worth.
+        let splits = [split(1, 2 << 20), split(2, 3 << 20)];
+        assert_eq!(take_of(&splits, 512, 8), 2);
+    }
+
+    #[test]
+    fn lone_crossing_split_is_not_a_group() {
+        // A single split at the target is take=1; the caller's >= 2 check
+        // leaves it alone.
+        let splits = [split(1, 600 << 20)];
+        assert_eq!(take_of(&splits, 512, 8), 1);
     }
 }

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -35,6 +35,8 @@ pub struct ControlMetrics {
     pub tombstones_purged: AtomicU64,
     /// Tombstone rows pending (as of the last compaction scan).
     pub tombstones_pending: AtomicU64,
+    /// Objects deleted because their placement rows had no split row (#50).
+    pub stray_objects_deleted: AtomicU64,
 }
 
 fn counter(out: &mut String, name: &str, help: &str, value: u64) {
@@ -198,6 +200,12 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
             "rsearch_tombstones_purged_total",
             "Tombstone rows purged once no split could still hold a hidden version.",
             control.tombstones_purged.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_stray_objects_deleted_total",
+            "Objects deleted by the stray sweep: placement rows with no split row.",
+            control.stray_objects_deleted.load(Ordering::Relaxed),
         );
     }
 

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -83,7 +83,7 @@ cache_max_mb = 4096      # local split-fragment cache budget
 
 [control]
 interval_secs = 15          # background-job tick on the elected leader
-merge_min_mb = 100          # published splits smaller than this get merged
+merge_target_mb = 512       # splits below this keep merging until the output reaches it
 merge_max_group = 8         # max splits combined per merge
 gc_grace_secs = 600         # delay before deleting marked-for-delete splits
 staged_orphan_secs = 3600   # sweep splits stuck in 'staged' after a crash


### PR DESCRIPTION
Fixes #49
Fixes #50

## #49 — merge toward `merge_target_mb`

`merge_min_mb` was both the merge-candidate ceiling and the stop condition, so a split born above it (audit-stream flushes land at 49–68 MB) was never merged and split count grew linearly forever.

- New `merge_target_mb` config (default 512 MB): published splits **below the target** are candidates; each stream's group is cut once its combined size crosses the target (crossing split included), capped at `merge_max_group`, so outputs land at/above the target and immediately leave the candidate set.
- Groups that can't reach the target still merge whole — tiny trickle streams keep merging promptly, with the #15 skew filter still guarding write amplification.
- `merge_min_mb` remains as a deprecated alias; the effective target is `max(merge_target_mb, merge_min_mb)`, so existing configs parse and behave sanely after upgrade.

## #50 — leader-run stray-object sweep

A crash between the storage put and the split-row insert (or a partial cluster delete) leaves `object_locations` rows plus real files that nothing collects: GC walks `splits`, and the node-local reconcile sweep skips any key that still has a placement row — the row pins the file and the file pins the row.

- New `Metastore::stray_object_keys`: distinct placement keys with no `splits` row in **any** state, age-floored on the newest row (`staged_orphan_secs`, which already bounds the same crashed-flush window).
- New `stray_object_job` on the control leader (replicated backend only, waits for the settled membership view) deletes each stray via `storage.delete`, dropping peer copies, the local file, and every placement row together; copies on dead nodes become plain orphans their own reconcile sweep removes.
- New `rsearch_stray_objects_deleted_total` counter.

## Tests

- 4 new unit tests for the merge-group take logic; existing merge/skew tests unchanged and passing.
- New Postgres integration test for `stray_object_keys` (stray found, split row of any state protects, distinct keys, age floor holds).
- `cargo check --workspace --all-targets` clean; full workspace tests + `metastore_pg -- --ignored` all green.