### PR TITLE
Cut v0.4.1: merge fairness + throughput fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2415,7 +2415,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2434,7 +2434,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.4.0" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.4.0" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.4.0" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.4.0" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.4.0" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.4.0" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.4.1" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.4.1" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.4.1" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.4.1" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.4.1" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.4.1" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
Patch release carrying the merge-starvation work to the archive cluster.

- **#60 / PR #62** — per-stream candidate windowing (LATERAL, bounded index scans, deterministic tiebreaks) and round-robin stream selection, so every backlogged stream gets merge service.
- **#61 / PRs #63+#64** — `control.merges_per_tick` (default 4): up to N serial merges per tick so merge capacity outpaces split creation; existing configs unaffected (`serde(default)`).

Version bump only (workspace 0.4.0 → 0.4.1 + lockfile); no code changes. After merge I'll tag `v0.4.1` on the merge commit, matching v0.4.0.