### PR TITLE
Release v0.4.0: prefix/wildcard queries + search_after deep pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.3.2" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.3.2" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.3.2" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.3.2" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.3.2" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.3.2" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.4.0" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.4.0" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.4.0" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.4.0" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.4.0" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.4.0" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
Release-prep PR in the `release/v0.3.2-prep` (#48) pattern. Merging this lands everything on main and will automatically mark #55, #56, #57, and #58 as merged (their commits are contained here via local merges).

## Contents

- **#55 — `prefix` query** (issue #54): distance-0 prefix DFA over the term dictionary; keyword/text/dynamic fields; `case_insensitive` supported.
- **#58 — `wildcard` query** (issue #53): regex automaton over the term dictionary (ES's own execution model); dynamic-path anchoring; `case_insensitive` supported.
- **#56 — `search_after` deep pagination** (issue #52): `[timestamp_millis, _seq]` cursors page past `max_result_window`; totals/aggs stay full-query; per-split top-k, global merge, and cursor filters all share one (timestamp, `_seq`) order; `SeqClock` stamps carry a per-node salt so cursors are unique cluster-wide; cursor-outside splits are pruned.
- **#57 — Cargo.lock refresh**: 15 compatible transitive bumps; `aws-lc-fips-sys`/`aws-lc-rs` pins unchanged (CMVP certificate unaffected).
- **Version**: workspace 0.3.2 → **0.4.0** (minor — new features, no breaking API).

## Verification

- `cargo check --workspace`: clean, 0 warnings
- 91 lib tests passing across the workspace
- `cargo deny check bans licenses`: **bans ok, licenses ok** (FIPS gate)
- `cargo publish --workspace --dry-run`: all 7 publishable crates package and fully verify (build included), stopping only at the upload step

## Publishing (after merge)

```bash
git checkout main && git pull
CC=clang CXX=clang++ cargo publish --workspace
git tag v0.4.0 && git push origin v0.4.0
```

Cargo orders the workspace publish by dependency automatically (`rsearch-bench` is `publish = false`). Note the aws-lc-fips-sys cmake configure can flake on the first cold build — re-run and it succeeds.