### PR TITLE
Deep pagination via search_after (issue #52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,21 @@ through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 
 Deep pagination uses `search_after`: every hit's `sort` values are
-`[timestamp_millis, _seq]` — pass the last hit's values back as
-`search_after` to page strictly past it (with `from` = 0). Each page
-costs only `size` per split, so it pages past `max_result_window`,
-which caps plain `from`/`size` at 10k. Totals and aggregations reflect
-the full query, as in Elasticsearch. Hits from legacy (pre-`_seq`)
-splits report `-1` as the tiebreak and page by timestamp only there;
-merging them to the current split format restores exact paging.
+`[timestamp_millis, _seq]` — the `_seq` element is an implicit unique
+tiebreak appended to the timestamp sort, the way Elasticsearch's
+point-in-time search appends `_shard_doc` — and passing the last hit's
+values back as `search_after` (with `from` = 0) pages strictly past it.
+Each page costs only `size` per split, so it pages past
+`max_result_window`, which caps plain `from`/`size` at 10k. Totals and
+aggregations reflect the full query on every page, as in Elasticsearch;
+send `track_total_hits: false` on follow-up pages to skip recounting,
+which also lets splits wholly behind the cursor be skipped entirely.
+Always pass both sort values back: a one-element `[timestamp]` cursor
+pages strictly by timestamp and skips equal-timestamp documents at the
+page boundary (the classic ES footgun with a non-unique sort). Hits
+from legacy (pre-`_seq`) splits report `-1` as the tiebreak and page by
+timestamp only there; merging them to the current split format restores
+exact paging.
 
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ fields by `name:term` or via `fields`). Aggregations pass
 through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 
+Deep pagination uses `search_after`: every hit's `sort` values are
+`[timestamp_millis, _seq]` — pass the last hit's values back as
+`search_after` to page strictly past it (with `from` = 0). Each page
+costs only `size` per split, so it pages past `max_result_window`,
+which caps plain `from`/`size` at 10k. Totals and aggregations reflect
+the full query, as in Elasticsearch. Hits from legacy (pre-`_seq`)
+splits report `-1` as the tiebreak and page by timestamp only there;
+merging them to the current split format restores exact paging.
+
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.
 

--- a/crates/rsearch-index/src/document.rs
+++ b/crates/rsearch-index/src/document.rs
@@ -40,7 +40,7 @@ pub fn extract_timestamp(doc: &serde_json::Value) -> Option<tantivy::DateTime> {
 
 /// Widest epoch-millis range tantivy's nanosecond representation holds
 /// (~year 1677 to ~2262). Out-of-range inputs clamp instead of panicking.
-const MAX_SAFE_MILLIS: i64 = i64::MAX / 1_000_000;
+pub const MAX_SAFE_MILLIS: i64 = i64::MAX / 1_000_000;
 
 /// Normalize an epoch number of unknown unit (secs, millis, micros, or
 /// nanos — shippers send all four) to clamped epoch milliseconds.

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -17,7 +17,9 @@ pub use dynamic_paths::dynamic_string_paths;
 pub use tantivy::DateTime;
 pub use cache::SplitCache;
 pub use reader::{ReadDoc, SplitReader};
-pub use document::{DocIdentity, DocumentConverter, epoch_to_millis, extract_timestamp};
+pub use document::{
+    DocIdentity, DocumentConverter, MAX_SAFE_MILLIS, epoch_to_millis, extract_timestamp,
+};
 pub use error::{IndexError, IndexResult};
 pub use exclusions::{ExcludeDocsQuery, ExclusionSet, Tombstone};
 pub use mapping::{

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -35,36 +35,75 @@ pub struct StreamInfo {
 /// its own entry immediately.
 const STREAM_INFO_TTL: Duration = Duration::from_secs(10);
 
+/// Bits every stamp reserves for a per-node salt: `search_after` cursors
+/// use `(timestamp, _seq)` as their paging position, so two nodes must
+/// not be able to mint the same `_seq` in the same microsecond.
+const SEQ_SALT_BITS: u32 = 10;
+const SEQ_SALT_MASK: i64 = (1 << SEQ_SALT_BITS) - 1;
+
 /// Write-sequence source: a hybrid logical clock. Stamps are micros
-/// since epoch, forced strictly increasing across calls on one node, and
+/// since epoch shifted left by [`SEQ_SALT_BITS`] with a node salt in the
+/// low bits, forced strictly increasing across calls on one node, and
 /// pushed past every sequence this node has *observed* from the cluster
 /// (tombstone bounds of the ids being written, the stream's highest
 /// published `_seq`) — so a replacement written on a node whose wall
 /// clock lags the previous writer's still orders after it. Wall clocks
-/// only set the pace; causality comes from the observations.
+/// only set the pace; causality comes from the observations. The salt
+/// (a hash of the node id) keeps stamps distinct across nodes even at
+/// the same microsecond, and every stamp — including the increment
+/// fallback — carries it, so cross-node collisions need a salt collision
+/// too. Pre-salt stamps (plain micros) are ~1000× smaller, so all new
+/// writes order after all old ones and `observe` folds them in as
+/// before.
 #[derive(Default)]
 pub struct SeqClock {
     last: std::sync::atomic::AtomicI64,
+    salt: i64,
 }
 
 impl SeqClock {
+    /// A clock whose stamps carry a salt derived from `node_id` in their
+    /// low bits. (Non-cryptographic hash: disambiguation, not security.)
+    pub fn new(node_id: &str) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        node_id.hash(&mut hasher);
+        Self {
+            last: std::sync::atomic::AtomicI64::new(0),
+            salt: (hasher.finish() as i64) & SEQ_SALT_MASK,
+        }
+    }
+
     /// Fold a sequence seen elsewhere into the clock: later stamps exceed it.
     pub fn observe(&self, seen: i64) {
         self.last.fetch_max(seen, Ordering::AcqRel);
     }
 
+    /// The lowest stamp carrying this clock's salt that is strictly
+    /// greater than `last` (saturating at the top of the range).
+    fn stamp_after(&self, last: i64) -> i64 {
+        let slot = (last >> SEQ_SALT_BITS).saturating_add(1);
+        if slot > (i64::MAX >> SEQ_SALT_BITS) {
+            i64::MAX
+        } else {
+            (slot << SEQ_SALT_BITS) | self.salt
+        }
+    }
+
     /// Next sequence stamp.
     pub fn next(&self) -> i64 {
-        let now = SystemTime::now()
+        let micros = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_micros() as i64)
             .unwrap_or(0);
-        // fetch_update: `last = max(last + 1, now)` atomically.
+        let now = (micros.clamp(0, i64::MAX >> SEQ_SALT_BITS) << SEQ_SALT_BITS) | self.salt;
+        // fetch_update: `last = max(first salted stamp past last, now)`
+        // atomically.
         self.last
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |last| {
-                Some(now.max(last.saturating_add(1)))
+                Some(now.max(self.stamp_after(last)))
             })
-            .map(|prev| now.max(prev.saturating_add(1)))
+            .map(|prev| now.max(self.stamp_after(prev)))
             .unwrap_or(now)
     }
 }
