### PR TITLE
Add merges_per_tick to lift the one-merge-per-tick throughput cap

### DIFF
--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -146,6 +146,14 @@ pub struct ControlConfig {
     pub merge_min_mb: i64,
     /// Max splits combined per merge operation.
     pub merge_max_group: usize,
+    /// Max merge operations run (serially) per control tick. Merge
+    /// capacity must exceed cluster-wide split creation or split count —
+    /// and with it query cost — grows without bound (#61); one merge per
+    /// tick was break-even on a 4-stream cluster. Raising this drains
+    /// backlogs faster at the cost of a longer tick, which delays the
+    /// tick's other jobs. Merges stay serial so peak memory stays one
+    /// writer budget regardless of this setting.
+    pub merges_per_tick: usize,
     /// Seconds a split stays marked_for_delete before storage deletion,
     /// letting in-flight searches finish.
     pub gc_grace_secs: f64,
@@ -190,6 +198,7 @@ impl Default for ControlConfig {
             merge_target_mb: 512,
             merge_min_mb: 100,
             merge_max_group: 8,
+            merges_per_tick: 4,
             gc_grace_secs: 600.0,
             allow_insecure_webhooks: false,
             staged_orphan_secs: 3600.0,

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -582,47 +582,52 @@ impl ControlPlane {
         }
     }
 
-    /// Combine one group of >= 2 published splits below the merge target
-    /// into a single split. Streams are serviced round-robin (#60): the
+    /// Combine groups of >= 2 published splits below the merge target
+    /// into single splits, up to `merges_per_tick` per tick (#61).
+    /// Streams are serviced round-robin (#60): each merge goes to the
     /// first eligible stream past the last one selected, wrapping around,
     /// so every backlogged stream gets a turn regardless of its stream_id
-    /// or how old its data is. One merge per tick bounds the work.
+    /// or how old its data is. Merges run serially — peak memory stays
+    /// one writer budget — and candidates are re-fetched between merges,
+    /// since each one changes the published set.
     async fn merge_job(&self) -> anyhow::Result<()> {
         use std::sync::atomic::Ordering;
         let target_bytes = self.merge_target_bytes();
-        let small = self
-            .metastore
-            .small_published_splits(target_bytes, MERGE_WINDOW_PER_STREAM)
-            .await?;
-        let cursor = self.merge_cursor.load(Ordering::Relaxed);
-        let Some((stream_id, group)) =
-            select_merge_group(&small, target_bytes, self.config.merge_max_group, cursor)
-        else {
-            return Ok(());
-        };
-        // Advance before merging, so a stream whose merges keep failing
-        // can't wedge the rotation on itself.
-        self.merge_cursor.store(stream_id, Ordering::Relaxed);
+        for _ in 0..self.config.merges_per_tick.max(1) {
+            let small = self
+                .metastore
+                .small_published_splits(target_bytes, MERGE_WINDOW_PER_STREAM)
+                .await?;
+            let cursor = self.merge_cursor.load(Ordering::Relaxed);
+            let Some((stream_id, group)) =
+                select_merge_group(&small, target_bytes, self.config.merge_max_group, cursor)
+            else {
+                break;
+            };
+            // Advance before merging, so a stream whose merges keep
+            // failing can't wedge the rotation on itself.
+            self.merge_cursor.store(stream_id, Ordering::Relaxed);
 
-        let stream = self.metastore.get_stream_by_id(stream_id).await?;
-        info!(
-            stream = %stream.name,
-            splits = group.len(),
-            docs = group.iter().map(|s| s.doc_count).sum::<i64>(),
-            "merging small splits"
-        );
-        // A merge is also a compaction: document-mode streams drop their
-        // tombstoned versions on the way through.
-        let tombstones = self.stream_tombstones(&stream).await?;
-        let group_refs: Vec<&SplitRecord> = group.to_vec();
-        let rebuilt = self.rebuild_splits(&stream, &group_refs, &tombstones).await?;
-        match rebuilt {
-            Some(new_split_id) => info!(
-                merged_into = %new_split_id,
-                sources = group.len(),
-                "merge complete"
-            ),
-            None => info!(sources = group.len(), "merge: every document was tombstoned; sources dropped"),
+            let stream = self.metastore.get_stream_by_id(stream_id).await?;
+            info!(
+                stream = %stream.name,
+                splits = group.len(),
+                docs = group.iter().map(|s| s.doc_count).sum::<i64>(),
+                "merging small splits"
+            );
+            // A merge is also a compaction: document-mode streams drop
+            // their tombstoned versions on the way through.
+            let tombstones = self.stream_tombstones(&stream).await?;
+            let group_refs: Vec<&SplitRecord> = group.to_vec();
+            let rebuilt = self.rebuild_splits(&stream, &group_refs, &tombstones).await?;
+            match rebuilt {
+                Some(new_split_id) => info!(
+                    merged_into = %new_split_id,
+                    sources = group.len(),
+                    "merge complete"
+                ),
+                None => info!(sources = group.len(), "merge: every document was tombstoned; sources dropped"),
+            }
         }
         Ok(())
     }

--- a/rsearch.example.toml
+++ b/rsearch.example.toml
@@ -85,6 +85,7 @@ cache_max_mb = 4096      # local split-fragment cache budget
 interval_secs = 15          # background-job tick on the elected leader
 merge_target_mb = 512       # splits below this keep merging until the output reaches it
 merge_max_group = 8         # max splits combined per merge
+merges_per_tick = 4         # max merges (serial) per tick; must outpace split creation
 gc_grace_secs = 600         # delay before deleting marked-for-delete splits
 staged_orphan_secs = 3600   # sweep splits stuck in 'staged' after a crash
 repair_stale_secs = 300     # replicated backend: holder silence before re-replication


### PR DESCRIPTION
Fixes #61. Stacked on #62 (base is `fix/issue-60-merge-fairness`; GitHub will retarget to `main` when #62 merges).

## Problem

`merge_job` ran exactly one merge per 15-second tick regardless of backlog. On the archive cluster that nets roughly -6,500 splits/day against ~7,950 created — split count (and with it query cost) grows without bound even once #60's fairness fix spreads merges across streams.

## Fix

New `control.merges_per_tick` knob (default 4, `#[serde(default)]` so existing configs are unaffected): `merge_job` loops up to that many select+merge rounds per tick, re-fetching candidates between rounds since each merge changes the published set. The #62 round-robin cursor advances per merge, so within one tick the slots spread across backlogged streams — and a lone backlogged stream may use all of them.

Deliberately **serial**, not concurrent: `rebuild_splits` streams docs through a single Tantivy writer, so peak memory stays one writer budget no matter the setting. The cost is a longer tick delaying the other control jobs (repair, retention, alerts), which is why the default stays modest. If serial-per-tick still can't keep up on larger clusters, concurrent merge execution (bounded, memory-budget-aware, with per-merge work dirs) is the follow-on — happy to file that as a tracking issue if it shows up in practice.

Also documents the knob in `rsearch.example.toml`.

## Verification

`cargo check` clean; 17/17 control unit tests pass (selection logic unchanged — this only loops it).