### PR TITLE
Fix merge starvation across streams (round-robin selection + per-stream candidate window)

### DIFF
--- a/crates/rsearch-metastore/src/control.rs
+++ b/crates/rsearch-metastore/src/control.rs
@@ -83,26 +83,31 @@ impl Metastore {
     /// Published splits smaller than `max_size_bytes`, grouped by stream,
     /// ordered by time — merge candidates. The window is per stream — each
     /// stream's `per_stream_limit` oldest candidates — so one backlogged
-    /// stream can't fill the whole result and starve the rest (#60).
+    /// stream can't fill the whole result and starve the rest (#60). The
+    /// LATERAL join makes each stream a bounded range scan of the
+    /// `(stream_id, state, time_start_millis)` index instead of sorting
+    /// every under-target split in the table; `id` breaks timestamp ties
+    /// so the window edge is deterministic.
     pub async fn small_published_splits(
         &self,
         max_size_bytes: i64,
         per_stream_limit: i64,
     ) -> MetastoreResult<Vec<SplitRecord>> {
         Ok(sqlx::query_as::<_, SplitRecord>(
-            "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
-                    time_start_millis, time_end_millis, footer_len, created_by,
-                    seq_min, seq_max, tombstone_seq_applied
-             FROM (SELECT id, split_id, stream_id, state, storage_key, doc_count,
-                          size_bytes, time_start_millis, time_end_millis, footer_len,
-                          created_by, seq_min, seq_max, tombstone_seq_applied,
-                          ROW_NUMBER() OVER (
-                              PARTITION BY stream_id ORDER BY time_start_millis
-                          ) AS rn
-                   FROM splits
-                   WHERE state = 'published' AND size_bytes < $1) ranked
-             WHERE rn <= $2
-             ORDER BY stream_id, time_start_millis",
+            "SELECT c.id, c.split_id, c.stream_id, c.state, c.storage_key, c.doc_count,
+                    c.size_bytes, c.time_start_millis, c.time_end_millis, c.footer_len,
+                    c.created_by, c.seq_min, c.seq_max, c.tombstone_seq_applied
+             FROM streams st
+             CROSS JOIN LATERAL (
+                 SELECT id, split_id, stream_id, state, storage_key, doc_count,
+                        size_bytes, time_start_millis, time_end_millis, footer_len,
+                        created_by, seq_min, seq_max, tombstone_seq_applied
+                 FROM splits
+                 WHERE stream_id = st.id AND state = 'published' AND size_bytes < $1
+                 ORDER BY time_start_millis, id
+                 LIMIT $2
+             ) c
+             ORDER BY c.stream_id, c.time_start_millis, c.id",
         )
         .bind(max_size_bytes)
         .bind(per_stream_limit)

--- a/crates/rsearch-metastore/src/control.rs
+++ b/crates/rsearch-metastore/src/control.rs
@@ -81,23 +81,31 @@ impl Metastore {
     }
 
     /// Published splits smaller than `max_size_bytes`, grouped by stream,
-    /// ordered by time — merge candidates.
+    /// ordered by time — merge candidates. The window is per stream — each
+    /// stream's `per_stream_limit` oldest candidates — so one backlogged
+    /// stream can't fill the whole result and starve the rest (#60).
     pub async fn small_published_splits(
         &self,
         max_size_bytes: i64,
-        limit: i64,
+        per_stream_limit: i64,
     ) -> MetastoreResult<Vec<SplitRecord>> {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
                     time_start_millis, time_end_millis, footer_len, created_by,
                     seq_min, seq_max, tombstone_seq_applied
-             FROM splits
-             WHERE state = 'published' AND size_bytes < $1
-             ORDER BY stream_id, time_start_millis
-             LIMIT $2",
+             FROM (SELECT id, split_id, stream_id, state, storage_key, doc_count,
+                          size_bytes, time_start_millis, time_end_millis, footer_len,
+                          created_by, seq_min, seq_max, tombstone_seq_applied,
+                          ROW_NUMBER() OVER (
+                              PARTITION BY stream_id ORDER BY time_start_millis
+                          ) AS rn
+                   FROM splits
+                   WHERE state = 'published' AND size_bytes < $1) ranked
+             WHERE rn <= $2
+             ORDER BY stream_id, time_start_millis",
         )
         .bind(max_size_bytes)
-        .bind(limit)
+        .bind(per_stream_limit)
         .fetch_all(self.pool())
         .await?)
     }

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -172,6 +172,71 @@ async fn split_state_machine() {
 
 #[tokio::test]
 #[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn small_published_splits_windows_per_stream() {
+    let Some(ms) = metastore().await else { return };
+    let busy = ms.ensure_stream(&unique("merge-busy")).await.unwrap();
+    let starved = ms.ensure_stream(&unique("merge-starved")).await.unwrap();
+
+    // The busy stream has more small splits than the window, all newer
+    // than the starved stream's; a global LIMIT would return only busy
+    // rows (#60).
+    for (stream, count, base_millis) in
+        [(&busy, 4i64, 2_000_000i64), (&starved, 3, 1_000_000)]
+    {
+        for i in 0..count {
+            let split_id = unique("split");
+            ms.stage_split(&NewSplit {
+                split_id: &split_id,
+                stream_id: stream.id,
+                storage_key: &format!("streams/{}/{split_id}.split", stream.name),
+                doc_count: 100,
+                size_bytes: 4096,
+                time_start_millis: base_millis + i * 1_000,
+                time_end_millis: base_millis + i * 1_000 + 999,
+                footer_len: 512,
+                created_by: None,
+                seq_min: None,
+                seq_max: None,
+                tombstone_seq_applied: 0,
+            })
+            .await
+            .unwrap();
+            ms.publish_split(&split_id).await.unwrap();
+        }
+    }
+
+    // The shared dev database may hold other streams' splits; assert only
+    // on rows belonging to the two streams created here.
+    let ours: Vec<_> = ms
+        .small_published_splits(1 << 20, 2)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|s| s.stream_id == busy.id || s.stream_id == starved.id)
+        .collect();
+
+    // Each stream contributes its two oldest candidates, time-ordered,
+    // regardless of how many the busier stream holds.
+    let busy_rows: Vec<i64> = ours
+        .iter()
+        .filter(|s| s.stream_id == busy.id)
+        .map(|s| s.time_start_millis)
+        .collect();
+    let starved_rows: Vec<i64> = ours
+        .iter()
+        .filter(|s| s.stream_id == starved.id)
+        .map(|s| s.time_start_millis)
+        .collect();
+    assert_eq!(busy_rows, vec![2_000_000, 2_001_000]);
+    assert_eq!(starved_rows, vec![1_000_000, 1_001_000]);
+
+    for stream in [&busy, &starved] {
+        ms.delete_stream(&stream.name).await.unwrap();
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
 async fn node_heartbeats() {
     let Some(ms) = metastore().await else { return };
     let node_id = unique("node");

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -179,11 +179,15 @@ async fn small_published_splits_windows_per_stream() {
 
     // The busy stream has more small splits than the window, all newer
     // than the starved stream's; a global LIMIT would return only busy
-    // rows (#60).
-    for (stream, count, base_millis) in
-        [(&busy, 4i64, 2_000_000i64), (&starved, 3, 1_000_000)]
-    {
-        for i in 0..count {
+    // rows (#60). The starved stream's two oldest tie on time_start so
+    // the window edge exercises the id tiebreak.
+    let mut created: std::collections::HashMap<i64, Vec<String>> =
+        std::collections::HashMap::new();
+    for (stream, times) in [
+        (&busy, vec![2_000_000i64, 2_001_000, 2_002_000, 2_003_000]),
+        (&starved, vec![1_000_000, 1_000_000, 1_001_000]),
+    ] {
+        for start in times {
             let split_id = unique("split");
             ms.stage_split(&NewSplit {
                 split_id: &split_id,
@@ -191,8 +195,8 @@ async fn small_published_splits_windows_per_stream() {
                 storage_key: &format!("streams/{}/{split_id}.split", stream.name),
                 doc_count: 100,
                 size_bytes: 4096,
-                time_start_millis: base_millis + i * 1_000,
-                time_end_millis: base_millis + i * 1_000 + 999,
+                time_start_millis: start,
+                time_end_millis: start + 999,
                 footer_len: 512,
                 created_by: None,
                 seq_min: None,
@@ -202,6 +206,7 @@ async fn small_published_splits_windows_per_stream() {
             .await
             .unwrap();
             ms.publish_split(&split_id).await.unwrap();
+            created.entry(stream.id).or_default().push(split_id);
         }
     }
 
@@ -215,20 +220,30 @@ async fn small_published_splits_windows_per_stream() {
         .filter(|s| s.stream_id == busy.id || s.stream_id == starved.id)
         .collect();
 
-    // Each stream contributes its two oldest candidates, time-ordered,
-    // regardless of how many the busier stream holds.
-    let busy_rows: Vec<i64> = ours
+    // Each stream contributes exactly its two oldest candidates,
+    // time-ordered within the stream, regardless of how many the busier
+    // stream holds. The starved stream's timestamp tie resolves to
+    // insertion (id) order.
+    let busy_ids: Vec<&str> = ours
         .iter()
         .filter(|s| s.stream_id == busy.id)
-        .map(|s| s.time_start_millis)
+        .map(|s| s.split_id.as_str())
         .collect();
-    let starved_rows: Vec<i64> = ours
+    let starved_ids: Vec<&str> = ours
         .iter()
         .filter(|s| s.stream_id == starved.id)
-        .map(|s| s.time_start_millis)
+        .map(|s| s.split_id.as_str())
         .collect();
-    assert_eq!(busy_rows, vec![2_000_000, 2_001_000]);
-    assert_eq!(starved_rows, vec![1_000_000, 1_001_000]);
+    let expect = |stream_id: i64| -> Vec<&str> {
+        created[&stream_id][..2].iter().map(String::as_str).collect()
+    };
+    assert_eq!(busy_ids, expect(busy.id));
+    assert_eq!(starved_ids, expect(starved.id));
+    assert!(
+        ours.windows(2).all(|w| w[0].stream_id != w[1].stream_id
+            || w[0].time_start_millis <= w[1].time_start_millis),
+        "rows must be time-ordered within each stream"
+    );
 
     for stream in [&busy, &starved] {
         ms.delete_stream(&stream.name).await.unwrap();

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -576,26 +576,17 @@ impl ControlPlane {
         }
     }
 
-    /// Combine the first group of >= 2 published splits below the merge
-    /// target in one stream into a single split. One merge per tick
-    /// bounds the work.
+    /// Combine one group of >= 2 published splits below the merge target
+    /// into a single split, servicing the stream whose eligible
+    /// candidates are oldest (#60). One merge per tick bounds the work.
     async fn merge_job(&self) -> anyhow::Result<()> {
         let target_bytes = self.merge_target_bytes();
         let small = self
             .metastore
-            .small_published_splits(target_bytes, 200)
+            .small_published_splits(target_bytes, MERGE_WINDOW_PER_STREAM)
             .await?;
-        let mut by_stream: BTreeMap<i64, Vec<&SplitRecord>> = BTreeMap::new();
-        for split in &small {
-            by_stream.entry(split.stream_id).or_default().push(split);
-        }
-        let Some((stream_id, group)) = by_stream
-            .into_iter()
-            .find_map(|(id, group)| {
-                let group = merge_candidates(group);
-                let take = merge_take(&group, target_bytes, self.config.merge_max_group);
-                (take >= 2).then(|| (id, group[..take].to_vec()))
-            })
+        let Some((stream_id, group)) =
+            select_merge_group(&small, target_bytes, self.config.merge_max_group)
         else {
             return Ok(());
         };
@@ -1007,6 +998,40 @@ impl ControlPlane {
 /// smaller merge candidate in its stream is left out of the merge group.
 const MERGE_SKEW_FACTOR: i64 = 10;
 
+/// Oldest under-target candidates fetched per stream each merge tick.
+/// The window used to be 200 rows across all streams, which the busiest
+/// stream could occupy entirely, starving the rest (#60); per stream it
+/// only needs to cover `merge_max_group` with headroom for splits the
+/// skew filter excludes.
+const MERGE_WINDOW_PER_STREAM: i64 = 64;
+
+/// Choose which stream to merge this tick: group the candidate window by
+/// stream, run each group through the skew and take rules, and pick the
+/// eligible group that starts earliest in time (#60). Oldest-first is a
+/// least-recently-serviced approximation — merging advances a stream's
+/// oldest candidate forward, so a stream being drained yields to the
+/// next-oldest once it catches up, instead of the lowest stream_id
+/// monopolizing every tick. Candidates must arrive time-ordered within
+/// each stream, as `small_published_splits` returns them.
+fn select_merge_group(
+    small: &[SplitRecord],
+    target_bytes: i64,
+    max_group: usize,
+) -> Option<(i64, Vec<&SplitRecord>)> {
+    let mut by_stream: BTreeMap<i64, Vec<&SplitRecord>> = BTreeMap::new();
+    for split in small {
+        by_stream.entry(split.stream_id).or_default().push(split);
+    }
+    by_stream
+        .into_iter()
+        .filter_map(|(id, group)| {
+            let group = merge_candidates(group);
+            let take = merge_take(&group, target_bytes, max_group);
+            (take >= 2).then(|| (id, group[..take].to_vec()))
+        })
+        .min_by_key(|(_, group)| group[0].time_start_millis)
+}
+
 /// Drop dominant splits from a stream's merge group (#15). Merging is a
 /// full rewrite of every source, so folding a trickle of tiny splits into
 /// one dominant under-target split re-wrote its bytes every tick —
@@ -1178,5 +1203,76 @@ mod tests {
         // leaves it alone.
         let splits = [split(1, 600 << 20)];
         assert_eq!(take_of(&splits, 512, 8), 1);
+    }
+
+    fn stream_split(stream_id: i64, id: i64, size_bytes: i64) -> SplitRecord {
+        SplitRecord {
+            stream_id,
+            ..split(id, size_bytes)
+        }
+    }
+
+    fn selected(
+        splits: &[SplitRecord],
+        target_mb: i64,
+    ) -> Option<(i64, Vec<i64>)> {
+        select_merge_group(splits, target_mb << 20, 8)
+            .map(|(id, group)| (id, group.iter().map(|s| s.id).collect()))
+    }
+
+    #[test]
+    fn oldest_stream_wins_regardless_of_stream_id() {
+        // The #60 shape: the lowest stream_id has plenty of fresh
+        // candidates, but another stream's backlog is older.
+        let splits = [
+            stream_split(2, 10, 1 << 20),
+            stream_split(2, 11, 1 << 20),
+            stream_split(4, 1, 1 << 20),
+            stream_split(4, 2, 1 << 20),
+        ];
+        assert_eq!(selected(&splits, 512), Some((4, vec![1, 2])));
+    }
+
+    #[test]
+    fn stream_with_one_candidate_is_skipped() {
+        let splits = [
+            stream_split(2, 1, 1 << 20),
+            stream_split(3, 5, 1 << 20),
+            stream_split(3, 6, 1 << 20),
+        ];
+        assert_eq!(selected(&splits, 512), Some((3, vec![5, 6])));
+    }
+
+    #[test]
+    fn skew_filtered_stream_yields_to_the_next() {
+        // Stream 2's oldest group collapses to one survivor after the
+        // dominant split is excluded, so stream 3 is serviced instead.
+        let splits = [
+            stream_split(2, 1, 52 << 20),
+            stream_split(2, 2, 4 << 10),
+            stream_split(3, 5, 1 << 20),
+            stream_split(3, 6, 1 << 20),
+        ];
+        assert_eq!(selected(&splits, 512), Some((3, vec![5, 6])));
+    }
+
+    #[test]
+    fn group_is_capped_by_take() {
+        // Only the leading splits up to the target-crossing one merge.
+        let splits = [
+            stream_split(2, 1, 300 << 20),
+            stream_split(2, 2, 300 << 20),
+            stream_split(2, 3, 300 << 20),
+        ];
+        assert_eq!(selected(&splits, 512), Some((2, vec![1, 2])));
+    }
+
+    #[test]
+    fn no_eligible_group_selects_nothing() {
+        let splits = [
+            stream_split(2, 1, 1 << 20),
+            stream_split(3, 2, 1 << 20),
+        ];
+        assert_eq!(selected(&splits, 512), None);
     }
 }

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -53,6 +53,11 @@ pub struct ControlPlane {
     /// healthy steady-state ticks don't pay a full-table scan every 15s.
     repair_scan: std::sync::Mutex<RepairScanState>,
     compaction: std::sync::Mutex<CompactionState>,
+    /// Round-robin cursor for the merge job (#60): the stream_id last
+    /// selected for a merge, so the next tick starts past it. In-memory
+    /// only — fairness only needs to hold across one leader's consecutive
+    /// ticks; a new leader restarts the rotation from the lowest id.
+    merge_cursor: std::sync::atomic::AtomicI64,
 }
 
 #[derive(Default)]
@@ -120,6 +125,7 @@ impl ControlPlane {
             metrics,
             repair_scan: std::sync::Mutex::new(RepairScanState::default()),
             compaction: std::sync::Mutex::new(CompactionState::default()),
+            merge_cursor: std::sync::atomic::AtomicI64::new(0),
         })
     }
 
@@ -577,19 +583,26 @@ impl ControlPlane {
     }
 
     /// Combine one group of >= 2 published splits below the merge target
-    /// into a single split, servicing the stream whose eligible
-    /// candidates are oldest (#60). One merge per tick bounds the work.
+    /// into a single split. Streams are serviced round-robin (#60): the
+    /// first eligible stream past the last one selected, wrapping around,
+    /// so every backlogged stream gets a turn regardless of its stream_id
+    /// or how old its data is. One merge per tick bounds the work.
     async fn merge_job(&self) -> anyhow::Result<()> {
+        use std::sync::atomic::Ordering;
         let target_bytes = self.merge_target_bytes();
         let small = self
             .metastore
             .small_published_splits(target_bytes, MERGE_WINDOW_PER_STREAM)
             .await?;
+        let cursor = self.merge_cursor.load(Ordering::Relaxed);
         let Some((stream_id, group)) =
-            select_merge_group(&small, target_bytes, self.config.merge_max_group)
+            select_merge_group(&small, target_bytes, self.config.merge_max_group, cursor)
         else {
             return Ok(());
         };
+        // Advance before merging, so a stream whose merges keep failing
+        // can't wedge the rotation on itself.
+        self.merge_cursor.store(stream_id, Ordering::Relaxed);
 
         let stream = self.metastore.get_stream_by_id(stream_id).await?;
         info!(
@@ -1007,29 +1020,39 @@ const MERGE_WINDOW_PER_STREAM: i64 = 64;
 
 /// Choose which stream to merge this tick: group the candidate window by
 /// stream, run each group through the skew and take rules, and pick the
-/// eligible group that starts earliest in time (#60). Oldest-first is a
-/// least-recently-serviced approximation — merging advances a stream's
-/// oldest candidate forward, so a stream being drained yields to the
-/// next-oldest once it catches up, instead of the lowest stream_id
-/// monopolizing every tick. Candidates must arrive time-ordered within
-/// each stream, as `small_published_splits` returns them.
+/// first eligible stream with id strictly greater than `after_stream`,
+/// wrapping to the lowest when none is (#60). Round-robin keys fairness
+/// on service order, not on the data's timestamps: a merged output that
+/// stays under target re-enters with its sources' ancient time range, so
+/// any data-age priority would hand a tiny-split backlog (or a
+/// historical backfill) the merge slot every tick. Candidates must
+/// arrive time-ordered within each stream, as `small_published_splits`
+/// returns them.
 fn select_merge_group(
     small: &[SplitRecord],
     target_bytes: i64,
     max_group: usize,
+    after_stream: i64,
 ) -> Option<(i64, Vec<&SplitRecord>)> {
     let mut by_stream: BTreeMap<i64, Vec<&SplitRecord>> = BTreeMap::new();
     for split in small {
         by_stream.entry(split.stream_id).or_default().push(split);
     }
-    by_stream
+    // Ascending by stream_id (BTreeMap order), so position() finds the
+    // first eligible stream past the cursor and index 0 is the wrap.
+    let mut eligible: Vec<(i64, Vec<&SplitRecord>)> = by_stream
         .into_iter()
         .filter_map(|(id, group)| {
             let group = merge_candidates(group);
             let take = merge_take(&group, target_bytes, max_group);
             (take >= 2).then(|| (id, group[..take].to_vec()))
         })
-        .min_by_key(|(_, group)| group[0].time_start_millis)
+        .collect();
+    let pick = eligible
+        .iter()
+        .position(|(id, _)| *id > after_stream)
+        .unwrap_or(0);
+    (!eligible.is_empty()).then(|| eligible.swap_remove(pick))
 }
 
 /// Drop dominant splits from a stream's merge group (#15). Merging is a
@@ -1215,22 +1238,60 @@ mod tests {
     fn selected(
         splits: &[SplitRecord],
         target_mb: i64,
+        after_stream: i64,
     ) -> Option<(i64, Vec<i64>)> {
-        select_merge_group(splits, target_mb << 20, 8)
+        select_merge_group(splits, target_mb << 20, 8, after_stream)
             .map(|(id, group)| (id, group.iter().map(|s| s.id).collect()))
     }
 
     #[test]
-    fn oldest_stream_wins_regardless_of_stream_id() {
-        // The #60 shape: the lowest stream_id has plenty of fresh
-        // candidates, but another stream's backlog is older.
+    fn round_robin_advances_past_the_cursor_and_wraps() {
         let splits = [
-            stream_split(2, 10, 1 << 20),
-            stream_split(2, 11, 1 << 20),
-            stream_split(4, 1, 1 << 20),
-            stream_split(4, 2, 1 << 20),
+            stream_split(2, 1, 1 << 20),
+            stream_split(2, 2, 1 << 20),
+            stream_split(3, 5, 1 << 20),
+            stream_split(3, 6, 1 << 20),
+            stream_split(4, 8, 1 << 20),
+            stream_split(4, 9, 1 << 20),
         ];
-        assert_eq!(selected(&splits, 512), Some((4, vec![1, 2])));
+        assert_eq!(selected(&splits, 512, 0), Some((2, vec![1, 2])));
+        assert_eq!(selected(&splits, 512, 2), Some((3, vec![5, 6])));
+        assert_eq!(selected(&splits, 512, 3), Some((4, vec![8, 9])));
+        // Past the highest id: wrap to the lowest.
+        assert_eq!(selected(&splits, 512, 4), Some((2, vec![1, 2])));
+    }
+
+    #[test]
+    fn re_entrant_backlog_does_not_monopolize() {
+        // The residual #60 hazard: stream 2's merged output re-enters
+        // under target with its sources' ancient time range. Data age
+        // must not matter — after servicing stream 2, stream 4 is next.
+        let splits = [
+            stream_split(2, 1, 3 << 20), // merged output, oldest data
+            stream_split(2, 2, 1 << 10),
+            stream_split(4, 10, 1 << 20),
+            stream_split(4, 11, 1 << 20),
+        ];
+        assert_eq!(selected(&splits, 512, 2), Some((4, vec![10, 11])));
+    }
+
+    #[test]
+    fn rotation_alternates_over_successive_ticks() {
+        // Two perpetually backlogged streams split the merge slots evenly.
+        let splits = [
+            stream_split(2, 1, 1 << 20),
+            stream_split(2, 2, 1 << 20),
+            stream_split(4, 8, 1 << 20),
+            stream_split(4, 9, 1 << 20),
+        ];
+        let mut cursor = 0;
+        let mut serviced = Vec::new();
+        for _ in 0..4 {
+            let (stream_id, _) = selected(&splits, 512, cursor).unwrap();
+            serviced.push(stream_id);
+            cursor = stream_id;
+        }
+        assert_eq!(serviced, vec![2, 4, 2, 4]);
     }
 
     #[test]
@@ -1240,7 +1301,7 @@ mod tests {
             stream_split(3, 5, 1 << 20),
             stream_split(3, 6, 1 << 20),
         ];
-        assert_eq!(selected(&splits, 512), Some((3, vec![5, 6])));
+        assert_eq!(selected(&splits, 512, 0), Some((3, vec![5, 6])));
     }
 
     #[test]
@@ -1253,7 +1314,7 @@ mod tests {
             stream_split(3, 5, 1 << 20),
             stream_split(3, 6, 1 << 20),
         ];
-        assert_eq!(selected(&splits, 512), Some((3, vec![5, 6])));
+        assert_eq!(selected(&splits, 512, 0), Some((3, vec![5, 6])));
     }
 
     #[test]
@@ -1264,7 +1325,7 @@ mod tests {
             stream_split(2, 2, 300 << 20),
             stream_split(2, 3, 300 << 20),
         ];
-        assert_eq!(selected(&splits, 512), Some((2, vec![1, 2])));
+        assert_eq!(selected(&splits, 512, 0), Some((2, vec![1, 2])));
     }
 
     #[test]
@@ -1273,6 +1334,6 @@ mod tests {
             stream_split(2, 1, 1 << 20),
             stream_split(3, 2, 1 << 20),
         ];
-        assert_eq!(selected(&splits, 512), None);
+        assert_eq!(selected(&splits, 512, 0), None);
     }
 }


### PR DESCRIPTION
Fixes #60.

## Problem

Two stacked biases guaranteed only the lowest backlogged stream_id ever merged:

1. `small_published_splits` used a global `ORDER BY stream_id, time_start_millis LIMIT 200` — with ~7,000 audit splits under the 512 MB target, the window never contained a row from any other stream.
2. `merge_job` iterated a `BTreeMap` keyed by stream_id and took the first eligible stream.

On the archive cluster, `infrastructure` and `application` had not merged since cluster creation (backlogs growing ~2,700 splits/day; query cost scales with splits touched).

## Fix

**Metastore** (`rsearch-metastore/src/control.rs`): the candidate query windows per stream via `CROSS JOIN LATERAL` — each stream's `per_stream_limit` (64) oldest under-target splits — so no stream can occupy the whole result. Each stream is a bounded range scan of the existing `idx_splits_stream_state_time` index with `LIMIT` early termination (verified via `EXPLAIN`), replacing a full sort of every under-target split per tick. Both `ORDER BY`s carry an `id` tiebreak so the window edge is deterministic under timestamp ties.

**Server** (`rsearch-server/src/control.rs`): selection is extracted into `select_merge_group`, which round-robins on a `ControlPlane` stream_id cursor — the first eligible stream past the last one serviced, wrapping. Fairness is keyed on service order rather than data timestamps: an oldest-data-first scheme (the first draft here) still starves, because a tiny-split stream's merged output re-enters under target with its sources' ancient time range and holds the global minimum every tick. The cursor advances at selection time so a stream with failing merges can't wedge the rotation, and is in-memory only — a leader failover just restarts the rotation.

No change to the `merge_candidates` skew filter (#15) or the `merge_take` target-crossing rule (#49).

## Tests

- Unit tests pin the rotation: alternation over successive ticks, wrap past the highest id, skew-filtered/one-candidate streams skipped, and the re-entrant-backlog scenario (oldest data in the system does not recapture the slot).
- New pg integration test `small_published_splits_windows_per_stream`: a busy stream can't fill the window, per-stream time ordering, and a timestamp tie at the window edge resolves by insertion order.
- `cargo check` clean; 17/17 unit tests, 9/9 pg integration tests against a real Postgres.

Merge *throughput* (one merge per tick can't keep up with split creation) is tracked separately in #61.