@@ -171,6 +210,7 @@ impl IngestPipeline {
         metastore: Metastore,
         wal: Arc<Wal>,
     ) -> Self {
+        let seq = SeqClock::new(&config.node_id);
         let pipeline = Self {
             inner: Arc::new(PipelineInner {
                 config,
@@ -181,7 +221,7 @@ impl IngestPipeline {
                 worker_create: tokio::sync::Mutex::new(()),
                 metrics: IngestMetrics::default(),
                 rules: std::sync::RwLock::new(Arc::new(Vec::new())),
-                seq: SeqClock::default(),
+                seq,
                 stream_info: std::sync::RwLock::new(HashMap::new()),
             }),
         };
@@ -880,5 +920,38 @@ mod tests {
         let c = clock.next();
         clock.observe(a);
         assert!(clock.next() > c);
+    }
+
+    /// Two nodes minting stamps at the same wall-clock instant must never
+    /// collide: `search_after` cursors rely on `(timestamp, _seq)` being
+    /// unique cluster-wide, and each node's salt rides in the low bits of
+    /// every stamp — including increment-fallback stamps minted while a
+    /// clock is pushed ahead of wall time by an observation.
+    #[test]
+    fn seq_clock_salts_keep_nodes_distinct() {
+        let a = SeqClock::new("node-a");
+        let b = SeqClock::new("node-b");
+        let salt = |s: i64| s & super::SEQ_SALT_MASK;
+        let first_a = a.next();
+        let first_b = b.next();
+        assert_ne!(salt(first_a), salt(first_b), "test node ids must hash apart");
+        // Drive both clocks into the increment fallback from the same
+        // observed stamp (a peer far in the future) — the classic
+        // collision path for an unsalted hybrid clock.
+        let far = first_a.max(first_b) + (10_000_000_000 << super::SEQ_SALT_BITS);
+        a.observe(far);
+        b.observe(far);
+        let mut seen = std::collections::HashSet::new();
+        let mut last_a = 0;
+        let mut last_b = 0;
+        for _ in 0..1000 {
+            let sa = a.next();
+            let sb = b.next();
+            assert!(sa > last_a && sb > last_b, "stamps must stay monotonic");
+            (last_a, last_b) = (sa, sb);
+            assert_eq!(salt(sa), salt(first_a));
+            assert_eq!(salt(sb), salt(first_b));
+            assert!(seen.insert(sa) && seen.insert(sb), "cross-node stamp collision");
+        }
     }
 }

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -17,7 +17,7 @@ use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResult
 use tantivy::collector::{Count, TopDocs};
 use tantivy::query::{BooleanQuery, Occur, Query, RangeQuery};
 use tantivy::schema::{Term, Value as _};
-use tantivy::{DocAddress, Order, TantivyDocument};
+use tantivy::{DocAddress, TantivyDocument};
 use tokio::sync::Mutex;
 use tracing::warn;
 
@@ -173,18 +173,31 @@ impl SearchRequest {
         // search_after: the previous page's last `sort` values. The
         // timestamp is taken verbatim as epoch millis (it is what our own
         // `sort` emitted — no unit heuristic, which would rescale small
-        // values).
+        // values), clamped to the tantivy-safe range like every other
+        // timestamp input so a hostile cursor can't overflow the nanos
+        // conversion.
         let search_after = match body.get("search_after") {
-            None => None,
+            None | Some(Value::Null) => None,
             Some(Value::Array(vals)) if (1..=2).contains(&vals.len()) => {
+                // Whole-valued floats are accepted: JSON round-trips in
+                // some clients re-encode the echoed integer as a float.
                 let as_i64 = |v: &Value| {
-                    v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                    v.as_i64()
+                        .or_else(|| {
+                            v.as_f64()
+                                .filter(|f| f.fract() == 0.0 && f.abs() <= 9_007_199_254_740_992.0)
+                                .map(|f| f as i64)
+                        })
+                        .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
                 };
-                let timestamp_millis = as_i64(&vals[0]).ok_or_else(|| {
-                    SearchError::BadRequest(
-                        "search_after[0] must be the timestamp sort value (epoch millis)".into(),
-                    )
-                })?;
+                let timestamp_millis = as_i64(&vals[0])
+                    .ok_or_else(|| {
+                        SearchError::BadRequest(
+                            "search_after[0] must be the timestamp sort value (epoch millis)"
+                                .into(),
+                        )
+                    })?
+                    .clamp(-rsearch_index::MAX_SAFE_MILLIS, rsearch_index::MAX_SAFE_MILLIS);
                 let seq = vals
                     .get(1)
                     .map(|v| {
@@ -641,12 +654,30 @@ impl SearchService {
                 let fully_covered = is_match_all
                     && t_start.map(|s| split.time_start_millis >= s).unwrap_or(true)
                     && t_end.map(|e| split.time_end_millis <= e).unwrap_or(true);
+                // A split lying entirely on the already-paged side of the
+                // cursor cannot contribute page hits — its top-k pass is
+                // skipped, and when the count is skippable too the split
+                // is not even opened. (Strict compare: a split touching
+                // the boundary timestamp may still hold page docs.)
+                let outside_cursor = match cursor {
+                    Some(c) if sort_desc => split.time_start_millis > c.timestamp_millis,
+                    Some(c) => split.time_end_millis < c.timestamp_millis,
+                    None => false,
+                };
                 async move {
-                    let reader = this.reader(&split_id, &storage_key, applied_through).await?;
                     let skip_count = match track {
                         Some(cap) => counted.load(Ordering::Relaxed) >= cap,
                         None => false,
                     };
+                    if outside_cursor && skip_count && aggregations.is_none() {
+                        return Ok(SplitOutcome {
+                            count: 0,
+                            count_is_lower_bound: true,
+                            hits: Vec::new(),
+                            aggs: None,
+                        });
+                    }
+                    let reader = this.reader(&split_id, &storage_key, applied_through).await?;
                     let outcome = tokio::task::spawn_blocking(move || {
                         let exclusions = match tombstones {
                             Some(list) => Some(reader.apply_tombstones(&list)?),
@@ -660,6 +691,7 @@ impl SearchService {
                             fetch_limit,
                             sort_desc,
                             cursor,
+                            outside_cursor,
                             skip_count,
                             idx,
                             doc_count,
@@ -965,6 +997,34 @@ fn cursor_clause(schema: &MappedSchema, cursor: SearchAfter, sort_desc: bool) ->
     }
 }
 
+/// Per-split top-k collector ordering by the same key the global merge
+/// uses — (timestamp, `_seq`), direction-normalized (asc negates both
+/// legs) so the collector's greatest-first heap yields the requested
+/// direction, ties broken by ascending doc id exactly like the merge.
+/// Truncating per split by any other order hands the merge the wrong end
+/// of an equal-timestamp group: with timestamp-only ordering, docs
+/// beyond the page size in such a group became unreachable through
+/// `search_after` and duplicated under `from`/`size` (review finding).
+/// Legacy splits (no `_seq` column) yield the -1 sentinel.
+fn top_sort_key_collector(
+    limit: usize,
+    sort_desc: bool,
+) -> impl tantivy::collector::Collector<Fruit = Vec<((i64, i64), DocAddress)>> {
+    TopDocs::with_limit(limit.max(1)).order_by(move |segment: &tantivy::SegmentReader| {
+        let ts_col = segment.fast_fields().date("_timestamp").ok();
+        let seq_col = segment.fast_fields().i64(rsearch_index::SEQ_FIELD).ok();
+        move |doc: tantivy::DocId| {
+            let ts = ts_col
+                .as_ref()
+                .and_then(|col| col.first(doc))
+                .map(|t| t.into_timestamp_millis())
+                .unwrap_or_default();
+            let seq = seq_col.as_ref().and_then(|col| col.first(doc)).unwrap_or(-1);
+            if sort_desc { (ts, seq) } else { (ts.saturating_neg(), seq.saturating_neg()) }
+        }
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn search_one_split(
     reader: &SplitReader,
@@ -973,6 +1033,7 @@ fn search_one_split(
     fetch_limit: usize,
     sort_desc: bool,
     cursor: Option<SearchAfter>,
+    page_outside_cursor: bool,
     skip_count: bool,
     split_idx: usize,
     doc_count: usize,
@@ -999,38 +1060,19 @@ fn search_one_split(
     }
     let searcher = reader.searcher()?;
 
-    let order = if sort_desc { Order::Desc } else { Order::Asc };
-    let top_collector = TopDocs::with_limit(fetch_limit.max(1))
-        .order_by_fast_field::<tantivy::DateTime>("_timestamp", order);
+    let top_collector = top_sort_key_collector(fetch_limit, sort_desc);
 
-    // Resolve top-k pairs into hits, reading each one's `_seq` from its
-    // segment's fast column (None on legacy splits) — the tiebreak the
-    // global merge and search_after cursors sort by.
-    let has_seq = reader.mapped_schema().seq.is_some();
-    let make_hits = |top: Vec<(Option<tantivy::DateTime>, DocAddress)>| -> Vec<SplitHit> {
-        let mut seq_cols: HashMap<u32, Option<tantivy::columnar::Column<i64>>> = HashMap::new();
+    // Resolve the collector's ((ts, seq), doc) pairs into hits,
+    // un-normalizing the asc negation; -1 marks a doc without a `_seq`
+    // (legacy split).
+    let make_hits = |top: Vec<((i64, i64), DocAddress)>| -> Vec<SplitHit> {
         top.into_iter()
-            .map(|(timestamp, doc)| {
-                let seq = has_seq
-                    .then(|| {
-                        seq_cols
-                            .entry(doc.segment_ord)
-                            .or_insert_with(|| {
-                                searcher
-                                    .segment_reader(doc.segment_ord)
-                                    .fast_fields()
-                                    .i64(rsearch_index::SEQ_FIELD)
-                                    .ok()
-                            })
-                            .as_ref()
-                            .and_then(|col| col.first(doc.doc_id))
-                    })
-                    .flatten();
+            .map(|((ts, seq), doc)| {
+                let (ts, seq) =
+                    if sort_desc { (ts, seq) } else { (ts.saturating_neg(), seq.saturating_neg()) };
                 SplitHit {
-                    timestamp_millis: timestamp
-                        .map(|t| t.into_timestamp_millis())
-                        .unwrap_or_default(),
-                    seq,
+                    timestamp_millis: ts,
+                    seq: (seq >= 0).then_some(seq),
                     split_idx,
                     doc,
                 }
@@ -1038,12 +1080,15 @@ fn search_one_split(
             .collect()
     };
     // The cursor narrows only the page's top-k query — totals and
-    // aggregations keep reflecting the full query, as in ES. Builds its
-    // own collector so the combined-collector arms below can consume the
-    // shared one.
-    let page_search = |base: Box<dyn Query>| -> SearchResult<Vec<(Option<tantivy::DateTime>, DocAddress)>> {
-        let collector = TopDocs::with_limit(fetch_limit.max(1))
-            .order_by_fast_field::<tantivy::DateTime>("_timestamp", order);
+    // aggregations keep reflecting the full query, as in ES. A split
+    // wholly on the paged side of the cursor skips the pass entirely.
+    // Builds its own collector so the combined-collector arms below can
+    // consume the shared one.
+    let page_search = |base: Box<dyn Query>| -> SearchResult<Vec<((i64, i64), DocAddress)>> {
+        if page_outside_cursor {
+            return Ok(Vec::new());
+        }
+        let collector = top_sort_key_collector(fetch_limit, sort_desc);
         let page_query: Box<dyn Query> = match cursor {
             Some(c) => Box::new(BooleanQuery::new(vec![
                 (Occur::Must, base),
@@ -1156,6 +1201,26 @@ mod tests {
         let parsed = SearchRequest::parse("logs", &json!({"search_after": [1000, -1]})).unwrap();
         assert_eq!(parsed.search_after.unwrap().timestamp_millis, 1000);
         assert_eq!(parsed.search_after.unwrap().seq, Some(-1));
+
+        // Whole-valued floats are accepted (JSON round-trips in some
+        // clients re-encode echoed integers as floats).
+        let parsed =
+            SearchRequest::parse("logs", &json!({"search_after": [2000.0, 5.0]})).unwrap();
+        let cursor = parsed.search_after.unwrap();
+        assert_eq!((cursor.timestamp_millis, cursor.seq), (2000, Some(5)));
+
+        // An explicit null means "no cursor", not a 400.
+        let parsed = SearchRequest::parse("logs", &json!({"search_after": null})).unwrap();
+        assert!(parsed.search_after.is_none());
+
+        // A hostile timestamp clamps to the tantivy-safe range instead of
+        // overflowing the nanos conversion downstream.
+        let parsed =
+            SearchRequest::parse("logs", &json!({"search_after": [i64::MAX, 1]})).unwrap();
+        assert_eq!(
+            parsed.search_after.unwrap().timestamp_millis,
+            rsearch_index::MAX_SAFE_MILLIS
+        );
     }
 
     #[test]
@@ -1167,20 +1232,17 @@ mod tests {
             json!({"search_after": {"ts": 1}}),
             json!({"search_after": ["not-a-number"]}),
             json!({"search_after": [1000, "x"]}),
+            // A fractional float is not a sort value we ever emitted.
+            json!({"search_after": [1000.5]}),
         ] {
             let err = SearchRequest::parse("logs", &body).unwrap_err();
             assert!(matches!(err, SearchError::BadRequest(_)), "{body}");
         }
     }
 
-    /// Docs as (timestamp_millis, seq) at the given schema version →
-    /// how many pass the cursor clause.
-    fn count_past(
-        schema_version: u32,
-        docs: &[(i64, i64)],
-        cursor: SearchAfter,
-        sort_desc: bool,
-    ) -> usize {
+    /// In-RAM index of (timestamp_millis, seq) docs at the given schema
+    /// version.
+    fn build_index(schema_version: u32, docs: &[(i64, i64)]) -> (MappedSchema, tantivy::Index) {
         let schema = MappedSchema::build_versioned(IndexMapping::default(), schema_version);
         let index = tantivy::Index::create_in_ram(schema.schema.clone());
         let converter = DocumentConverter::new(schema.clone());
@@ -1198,6 +1260,18 @@ mod tests {
             writer.add_document(doc).unwrap();
         }
         writer.commit().unwrap();
+        (schema, index)
+    }
+
+    /// Docs as (timestamp_millis, seq) at the given schema version →
+    /// how many pass the cursor clause.
+    fn count_past(
+        schema_version: u32,
+        docs: &[(i64, i64)],
+        cursor: SearchAfter,
+        sort_desc: bool,
+    ) -> usize {
+        let (schema, index) = build_index(schema_version, docs);
         let searcher = index.reader().unwrap().searcher();
         let clause = cursor_clause(&schema, cursor, sort_desc);
         searcher.search(&clause, &Count).unwrap()
@@ -1234,6 +1308,64 @@ mod tests {
         assert_eq!(count_past(1, &DOCS, after(1000, None), true), 0);
         // asc past ts=2000: only d.
         assert_eq!(count_past(1, &DOCS, after(2000, None), false), 1);
+    }
+
+    /// Review finding (critical): the per-split top-k must truncate in
+    /// the same (timestamp, `_seq`) order the merge and cursors use.
+    /// With timestamp-only collection, an equal-timestamp group larger
+    /// than the page size kept the wrong end of the group, making the
+    /// rest unreachable through search_after (and duplicating pages
+    /// under from/size).
+    #[test]
+    fn pagination_survives_tie_groups_larger_than_page() {
+        use tantivy::query::AllQuery;
+        let docs: Vec<(i64, i64)> = (1..=6).map(|seq| (1000, seq)).collect();
+        let (schema, index) = build_index(1, &docs);
+        let searcher = index.reader().unwrap().searcher();
+        let page_seqs = |cursor: Option<SearchAfter>, sort_desc: bool| -> Vec<i64> {
+            let query: Box<dyn Query> = match cursor {
+                Some(c) => Box::new(BooleanQuery::new(vec![
+                    (Occur::Must, Box::new(AllQuery) as Box<dyn Query>),
+                    (Occur::Must, cursor_clause(&schema, c, sort_desc)),
+                ])),
+                None => Box::new(AllQuery),
+            };
+            searcher
+                .search(&query, &top_sort_key_collector(2, sort_desc))
+                .unwrap()
+                .into_iter()
+                .map(|((_, seq), _)| if sort_desc { seq } else { seq.saturating_neg() })
+                .collect()
+        };
+        // desc: pages tile the tie group newest-seq-first, each page's
+        // cursor being its last (ts, seq); no doc unreachable, none
+        // repeated.
+        assert_eq!(page_seqs(None, true), vec![6, 5]);
+        assert_eq!(page_seqs(Some(after(1000, Some(5))), true), vec![4, 3]);
+        assert_eq!(page_seqs(Some(after(1000, Some(3))), true), vec![2, 1]);
+        assert_eq!(page_seqs(Some(after(1000, Some(1))), true), Vec::<i64>::new());
+        // asc mirrors.
+        assert_eq!(page_seqs(None, false), vec![1, 2]);
+        assert_eq!(page_seqs(Some(after(1000, Some(2))), false), vec![3, 4]);
+        assert_eq!(page_seqs(Some(after(1000, Some(4))), false), vec![5, 6]);
+        assert_eq!(page_seqs(Some(after(1000, Some(6))), false), Vec::<i64>::new());
+    }
+
+    /// The collector's primary key stays the timestamp; `_seq` only
+    /// breaks ties.
+    #[test]
+    fn collector_orders_by_timestamp_then_seq() {
+        use tantivy::query::AllQuery;
+        // Higher seq at an older timestamp must not outrank a newer doc.
+        let (_, index) = build_index(1, &[(1000, 900), (2000, 5), (1000, 950)]);
+        let searcher = index.reader().unwrap().searcher();
+        let keys: Vec<(i64, i64)> = searcher
+            .search(&AllQuery, &top_sort_key_collector(3, true))
+            .unwrap()
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect();
+        assert_eq!(keys, vec![(2000, 5), (1000, 950), (1000, 900)]);
     }
 
     #[test]

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -4,6 +4,7 @@
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
+use std::ops::Bound;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
@@ -14,8 +15,8 @@ use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_result::AggregationResults;
 use tantivy::aggregation::intermediate_agg_result::IntermediateAggregationResults;
 use tantivy::collector::{Count, TopDocs};
-use tantivy::query::{BooleanQuery, Occur, Query};
-use tantivy::schema::Value as _;
+use tantivy::query::{BooleanQuery, Occur, Query, RangeQuery};
+use tantivy::schema::{Term, Value as _};
 use tantivy::{DocAddress, Order, TantivyDocument};
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -75,7 +76,22 @@ pub struct FoundDocument {
     pub source: Value,
 }
 
+/// A `search_after` cursor: the `sort` values of the previous page's
+/// last hit, i.e. `[timestamp_millis, _seq]` (issue #52). Paging resumes
+/// strictly past this position in (timestamp, `_seq`) order.
+#[derive(Clone, Copy, Debug)]
+pub struct SearchAfter {
+    /// Timestamp sort value, epoch millis.
+    pub timestamp_millis: i64,
+    /// `_seq` tiebreak. `None` when the caller passed a bare `[ts]`
+    /// cursor — paging is then strictly by timestamp, so equal-timestamp
+    /// documents at the page boundary are skipped. `-1` is the sentinel
+    /// legacy (pre-`_seq`) hits report in their `sort` values.
+    pub seq: Option<i64>,
+}
+
 /// A parsed `_search` request body.
+#[derive(Debug)]
 pub struct SearchRequest {
     /// Stream (index) the search runs against.
     pub stream: String,
@@ -93,6 +109,11 @@ pub struct SearchRequest {
     pub include_source: bool,
     /// Exact-count ceiling; None = unbounded (always exact).
     pub track_total_hits: Option<usize>,
+    /// Resume paging strictly past this cursor (requires `from` = 0).
+    /// Unlike `from`/`size`, each page costs only `size` per split, so it
+    /// pages past `max_result_window` (issue #52). Totals and
+    /// aggregations still reflect the full query, as in ES.
+    pub search_after: Option<SearchAfter>,
 }
 
 impl SearchRequest {
@@ -149,6 +170,44 @@ impl SearchRequest {
                 }
             }
         }
+        // search_after: the previous page's last `sort` values. The
+        // timestamp is taken verbatim as epoch millis (it is what our own
+        // `sort` emitted — no unit heuristic, which would rescale small
+        // values).
+        let search_after = match body.get("search_after") {
+            None => None,
+            Some(Value::Array(vals)) if (1..=2).contains(&vals.len()) => {
+                let as_i64 = |v: &Value| {
+                    v.as_i64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
+                };
+                let timestamp_millis = as_i64(&vals[0]).ok_or_else(|| {
+                    SearchError::BadRequest(
+                        "search_after[0] must be the timestamp sort value (epoch millis)".into(),
+                    )
+                })?;
+                let seq = vals
+                    .get(1)
+                    .map(|v| {
+                        as_i64(v).ok_or_else(|| {
+                            SearchError::BadRequest(
+                                "search_after[1] must be the _seq sort value (integer)".into(),
+                            )
+                        })
+                    })
+                    .transpose()?;
+                Some(SearchAfter { timestamp_millis, seq })
+            }
+            Some(_) => {
+                return Err(SearchError::BadRequest(
+                    "search_after must be an array of 1-2 sort values ([timestamp, _seq])".into(),
+                ));
+            }
+        };
+        if search_after.is_some() && from != 0 {
+            return Err(SearchError::BadRequest(
+                "[from] parameter must be set to 0 when [search_after] is used".into(),
+            ));
+        }
         let aggs = body
             .get("aggs")
             .or_else(|| body.get("aggregations"))
@@ -166,6 +225,7 @@ impl SearchRequest {
             aggs,
             include_source,
             track_total_hits,
+            search_after,
         })
     }
 }
@@ -179,6 +239,10 @@ type FetchedDoc = (usize, Option<String>, Option<i64>, Option<String>);
 #[derive(Clone)]
 struct SplitHit {
     timestamp_millis: i64,
+    /// `_seq` tiebreak (None on legacy splits without the column). Part
+    /// of the global sort order so `search_after` cursors page
+    /// deterministically across splits (issue #52).
+    seq: Option<i64>,
     split_idx: usize,
     doc: DocAddress,
 }
@@ -471,6 +535,7 @@ impl SearchService {
                 aggs: None,
                 include_source: true,
                 track_total_hits: Some(0),
+                search_after: None,
             };
             let response = self.search(request).await?;
             for hit in response["hits"]["hits"].as_array().into_iter().flatten() {
@@ -547,6 +612,7 @@ impl SearchService {
         // split order so split_idx stays meaningful.
         let track = request.track_total_hits;
         let sort_desc = request.sort_desc;
+        let cursor = request.search_after;
         // Running total of counted matches across splits. Once it passes
         // track_total_hits, later splits skip their Count collector and the
         // response reports `"relation": "gte"` — the default 10k cap stops
@@ -593,6 +659,7 @@ impl SearchService {
                             aggregations,
                             fetch_limit,
                             sort_desc,
+                            cursor,
                             skip_count,
                             idx,
                             doc_count,
@@ -628,15 +695,24 @@ impl SearchService {
             .iter_mut()
             .flat_map(|o| o.hits.drain(..))
             .collect();
-        // Stable order: timestamp, then split index, then doc — so equal
-        // timestamps page deterministically (L8).
+        // Stable order: timestamp, then `_seq` (the search_after tiebreak
+        // — legacy docs without one sort as -1), then split index and doc
+        // for determinism — so equal timestamps page deterministically
+        // (L8) and cursors resume at the same global position (issue #52).
         let cmp = |a: &SplitHit, b: &SplitHit| {
-            let ts = if request.sort_desc {
-                b.timestamp_millis.cmp(&a.timestamp_millis)
+            let (ts, seq) = if request.sort_desc {
+                (
+                    b.timestamp_millis.cmp(&a.timestamp_millis),
+                    b.seq.unwrap_or(-1).cmp(&a.seq.unwrap_or(-1)),
+                )
             } else {
-                a.timestamp_millis.cmp(&b.timestamp_millis)
+                (
+                    a.timestamp_millis.cmp(&b.timestamp_millis),
+                    a.seq.unwrap_or(-1).cmp(&b.seq.unwrap_or(-1)),
+                )
             };
-            ts.then(a.split_idx.cmp(&b.split_idx))
+            ts.then(seq)
+                .then(a.split_idx.cmp(&b.split_idx))
                 .then(a.doc.segment_ord.cmp(&b.doc.segment_ord))
                 .then(a.doc.doc_id.cmp(&b.doc.doc_id))
         };
@@ -814,11 +890,13 @@ fn hit_envelope(
     let id = id.unwrap_or_else(|| {
         format!("{}:{}:{}", split_id, hit.doc.segment_ord, hit.doc.doc_id)
     });
+    // `sort` is the search_after cursor: [timestamp, _seq]. Legacy docs
+    // without a `_seq` report the -1 sentinel (issue #52).
     let mut entry = json!({
         "_index": stream,
         "_id": id,
         "_score": Value::Null,
-        "sort": [hit.timestamp_millis],
+        "sort": [hit.timestamp_millis, seq.unwrap_or(-1)],
     });
     // `_version` is the write sequence: what the bulk/_doc responses
     // reported for this version of the document.
@@ -836,6 +914,57 @@ fn default_limits() -> AggregationLimitsGuard {
     AggregationLimitsGuard::new(Some(500 << 20), Some(65_000))
 }
 
+/// The query clause keeping only documents strictly past a `search_after`
+/// cursor in (timestamp, `_seq`) order — every leg is a fast-field range
+/// scan (issue #52). Built per split: schemas differ, and a legacy split
+/// has no `_seq` column. Legacy docs sort as seq -1 — after every real
+/// doc at the same timestamp in desc order, before them in asc — so a
+/// desc cursor with a real `_seq` must still include the boundary
+/// timestamp on a legacy split; every other legacy case pages strictly by
+/// timestamp, skipping equal-timestamp boundary docs (merging old splits
+/// to the current format restores exact paging).
+fn cursor_clause(schema: &MappedSchema, cursor: SearchAfter, sort_desc: bool) -> Box<dyn Query> {
+    let ts_term = |ms: i64| {
+        Term::from_field_date(schema.timestamp, tantivy::DateTime::from_timestamp_millis(ms))
+    };
+    let past_ts: Box<dyn Query> = Box::new(if sort_desc {
+        RangeQuery::new(Bound::Unbounded, Bound::Excluded(ts_term(cursor.timestamp_millis)))
+    } else {
+        RangeQuery::new(Bound::Excluded(ts_term(cursor.timestamp_millis)), Bound::Unbounded)
+    });
+    let Some(cursor_seq) = cursor.seq else {
+        // Bare [ts] cursor: strictly past the timestamp.
+        return past_ts;
+    };
+    match schema.seq {
+        Some(seq_field) => {
+            let seq_term = |s: i64| Term::from_field_i64(seq_field, s);
+            let past_seq: Box<dyn Query> = Box::new(if sort_desc {
+                RangeQuery::new(Bound::Unbounded, Bound::Excluded(seq_term(cursor_seq)))
+            } else {
+                RangeQuery::new(Bound::Excluded(seq_term(cursor_seq)), Bound::Unbounded)
+            });
+            let at_ts: Box<dyn Query> = Box::new(RangeQuery::new(
+                Bound::Included(ts_term(cursor.timestamp_millis)),
+                Bound::Included(ts_term(cursor.timestamp_millis)),
+            ));
+            let tie: Box<dyn Query> = Box::new(BooleanQuery::new(vec![
+                (Occur::Must, at_ts),
+                (Occur::Must, past_seq),
+            ]));
+            Box::new(BooleanQuery::new(vec![
+                (Occur::Should, past_ts),
+                (Occur::Should, tie),
+            ]))
+        }
+        None if sort_desc && cursor_seq >= 0 => Box::new(RangeQuery::new(
+            Bound::Unbounded,
+            Bound::Included(ts_term(cursor.timestamp_millis)),
+        )),
+        None => past_ts,
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn search_one_split(
     reader: &SplitReader,
@@ -843,6 +972,7 @@ fn search_one_split(
     aggregations: Option<Aggregations>,
     fetch_limit: usize,
     sort_desc: bool,
+    cursor: Option<SearchAfter>,
     skip_count: bool,
     split_idx: usize,
     doc_count: usize,
@@ -873,23 +1003,64 @@ fn search_one_split(
     let top_collector = TopDocs::with_limit(fetch_limit.max(1))
         .order_by_fast_field::<tantivy::DateTime>("_timestamp", order);
 
+    // Resolve top-k pairs into hits, reading each one's `_seq` from its
+    // segment's fast column (None on legacy splits) — the tiebreak the
+    // global merge and search_after cursors sort by.
+    let has_seq = reader.mapped_schema().seq.is_some();
+    let make_hits = |top: Vec<(Option<tantivy::DateTime>, DocAddress)>| -> Vec<SplitHit> {
+        let mut seq_cols: HashMap<u32, Option<tantivy::columnar::Column<i64>>> = HashMap::new();
+        top.into_iter()
+            .map(|(timestamp, doc)| {
+                let seq = has_seq
+                    .then(|| {
+                        seq_cols
+                            .entry(doc.segment_ord)
+                            .or_insert_with(|| {
+                                searcher
+                                    .segment_reader(doc.segment_ord)
+                                    .fast_fields()
+                                    .i64(rsearch_index::SEQ_FIELD)
+                                    .ok()
+                            })
+                            .as_ref()
+                            .and_then(|col| col.first(doc.doc_id))
+                    })
+                    .flatten();
+                SplitHit {
+                    timestamp_millis: timestamp
+                        .map(|t| t.into_timestamp_millis())
+                        .unwrap_or_default(),
+                    seq,
+                    split_idx,
+                    doc,
+                }
+            })
+            .collect()
+    };
+    // The cursor narrows only the page's top-k query — totals and
+    // aggregations keep reflecting the full query, as in ES. Builds its
+    // own collector so the combined-collector arms below can consume the
+    // shared one.
+    let page_search = |base: Box<dyn Query>| -> SearchResult<Vec<(Option<tantivy::DateTime>, DocAddress)>> {
+        let collector = TopDocs::with_limit(fetch_limit.max(1))
+            .order_by_fast_field::<tantivy::DateTime>("_timestamp", order);
+        let page_query: Box<dyn Query> = match cursor {
+            Some(c) => Box::new(BooleanQuery::new(vec![
+                (Occur::Must, base),
+                (Occur::Must, cursor_clause(reader.mapped_schema(), c, sort_desc)),
+            ])),
+            None => base,
+        };
+        searcher
+            .search(&page_query, &collector)
+            .map_err(SearchError::Tantivy)
+    };
+
     // match_all over a fully-covered split: the count is the split's
     // doc_count; skip the Count collector entirely (H3). Still runs the
     // top-k collector for the page.
     if fully_covered && aggregations.is_none() {
-        let top = searcher
-            .search(&query, &top_collector)
-            .map_err(SearchError::Tantivy)?;
-        let hits = top
-            .into_iter()
-            .map(|(timestamp, doc)| SplitHit {
-                timestamp_millis: timestamp
-                    .map(|t| t.into_timestamp_millis())
-                    .unwrap_or_default(),
-                split_idx,
-                doc,
-            })
-            .collect();
+        let hits = make_hits(page_search(query)?);
         return Ok(SplitOutcome {
             count: doc_count,
             count_is_lower_bound: false,
@@ -902,8 +1073,10 @@ fn search_one_split(
     // passed the cap) → don't run the Count collector at all; the total
     // becomes a lower bound (the page length). Aggregations still need
     // their collector, and counting is free alongside their full scan.
-    let (count, count_is_lower_bound, top, agg_result) = match (aggregations, skip_count) {
-        (Some(aggs), _) => {
+    // With a search_after cursor the page runs as its own search, so the
+    // count/agg pass over the full query stays separate.
+    let (count, count_is_lower_bound, top, agg_result) = match (aggregations, skip_count, cursor) {
+        (Some(aggs), _, cursor) => {
             let agg_collector = tantivy::aggregation::DistributedAggregationCollector::from_aggs(
                 aggs,
                 tantivy::aggregation::AggContextParams::new(
@@ -911,42 +1084,168 @@ fn search_one_split(
                     index.tokenizers().clone(),
                 ),
             );
-            let (count, top, aggs) = searcher
-                .search(&query, &(Count, top_collector, agg_collector))
-                .map_err(SearchError::Tantivy)?;
-            (count, false, top, Some(aggs))
+            match cursor {
+                None => {
+                    let (count, top, aggs) = searcher
+                        .search(&query, &(Count, top_collector, agg_collector))
+                        .map_err(SearchError::Tantivy)?;
+                    (count, false, top, Some(aggs))
+                }
+                Some(_) => {
+                    let (count, aggs) = searcher
+                        .search(&query, &(Count, agg_collector))
+                        .map_err(SearchError::Tantivy)?;
+                    let top = page_search(query)?;
+                    (count, false, top, Some(aggs))
+                }
+            }
         }
-        (None, true) => {
-            let top = searcher
-                .search(&query, &top_collector)
-                .map_err(SearchError::Tantivy)?;
+        (None, true, _) => {
+            let top = page_search(query)?;
             // Lower bound: at least the number of hits we returned.
             (top.len(), true, top, None)
         }
-        (None, false) => {
+        (None, false, None) => {
             let (count, top) = searcher
                 .search(&query, &(Count, top_collector))
                 .map_err(SearchError::Tantivy)?;
+            (count, false, top, None)
+        }
+        (None, false, Some(_)) => {
+            let count = searcher.search(&query, &Count).map_err(SearchError::Tantivy)?;
+            let top = page_search(query)?;
             (count, false, top, None)
         }
     };
 
     // Source is fetched later, only for the merged final page — here we
     // just record references (H4).
-    let hits = top
-        .into_iter()
-        .map(|(timestamp, doc)| SplitHit {
-            timestamp_millis: timestamp
-                .map(|t| t.into_timestamp_millis())
-                .unwrap_or_default(),
-            split_idx,
-            doc,
-        })
-        .collect();
+    let hits = make_hits(top);
     Ok(SplitOutcome {
         count,
         count_is_lower_bound,
         hits,
         aggs: agg_result,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsearch_index::{DocIdentity, DocumentConverter, IndexMapping};
+
+    #[test]
+    fn parses_search_after() {
+        let parsed = SearchRequest::parse(
+            "logs",
+            &json!({"size": 5, "search_after": [2000, 5]}),
+        )
+        .unwrap();
+        let cursor = parsed.search_after.unwrap();
+        assert_eq!(cursor.timestamp_millis, 2000);
+        assert_eq!(cursor.seq, Some(5));
+
+        // Bare [ts] cursor; numeric strings (JSON bigint safety) accepted.
+        let parsed = SearchRequest::parse("logs", &json!({"search_after": ["2000"]})).unwrap();
+        let cursor = parsed.search_after.unwrap();
+        assert_eq!(cursor.timestamp_millis, 2000);
+        assert_eq!(cursor.seq, None);
+
+        // The timestamp is NOT unit-heuristic rescaled: small sort values
+        // page as-is.
+        let parsed = SearchRequest::parse("logs", &json!({"search_after": [1000, -1]})).unwrap();
+        assert_eq!(parsed.search_after.unwrap().timestamp_millis, 1000);
+        assert_eq!(parsed.search_after.unwrap().seq, Some(-1));
+    }
+
+    #[test]
+    fn search_after_rejects_bad_shapes() {
+        for body in [
+            json!({"from": 5, "search_after": [1000]}),
+            json!({"search_after": []}),
+            json!({"search_after": [1, 2, 3]}),
+            json!({"search_after": {"ts": 1}}),
+            json!({"search_after": ["not-a-number"]}),
+            json!({"search_after": [1000, "x"]}),
+        ] {
+            let err = SearchRequest::parse("logs", &body).unwrap_err();
+            assert!(matches!(err, SearchError::BadRequest(_)), "{body}");
+        }
+    }
+
+    /// Docs as (timestamp_millis, seq) at the given schema version →
+    /// how many pass the cursor clause.
+    fn count_past(
+        schema_version: u32,
+        docs: &[(i64, i64)],
+        cursor: SearchAfter,
+        sort_desc: bool,
+    ) -> usize {
+        let schema = MappedSchema::build_versioned(IndexMapping::default(), schema_version);
+        let index = tantivy::Index::create_in_ram(schema.schema.clone());
+        let converter = DocumentConverter::new(schema.clone());
+        let mut writer = index.writer_with_num_threads(1, 20 << 20).unwrap();
+        for (i, (ts, seq)) in docs.iter().enumerate() {
+            let identity = DocIdentity::new(format!("d{i}"), *seq);
+            let (doc, _) = converter
+                .convert_with_source(
+                    json!({"n": i}),
+                    None,
+                    &identity,
+                    tantivy::DateTime::from_timestamp_millis(*ts),
+                )
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        let searcher = index.reader().unwrap().searcher();
+        let clause = cursor_clause(&schema, cursor, sort_desc);
+        searcher.search(&clause, &Count).unwrap()
+    }
+
+    /// (ts, seq): a=(1000,10) b=(1000,20) c=(2000,5) d=(3000,1).
+    /// desc order: d, c, b, a — asc order: a, b, c, d.
+    const DOCS: [(i64, i64); 4] = [(1000, 10), (1000, 20), (2000, 5), (3000, 1)];
+
+    fn after(ts: i64, seq: Option<i64>) -> SearchAfter {
+        SearchAfter { timestamp_millis: ts, seq }
+    }
+
+    #[test]
+    fn cursor_pages_strictly_past_ts_and_seq() {
+        // desc, cursor at c=(2000,5): b and a remain.
+        assert_eq!(count_past(1, &DOCS, after(2000, Some(5)), true), 2);
+        // desc, cursor at b=(1000,20): the equal-timestamp tie resolves by
+        // seq — only a remains.
+        assert_eq!(count_past(1, &DOCS, after(1000, Some(20)), true), 1);
+        // desc, cursor at a: page exhausted.
+        assert_eq!(count_past(1, &DOCS, after(1000, Some(10)), true), 0);
+        // asc, cursor at a=(1000,10): b, c, d remain (tie kept).
+        assert_eq!(count_past(1, &DOCS, after(1000, Some(10)), false), 3);
+        // asc, cursor at d: exhausted.
+        assert_eq!(count_past(1, &DOCS, after(3000, Some(1)), false), 0);
+    }
+
+    #[test]
+    fn bare_ts_cursor_pages_strictly_by_timestamp() {
+        // desc past ts=2000: only the two 1000s remain (equal-ts skipped
+        // by design for a 1-element cursor).
+        assert_eq!(count_past(1, &DOCS, after(2000, None), true), 2);
+        assert_eq!(count_past(1, &DOCS, after(1000, None), true), 0);
+        // asc past ts=2000: only d.
+        assert_eq!(count_past(1, &DOCS, after(2000, None), false), 1);
+    }
+
+    #[test]
+    fn legacy_split_cursor_degrades_by_timestamp() {
+        // Version-0 splits have no _seq column; docs sort as seq -1.
+        // desc + a real-seq cursor: legacy docs at the boundary timestamp
+        // sort after every real doc there, so they are still included.
+        assert_eq!(count_past(0, &DOCS, after(2000, Some(5)), true), 3);
+        // desc + a legacy (-1) cursor: strictly past the timestamp.
+        assert_eq!(count_past(0, &DOCS, after(2000, Some(-1)), true), 2);
+        // asc + a real-seq cursor: legacy docs at the boundary already
+        // sorted before it — strictly past.
+        assert_eq!(count_past(0, &DOCS, after(2000, Some(5)), false), 1);
+    }
 }

--- a/crates/rsearch-search/src/lib.rs
+++ b/crates/rsearch-search/src/lib.rs
@@ -8,5 +8,5 @@ pub mod logql;
 mod query_dsl;
 
 pub use error::{SearchError, SearchResult};
-pub use executor::{FoundDocument, SearchRequest, SearchService};
+pub use executor::{FoundDocument, SearchAfter, SearchRequest, SearchService};
 pub use query_dsl::{extract_time_bounds, rewrite_agg_fields, translate_query};

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -325,6 +325,7 @@ pub async fn delete_by_query(
             aggs: None,
             include_source: false,
             track_total_hits: Some(0),
+            search_after: None,
         };
         let response = match lookup.search(request).await {
             Ok(response) => response,


### PR DESCRIPTION
Closes #52.

Implements `search_after` cursors over the existing timestamp sort, using `_seq` (the HLC write stamp from #35, a fast field on every v1 split) as the deterministic tiebreak the issue asked about.

**How it works**
- Every hit's `sort` values are now `[timestamp_millis, _seq]`. Passing the last hit's values back as `search_after` (with `from` = 0, as ES requires) resumes strictly past that position in (timestamp, `_seq`) order.
- Each page costs only `size` per split — no `from + size` sort-and-discard — so it pages past the 10k `max_result_window` that still caps plain `from`/`size`.
- The cursor narrows only the page's top-k search. Totals and aggregations keep reflecting the full query (ES semantics), computed in a separate pass when a cursor is present.
- The cursor clause is built per split (schemas differ) and every leg is a fast-field range scan. The global merge now orders by (timestamp, `_seq`, split, doc) so cursors resume at the same global position across splits.

**Legacy v0 splits** (no `_seq` column): their docs sort with a `-1` sentinel tiebreak and page by timestamp only, with the direction-dependent boundary cases handled so nothing is silently dropped when a real-seq cursor crosses them; merging old splits to the current format restores exact paging. This is transitional — merges rewrite splits at the current version.

**Caller side (iWorldreg/pvitl)**: the scroll triple in `lib/search.rb` becomes a `search_after` loop — search with a sort, feed `hits.last['sort']` back until a short page. No `clear_scroll` needed; the cursor is stateless.

Tests cover cursor parsing/rejection shapes, strict (ts, seq) paging in both directions including equal-timestamp ties, bare-`[ts]` cursors, and the legacy-split degradation.