### PR TITLE
Match OpenSearch dynamic-string semantics: standard analyzer + .keyword (issue #66)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "unicode-segmentation",
  "uuid",
 ]
 
@@ -3605,6 +3606,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "untrusted"

--- a/README.md
+++ b/README.md
@@ -228,6 +228,24 @@ fields by `name:term` or via `fields`). Aggregations pass
 through Tantivy's ES-compatible module (terms, date_histogram, stats,
 percentiles, cardinality, …).
 
+Field semantics follow OpenSearch's dynamic mapping. An unmapped
+string is a `text` field analyzed by the **standard analyzer** (Unicode
+word breaks: `tech_admin` is one token, `Foo-Bar` is two, everything
+lowercased, no stop words) with a **`.keyword` sub-field** holding the
+exact value for strings of at most 256 characters (`ignore_above`).
+`term`/`terms` are not analyzed, so `term role=tech_admin` matches the
+whole token and `term role=admin` matches nothing, while
+`term print_status=printed` still matches "not printed" — on the text
+field, as in OpenSearch; use `print_status.keyword` for exact matching.
+`match`/`match_phrase` analyze their input; on `.keyword` the whole text
+is one term. `prefix`, `wildcard`, `range` and `exists` work on both
+views, and aggregations on `<path>.keyword` use the exact values (the
+bare path is accepted too, a superset of OpenSearch). Explicitly mapped
+`text` fields use the same analyzer; mapped `keyword` fields are exact.
+Splits written before v0.5 (schema version 2) keep their old tokens and
+have no `.keyword` view until the control node rewrites them (see
+`control.schema_upgrade_splits_per_tick` below).
+
 Deep pagination uses `search_after`: every hit's `sort` values are
 `[timestamp_millis, _seq]` — the `_seq` element is an implicit unique
 tiebreak appended to the timestamp sort, the way Elasticsearch's
@@ -295,6 +313,17 @@ On a document-mode index:
   (`control.compact_splits_per_tick`, default 8 per control tick, so a
   stream with many splits takes several ticks) plus `control.gc_grace_secs`
   for the old split object — lower those if an erasure SLA requires.
+  A separate pass rewrites splits whose on-disk layout predates the
+  running version (`control.schema_upgrade_splits_per_tick`, default 2,
+  newest data first, 0 disables; `rsearch_schema_upgrades_total` counts
+  them), so after an upgrade the corpus converges on one analyzer and
+  every split gains its `.keyword` view without operator action — while
+  it runs, a query can see old tokens from not-yet-rewritten splits.
+  Upgrade order matters for v0.5: new splits record the `standard`
+  tokenizer, which an older binary cannot resolve for `match` and
+  `query_string`, so upgrade search nodes before ingest and control
+  nodes (or stop all, then start all) and treat the release as
+  forward-only.
   Tombstone rows are purged once every split of the stream has applied
   them and they are older than `control.tombstone_purge_grace_secs`
   (default 1h); that grace also covers documents still buffered on an

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -184,6 +184,11 @@ pub struct ControlConfig {
     pub compact_max_age_secs: f64,
     /// Max splits rewritten (or marked up to date) per compaction tick.
     pub compact_splits_per_tick: i64,
+    /// Max published splits written under an older layout version that
+    /// are rewritten to the current one per control tick (newest data
+    /// first), so an upgraded cluster converges on one analyzer and every
+    /// split gains the `.keyword` view. 0 disables the pass.
+    pub schema_upgrade_splits_per_tick: i64,
     /// Tombstones are purged from the metastore only once no split can
     /// still hold a version they hide *and* they are at least this old —
     /// the age covers documents still buffered on an ingest node whose
@@ -207,6 +212,7 @@ impl Default for ControlConfig {
             compact_min_tombstones: 1_000,
             compact_max_age_secs: 3_600.0,
             compact_splits_per_tick: 8,
+            schema_upgrade_splits_per_tick: 2,
             tombstone_purge_grace_secs: 3_600.0,
         }
     }

--- a/crates/rsearch-index/Cargo.toml
+++ b/crates/rsearch-index/Cargo.toml
@@ -24,3 +24,4 @@ rsearch-storage.workspace = true
 tokio.workspace = true
 bytes.workspace = true
 memmap2 = { version = "0.9", features = ["stable_deref_trait"] }
+unicode-segmentation = "1"

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -54,6 +54,7 @@ impl SplitBuilder {
         let index_dir = work_dir.path().join("index");
         std::fs::create_dir(&index_dir)?;
         let index = Index::create_in_dir(&index_dir, schema.schema.clone())?;
+        crate::tokenizer::register_tokenizers(&index);
         let writer = index.writer_with_num_threads(1, memory_budget)?;
         Ok(Self {
             split_id: uuid::Uuid::new_v4().simple().to_string(),

--- a/crates/rsearch-index/src/document.rs
+++ b/crates/rsearch-index/src/document.rs
@@ -5,7 +5,7 @@ use tantivy::time::OffsetDateTime;
 use tantivy::time::format_description::well_known::Rfc3339;
 
 use crate::error::{IndexError, IndexResult};
-use crate::mapping::{FieldType, MappedSchema};
+use crate::mapping::{FieldType, KEYWORD_IGNORE_ABOVE, MappedSchema};
 
 /// A document's identity within its stream: the `_id` (client-supplied or
 /// generated) and the write sequence stamp that orders versions of it.
@@ -169,6 +169,19 @@ impl DocumentConverter {
             }
         }
         if !dynamic.is_empty() {
+            // The `.keyword` view: exact string values, with OpenSearch's
+            // dynamic `ignore_above` applied. Built before `dynamic` is
+            // moved into the tokenized field.
+            if let Some(raw_field) = self.schema.dynamic_raw
+                && let Some(raw) = keyword_projection(&dynamic)
+            {
+                out.add_object(
+                    raw_field,
+                    raw.into_iter()
+                        .map(|(k, v)| (k, tantivy::schema::OwnedValue::from(v)))
+                        .collect(),
+                );
+            }
             out.add_object(
                 self.schema.dynamic,
                 dynamic
@@ -178,6 +191,34 @@ impl DocumentConverter {
             );
         }
         Ok((out, timestamp))
+    }
+}
+
+/// The subset of `obj` that gets a `.keyword` value: string leaves of at
+/// most [`KEYWORD_IGNORE_ABOVE`] characters, keeping their object/array
+/// nesting so the JSON path is the same as in `_dynamic`. None when no
+/// string qualifies.
+fn keyword_projection(
+    obj: &serde_json::Map<String, serde_json::Value>,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let projected: serde_json::Map<String, serde_json::Value> = obj
+        .iter()
+        .filter_map(|(k, v)| keyword_value(v).map(|v| (k.clone(), v)))
+        .collect();
+    (!projected.is_empty()).then_some(projected)
+}
+
+fn keyword_value(value: &serde_json::Value) -> Option<serde_json::Value> {
+    match value {
+        serde_json::Value::String(s) => {
+            (s.chars().count() <= KEYWORD_IGNORE_ABOVE).then(|| value.clone())
+        }
+        serde_json::Value::Object(map) => keyword_projection(map).map(serde_json::Value::Object),
+        serde_json::Value::Array(items) => {
+            let kept: Vec<serde_json::Value> = items.iter().filter_map(keyword_value).collect();
+            (!kept.is_empty()).then_some(serde_json::Value::Array(kept))
+        }
+        _ => None,
     }
 }
 
@@ -290,8 +331,47 @@ mod tests {
             )
             .unwrap();
         assert_ne!(ts, fallback());
-        // _source + _timestamp + 4 mapped + _dynamic
-        assert!(doc.field_values().count() >= 6);
+        // _source + _timestamp + 4 mapped + _dynamic + _dynamic_raw
+        assert!(doc.field_values().count() >= 7);
+    }
+
+    #[test]
+    fn keyword_projection_keeps_short_strings_only() {
+        let long = "x".repeat(KEYWORD_IGNORE_ABOVE + 1);
+        let exact = "y".repeat(KEYWORD_IGNORE_ABOVE);
+        let obj = serde_json::json!({
+            "role": "tech_admin",
+            "n": 1,
+            "flag": true,
+            "long": long,
+            "exact": exact,
+            "nested": {"city": "Austin", "count": 2, "deeper": {"zip": "78701"}},
+            "tags": ["a", 7, {"k": "v"}, long, null],
+            "numbers": [1, 2],
+            "empty": {},
+        });
+        let projected = keyword_projection(obj.as_object().unwrap()).unwrap();
+        assert_eq!(
+            serde_json::Value::Object(projected),
+            serde_json::json!({
+                "role": "tech_admin",
+                "exact": exact,
+                "nested": {"city": "Austin", "deeper": {"zip": "78701"}},
+                "tags": ["a", {"k": "v"}],
+            })
+        );
+        assert!(keyword_projection(serde_json::json!({"n": 1}).as_object().unwrap()).is_none());
+    }
+
+    /// Legacy layouts have no `_dynamic_raw`; conversion must not touch it.
+    #[test]
+    fn legacy_schema_gets_no_raw_field() {
+        let schema = MappedSchema::build_versioned(IndexMapping::default(), 1);
+        assert!(schema.dynamic_raw.is_none());
+        let c = DocumentConverter::new(schema);
+        let (doc, _) = c.convert(serde_json::json!({"role": "tech_admin"}), fallback()).unwrap();
+        // _source + _timestamp + _id + _seq + _dynamic
+        assert_eq!(doc.field_values().count(), 5);
     }
 
     #[test]

--- a/crates/rsearch-index/src/dynamic_paths.rs
+++ b/crates/rsearch-index/src/dynamic_paths.rs
@@ -95,7 +95,7 @@ mod tests {
             }))
             .unwrap(),
         );
-        let index = tantivy::Index::create_in_ram(schema.schema.clone());
+        let index = schema.create_in_ram();
         let mut writer = index.writer(15_000_000).unwrap();
         let converter = crate::document::DocumentConverter::new(schema.clone());
         for doc in [

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -11,6 +11,7 @@ mod exclusions;
 mod mapping;
 mod reader;
 mod split_file;
+mod tokenizer;
 
 pub use builder::{PackagedSplit, SplitBuilder};
 pub use dynamic_paths::dynamic_string_paths;
@@ -23,7 +24,9 @@ pub use document::{
 pub use error::{IndexError, IndexResult};
 pub use exclusions::{ExcludeDocsQuery, ExclusionSet, Tombstone};
 pub use mapping::{
-    CURRENT_SCHEMA_VERSION, DYNAMIC_FIELD, FieldType, ID_FIELD, IndexMapping, MappedSchema,
-    SEQ_FIELD, SOURCE_FIELD, TIMESTAMP_FIELD,
+    CURRENT_SCHEMA_VERSION, DYNAMIC_FIELD, DYNAMIC_RAW_FIELD, FieldType, ID_FIELD, IndexMapping,
+    KEYWORD_IGNORE_ABOVE, KEYWORD_SUBFIELD, MappedSchema, SEQ_FIELD, SOURCE_FIELD,
+    TIMESTAMP_FIELD,
 };
 pub use split_file::{BundleMeta, FOOTER_TAIL_LEN, FileSpan, SplitMeta, parse_footer_tail, parse_meta};
+pub use tokenizer::{STANDARD_TOKENIZER, register_tokenizers, standard_analyzer};

--- a/crates/rsearch-index/src/mapping.rs
+++ b/crates/rsearch-index/src/mapping.rs
@@ -2,8 +2,11 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use tantivy::schema::{
-    DateOptions, DateTimePrecision, FAST, Field, INDEXED, STORED, STRING, Schema, TEXT,
+    DateOptions, DateTimePrecision, FAST, Field, INDEXED, IndexRecordOption, JsonObjectOptions,
+    STORED, STRING, Schema, TEXT, TextFieldIndexing, TextOptions,
 };
+
+use crate::tokenizer::STANDARD_TOKENIZER;
 
 use crate::error::{IndexError, IndexResult};
 
@@ -20,10 +23,21 @@ pub const ID_FIELD: &str = "_id";
 /// since epoch) taken when the write was accepted. Orders versions of the
 /// same `_id` and scopes tombstones. Present with `schema_version >= 1`.
 pub const SEQ_FIELD: &str = "_seq";
+/// Reserved JSON field holding the exact (untokenized) string values of
+/// unmapped keys: the `<path>.keyword` sub-field OpenSearch maps every
+/// dynamic string with. Present with `schema_version >= 2`.
+pub const DYNAMIC_RAW_FIELD: &str = "_dynamic_raw";
+/// Sub-field name for the exact-value view of a dynamic string.
+pub const KEYWORD_SUBFIELD: &str = "keyword";
+/// OpenSearch's `ignore_above` on dynamic keyword sub-fields: strings
+/// longer than this many characters have no `.keyword` value.
+pub const KEYWORD_IGNORE_ABOVE: usize = 256;
 /// Schema version written into new splits. `0` (or absent in the footer)
 /// is the legacy layout without `_id`/`_seq`; `1` adds them after the
-/// mapped fields so legacy field ordinals are unchanged.
-pub const CURRENT_SCHEMA_VERSION: u32 = 1;
+/// mapped fields so legacy field ordinals are unchanged; `2` switches
+/// text analysis to the OpenSearch `standard` analyzer and appends the
+/// `_dynamic_raw` keyword sub-field store (issue #66).
+pub const CURRENT_SCHEMA_VERSION: u32 = 2;
 
 /// Supported field types — the ES mapping subset.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -136,6 +150,9 @@ pub struct MappedSchema {
     pub id: Option<Field>,
     /// Handle to the `_seq` fast field; None for legacy schemas.
     pub seq: Option<Field>,
+    /// Handle to the `_dynamic_raw` JSON field (exact string values of
+    /// unmapped keys, the `.keyword` view); None before version 2.
+    pub dynamic_raw: Option<Field>,
     /// The layout version this schema follows.
     pub schema_version: u32,
 }
@@ -159,13 +176,29 @@ impl MappedSchema {
                 .set_fast()
                 .set_precision(DateTimePrecision::Milliseconds),
         );
-        let dynamic = builder.add_json_field(DYNAMIC_FIELD, TEXT | FAST);
+        // Version 2 analyzes text the way OpenSearch does; earlier splits
+        // were written with Tantivy's `default` tokenizer and must be
+        // read back with the layout they were built under.
+        let (text_options, dynamic_options): (TextOptions, JsonObjectOptions) = if schema_version >= 2 {
+            let indexing = TextFieldIndexing::default()
+                .set_tokenizer(STANDARD_TOKENIZER)
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions);
+            (
+                TextOptions::default().set_indexing_options(indexing.clone()),
+                JsonObjectOptions::default()
+                    .set_indexing_options(indexing)
+                    .set_fast(None),
+            )
+        } else {
+            (TEXT.into(), (TEXT | FAST).into())
+        };
+        let dynamic = builder.add_json_field(DYNAMIC_FIELD, dynamic_options);
 
         let mut fields = BTreeMap::new();
         for (name, ty) in &mapping.properties {
             let field = match ty {
                 FieldType::Keyword => builder.add_text_field(name, STRING | FAST),
-                FieldType::Text => builder.add_text_field(name, TEXT),
+                FieldType::Text => builder.add_text_field(name, text_options.clone()),
                 FieldType::Long => builder.add_i64_field(name, INDEXED | FAST),
                 FieldType::Double => builder.add_f64_field(name, INDEXED | FAST),
                 FieldType::Boolean => builder.add_bool_field(name, INDEXED | FAST),
@@ -190,6 +223,23 @@ impl MappedSchema {
         } else {
             (None, None)
         };
+        // Exact string values, one term per value (the `raw` tokenizer),
+        // no positions needed. Also a fast field: range, exists and
+        // aggregations on `<path>.keyword` read it, which keeps
+        // `ignore_above` semantics (a value past the limit has no keyword
+        // view at all) exactly as OpenSearch's keyword doc values do.
+        let dynamic_raw = (schema_version >= 2).then(|| {
+            builder.add_json_field(
+                DYNAMIC_RAW_FIELD,
+                JsonObjectOptions::default()
+                    .set_indexing_options(
+                        TextFieldIndexing::default()
+                            .set_tokenizer("raw")
+                            .set_index_option(IndexRecordOption::Basic),
+                    )
+                    .set_fast(None),
+            )
+        });
 
         Self {
             schema: builder.build(),
@@ -200,8 +250,24 @@ impl MappedSchema {
             mapping,
             id,
             seq,
+            dynamic_raw,
             schema_version,
         }
+    }
+
+    /// Name of the analyzer `text` fields and `_dynamic` strings were
+    /// indexed with under this layout version — what `match`-style
+    /// queries must analyze their input with to hit the same tokens.
+    pub fn text_tokenizer(&self) -> &'static str {
+        if self.schema_version >= 2 { STANDARD_TOKENIZER } else { "default" }
+    }
+
+    /// A fresh in-memory Tantivy index over this schema with rSearch's
+    /// analyzers registered (tests and tooling).
+    pub fn create_in_ram(&self) -> tantivy::Index {
+        let index = tantivy::Index::create_in_ram(self.schema.clone());
+        crate::tokenizer::register_tokenizers(&index);
+        index
     }
 }
 

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -100,6 +100,7 @@ impl SplitReader {
         // reader once here (also blocking: it opens every segment).
         let (index, reader) = tokio::task::spawn_blocking(move || {
             let index = Index::open(directory)?;
+            crate::tokenizer::register_tokenizers(&index);
             let reader = index
                 .reader_builder()
                 .reload_policy(tantivy::ReloadPolicy::Manual)

--- a/crates/rsearch-index/src/tokenizer.rs
+++ b/crates/rsearch-index/src/tokenizer.rs
@@ -1,0 +1,178 @@
+//! The `standard` analyzer: OpenSearch/Elasticsearch `standard` semantics
+//! on Tantivy.
+//!
+//! Tantivy's built-in `default` tokenizer splits on every non-alphanumeric
+//! character, so `tech_admin` indexes as `tech` + `admin` and a `term`
+//! query for the whole value can never match (issue #66). OpenSearch's
+//! standard tokenizer follows Unicode word-break rules (UAX #29), under
+//! which `_` joins words and `-` splits them, then drops tokens holding
+//! no letter or digit and lowercases the rest. This module reproduces
+//! that so queries written against OpenSearch return the same documents.
+
+use tantivy::Index;
+use tantivy::tokenizer::{LowerCaser, TextAnalyzer, Token, TokenStream, Tokenizer};
+use unicode_segmentation::{UWordBoundIndices, UnicodeSegmentation};
+
+/// Name the standard analyzer is registered under on every index.
+pub const STANDARD_TOKENIZER: &str = "standard";
+
+/// OpenSearch's `max_token_length` for the standard tokenizer: longer
+/// words are split at this many characters.
+pub const MAX_TOKEN_LENGTH: usize = 255;
+
+/// UAX #29 word-break tokenizer (the OpenSearch `standard` tokenizer).
+#[derive(Clone, Default)]
+pub struct StandardTokenizer {
+    token: Token,
+}
+
+/// Token stream over UAX #29 words; punctuation- and whitespace-only
+/// words are skipped, over-long words are split.
+pub struct StandardTokenStream<'a> {
+    text: &'a str,
+    words: UWordBoundIndices<'a>,
+    /// Remainder of a word longer than [`MAX_TOKEN_LENGTH`], as byte
+    /// offsets into `text`, still to be emitted in chunks.
+    long_word: Option<(usize, usize)>,
+    token: &'a mut Token,
+}
+
+impl Tokenizer for StandardTokenizer {
+    type TokenStream<'a> = StandardTokenStream<'a>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> StandardTokenStream<'a> {
+        self.token.reset();
+        StandardTokenStream {
+            text,
+            words: text.split_word_bound_indices(),
+            long_word: None,
+            token: &mut self.token,
+        }
+    }
+}
+
+impl StandardTokenStream<'_> {
+    /// Next (from, to) byte span to emit: the pending chunk of a long
+    /// word, else the next word containing a letter or digit.
+    fn next_span(&mut self) -> Option<(usize, usize)> {
+        if let Some((from, to)) = self.long_word.take() {
+            return Some(self.chunk(from, to));
+        }
+        for (from, word) in self.words.by_ref() {
+            if word.chars().any(char::is_alphanumeric) {
+                return Some(self.chunk(from, from + word.len()));
+            }
+        }
+        None
+    }
+
+    /// Cut the span at [`MAX_TOKEN_LENGTH`] characters, queueing the rest.
+    fn chunk(&mut self, from: usize, to: usize) -> (usize, usize) {
+        let word = &self.text[from..to];
+        match word.char_indices().nth(MAX_TOKEN_LENGTH) {
+            Some((cut, _)) => {
+                self.long_word = Some((from + cut, to));
+                (from, from + cut)
+            }
+            None => (from, to),
+        }
+    }
+}
+
+impl TokenStream for StandardTokenStream<'_> {
+    fn advance(&mut self) -> bool {
+        self.token.text.clear();
+        self.token.position = self.token.position.wrapping_add(1);
+        match self.next_span() {
+            Some((from, to)) => {
+                self.token.offset_from = from;
+                self.token.offset_to = to;
+                self.token.text.push_str(&self.text[from..to]);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn token(&self) -> &Token {
+        self.token
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        self.token
+    }
+}
+
+/// The standard analyzer: [`StandardTokenizer`] + lowercasing (no stop
+/// words, as in OpenSearch's default).
+pub fn standard_analyzer() -> TextAnalyzer {
+    TextAnalyzer::builder(StandardTokenizer::default())
+        .filter(LowerCaser)
+        .build()
+}
+
+/// Register rSearch's analyzers on an index. Must run on every index
+/// handle before it is written to or searched with an analyzed query:
+/// Tantivy resolves tokenizers by name from the handle, not from the
+/// index files.
+pub fn register_tokenizers(index: &Index) {
+    index
+        .tokenizers()
+        .register(STANDARD_TOKENIZER, standard_analyzer());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tokens(text: &str) -> Vec<String> {
+        let mut analyzer = standard_analyzer();
+        let mut stream = analyzer.token_stream(text);
+        let mut out = Vec::new();
+        while stream.advance() {
+            out.push(stream.token().text.clone());
+        }
+        out
+    }
+
+    #[test]
+    fn underscore_joins_hyphen_splits() {
+        // The issue #66 values, and the same shapes verified against
+        // OpenSearch 3.6.
+        assert_eq!(tokens("tech_admin"), ["tech_admin"]);
+        assert_eq!(tokens("not printed"), ["not", "printed"]);
+        assert_eq!(tokens("Foo-Bar_baz"), ["foo", "bar_baz"]);
+        assert_eq!(tokens("Hello, happy tax payer!"), ["hello", "happy", "tax", "payer"]);
+    }
+
+    #[test]
+    fn keeps_numbers_and_word_internal_punctuation() {
+        assert_eq!(tokens("3.14 v1.2.3 o'neil a.b"), ["3.14", "v1.2.3", "o'neil", "a.b"]);
+        assert_eq!(tokens("user@example.com"), ["user", "example.com"]);
+        assert_eq!(tokens("  --- ... "), Vec::<String>::new());
+        assert_eq!(tokens("日本語"), ["日", "本", "語"]);
+    }
+
+    #[test]
+    fn positions_and_offsets_follow_emitted_tokens_only() {
+        let mut analyzer = standard_analyzer();
+        let mut stream = analyzer.token_stream("a, b");
+        assert!(stream.advance());
+        assert_eq!((stream.token().position, stream.token().offset_from, stream.token().offset_to), (0, 0, 1));
+        assert!(stream.advance());
+        assert_eq!((stream.token().position, stream.token().offset_from, stream.token().offset_to), (1, 3, 4));
+        assert!(!stream.advance());
+    }
+
+    #[test]
+    fn splits_words_over_max_token_length() {
+        let long = "a".repeat(MAX_TOKEN_LENGTH + 2);
+        let got = tokens(&long);
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[0].len(), MAX_TOKEN_LENGTH);
+        assert_eq!(got[1], "aa");
+        // Character count, not bytes.
+        let long = "é".repeat(MAX_TOKEN_LENGTH);
+        assert_eq!(tokens(&long), [long.clone()]);
+    }
+}

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -890,6 +890,7 @@ async fn flush_inner(
             seq_min: packaged.meta.seq_min,
             seq_max: packaged.meta.seq_max,
             tombstone_seq_applied: 0,
+            schema_version: packaged.meta.schema_version as i32,
         })
         .await
     {

--- a/crates/rsearch-metastore/migrations/20260903203230_split_schema_version.sql
+++ b/crates/rsearch-metastore/migrations/20260903203230_split_schema_version.sql
@@ -1,0 +1,14 @@
+-- Split layout version (rsearch_index::CURRENT_SCHEMA_VERSION at build
+-- time), so the control node can find splits written under an older
+-- layout and rewrite them (issue #66). Existing rows default to 0: every
+-- split registered before this column existed is a rebuild candidate,
+-- which is correct — none of them carry the version-2 analyzer or the
+-- `.keyword` view. The exact pre-upgrade version is only in the split
+-- footer and does not matter for scheduling.
+ALTER TABLE splits ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 0;
+
+-- The upgrade scan: published splits below the current version, newest
+-- data first.
+CREATE INDEX idx_splits_schema_version_published
+    ON splits (schema_version, time_end_millis DESC)
+    WHERE state = 'published';

--- a/crates/rsearch-metastore/src/control.rs
+++ b/crates/rsearch-metastore/src/control.rs
@@ -96,12 +96,13 @@ impl Metastore {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT c.id, c.split_id, c.stream_id, c.state, c.storage_key, c.doc_count,
                     c.size_bytes, c.time_start_millis, c.time_end_millis, c.footer_len,
-                    c.created_by, c.seq_min, c.seq_max, c.tombstone_seq_applied
+                    c.created_by, c.seq_min, c.seq_max, c.tombstone_seq_applied,
+                    c.schema_version
              FROM streams st
              CROSS JOIN LATERAL (
                  SELECT id, split_id, stream_id, state, storage_key, doc_count,
                         size_bytes, time_start_millis, time_end_millis, footer_len,
-                        created_by, seq_min, seq_max, tombstone_seq_applied
+                        created_by, seq_min, seq_max, tombstone_seq_applied, schema_version
                  FROM splits
                  WHERE stream_id = st.id AND state = 'published' AND size_bytes < $1
                  ORDER BY time_start_millis, id
@@ -150,7 +151,7 @@ impl Metastore {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
                     time_start_millis, time_end_millis, footer_len, created_by,
-                    seq_min, seq_max, tombstone_seq_applied
+                    seq_min, seq_max, tombstone_seq_applied, schema_version
              FROM splits
              WHERE state = 'staged'
                AND created_at < now() - make_interval(secs => $1)
@@ -172,7 +173,7 @@ impl Metastore {
         Ok(sqlx::query_as::<_, SplitRecord>(
             "SELECT id, split_id, stream_id, state, storage_key, doc_count, size_bytes,
                     time_start_millis, time_end_millis, footer_len, created_by,
-                    seq_min, seq_max, tombstone_seq_applied
+                    seq_min, seq_max, tombstone_seq_applied, schema_version
              FROM splits
              WHERE state = 'marked_for_delete'
                AND updated_at < now() - make_interval(secs => $1)

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -8,7 +8,7 @@ use crate::types::{NewSplit, SplitRecord, SplitState, StreamMode, StreamRecord, 
 
 pub(crate) const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
      size_bytes, time_start_millis, time_end_millis, footer_len, created_by, \
-     seq_min, seq_max, tombstone_seq_applied";
+     seq_min, seq_max, tombstone_seq_applied, schema_version";
 
 /// Postgres-backed metadata store shared by every node role: streams,
 /// splits, nodes, placement, auth, routing rules, and alerts. Cloning
@@ -213,8 +213,8 @@ impl Metastore {
         sqlx::query(
             "INSERT INTO splits (split_id, stream_id, storage_key, doc_count, size_bytes,
                                  time_start_millis, time_end_millis, footer_len, created_by,
-                                 seq_min, seq_max, tombstone_seq_applied)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+                                 seq_min, seq_max, tombstone_seq_applied, schema_version)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
         )
         .bind(split.split_id)
         .bind(split.stream_id)
@@ -228,9 +228,31 @@ impl Metastore {
         .bind(split.seq_min)
         .bind(split.seq_max)
         .bind(split.tombstone_seq_applied)
+        .bind(split.schema_version)
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Published splits built under a layout older than `version`, newest
+    /// data first (it is queried most); at most `limit`. The control
+    /// node's schema-upgrade job rewrites them (issue #66).
+    pub async fn splits_below_schema_version(
+        &self,
+        version: i32,
+        limit: i64,
+    ) -> MetastoreResult<Vec<SplitRecord>> {
+        let query = format!(
+            "SELECT {SPLIT_COLUMNS} FROM splits
+             WHERE state = 'published' AND schema_version < $1
+             ORDER BY time_end_millis DESC
+             LIMIT $2"
+        );
+        Ok(sqlx::query_as::<_, SplitRecord>(sqlx::AssertSqlSafe(query))
+            .bind(version)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?)
     }
 
     /// staged → published. Fails if the split is missing or already moved.

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -126,6 +126,10 @@ pub struct SplitRecord {
     /// Highest tombstone `seq` applied when the split was built (0 for
     /// ingest-built splits: nothing applied yet).
     pub tombstone_seq_applied: i64,
+    /// Split layout version it was built under (see
+    /// `rsearch_index::CURRENT_SCHEMA_VERSION`); 0 for rows registered
+    /// before the column existed.
+    pub schema_version: i32,
 }
 
 /// A split to register (see `Metastore::stage_split`).
@@ -155,6 +159,8 @@ pub struct NewSplit<'a> {
     pub seq_max: Option<i64>,
     /// Highest tombstone seq applied while building.
     pub tombstone_seq_applied: i64,
+    /// Split layout version it was built under.
+    pub schema_version: i32,
 }
 
 impl SplitRecord {

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -74,6 +74,7 @@ async fn stream_mode_is_fixed_once_data_exists() {
         seq_min: None,
         seq_max: None,
         tombstone_seq_applied: 0,
+        schema_version: 0,
     })
     .await
     .unwrap();
@@ -108,6 +109,7 @@ async fn split_state_machine() {
         seq_min: Some(10),
         seq_max: Some(20),
         tombstone_seq_applied: 0,
+        schema_version: 0,
     })
     .await
     .unwrap();
@@ -202,6 +204,7 @@ async fn small_published_splits_windows_per_stream() {
                 seq_min: None,
                 seq_max: None,
                 tombstone_seq_applied: 0,
+                schema_version: 0,
             })
             .await
             .unwrap();
@@ -444,6 +447,7 @@ async fn tombstones_upsert_and_page_by_seq() {
         seq_min: Some(1),
         seq_max: Some(2),
         tombstone_seq_applied: applied,
+        schema_version: 0,
         }
     }
     let s1 = unique("s1");
@@ -493,6 +497,7 @@ async fn stray_object_keys_finds_placements_without_split_rows() {
         seq_min: None,
         seq_max: None,
         tombstone_seq_applied: 0,
+        schema_version: 0,
     })
     .await
     .unwrap();
@@ -516,5 +521,68 @@ async fn stray_object_keys_finds_placements_without_split_rows() {
 
     ms.remove_object_locations(&stray_key).await.unwrap();
     ms.remove_object_locations(&tracked_key).await.unwrap();
+    ms.delete_stream(&stream.name).await.unwrap();
+}
+
+#[tokio::test]
+#[ignore = "requires Postgres (set RSEARCH_TEST_DATABASE_URL)"]
+async fn splits_below_schema_version_lists_stale_layouts_newest_first() {
+    let Some(ms) = metastore().await else { return };
+    let stream = ms.ensure_stream(&unique("schema-upgrade")).await.unwrap();
+
+    // Two legacy splits (versions 0 and 1) and one current; only the
+    // legacy ones are upgrade candidates, newest data first (#66).
+    let mut ids = Vec::new();
+    for (version, end) in [(0, 1_000_999i64), (2, 3_000_999), (1, 2_000_999)] {
+        let split_id = unique("split");
+        ms.stage_split(&NewSplit {
+            split_id: &split_id,
+            stream_id: stream.id,
+            storage_key: &format!("streams/{}/{split_id}.split", stream.name),
+            doc_count: 10,
+            size_bytes: 1024,
+            time_start_millis: end - 999,
+            time_end_millis: end,
+            footer_len: 128,
+            created_by: None,
+            seq_min: None,
+            seq_max: None,
+            tombstone_seq_applied: 0,
+            schema_version: version,
+        })
+        .await
+        .unwrap();
+        ms.publish_split(&split_id).await.unwrap();
+        ids.push((version, split_id));
+    }
+
+    // The shared dev database may hold other streams' splits.
+    let ours: Vec<_> = ms
+        .splits_below_schema_version(2, 10_000)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|s| s.stream_id == stream.id)
+        .collect();
+    let expected: Vec<&str> = ids
+        .iter()
+        .filter(|(v, _)| *v < 2)
+        .map(|(_, id)| id.as_str())
+        .collect();
+    assert_eq!(ours.len(), 2);
+    assert_eq!(ours[0].split_id, expected[1], "version-1 split has the newer data");
+    assert_eq!(ours[1].split_id, expected[0]);
+    assert!(ours.iter().all(|s| s.schema_version < 2));
+
+    // The column round-trips through every split read path.
+    let current = ms
+        .splits_for_query(stream.id, None, None, 100)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|s| s.time_end_millis == 3_000_999)
+        .unwrap();
+    assert_eq!(current.schema_version, 2);
+
     ms.delete_stream(&stream.name).await.unwrap();
 }

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -1244,7 +1244,7 @@ mod tests {
     /// version.
     fn build_index(schema_version: u32, docs: &[(i64, i64)]) -> (MappedSchema, tantivy::Index) {
         let schema = MappedSchema::build_versioned(IndexMapping::default(), schema_version);
-        let index = tantivy::Index::create_in_ram(schema.schema.clone());
+        let index = schema.create_in_ram();
         let converter = DocumentConverter::new(schema.clone());
         let mut writer = index.writer_with_num_threads(1, 20 << 20).unwrap();
         for (i, (ts, seq)) in docs.iter().enumerate() {

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -9,8 +9,8 @@ use std::ops::Bound;
 
 use serde_json::Value;
 use tantivy::query::{
-    AllQuery, BooleanQuery, ExistsQuery, FuzzyTermQuery, Occur, PhraseQuery, Query, QueryParser,
-    RangeQuery, RegexQuery, TermQuery,
+    AllQuery, BooleanQuery, EmptyQuery, ExistsQuery, FuzzyTermQuery, Occur, PhraseQuery, Query,
+    QueryParser, RangeQuery, RegexQuery, TermQuery,
 };
 use tantivy::schema::{Field, IndexRecordOption, Term};
 use tantivy::time::OffsetDateTime;
@@ -27,7 +27,14 @@ const TIMESTAMP_ALIASES: [&str; 3] = ["@timestamp", "timestamp", "_timestamp"];
 enum Resolved {
     Timestamp(Field),
     Typed(Field, FieldType),
+    /// An unmapped name: a path into the tokenized `_dynamic` JSON field.
     Dynamic(Field, String),
+    /// `<path>.keyword` on an unmapped name: the exact-value view in
+    /// `_dynamic_raw` (issue #66). The field is None on splits written
+    /// before schema version 2, where the clause can match nothing —
+    /// the same way a `.keyword` sub-field that was never mapped behaves
+    /// in OpenSearch.
+    DynamicKeyword(Option<Field>, String),
 }
 
 fn resolve(schema: &MappedSchema, name: &str) -> Resolved {
@@ -50,7 +57,35 @@ fn resolve(schema: &MappedSchema, name: &str) -> Resolved {
     {
         return Resolved::Typed(field, FieldType::Long);
     }
+    // OpenSearch maps every dynamic string as `text` with a `keyword`
+    // sub-field; only unmapped names have one here too. A mapped field's
+    // `.keyword` falls through to a raw path no document holds, i.e. it
+    // matches nothing — as an undeclared sub-field does in OpenSearch.
+    if let Some(base) = name.strip_suffix(KEYWORD_PATH_SUFFIX)
+        && !base.is_empty()
+    {
+        return Resolved::DynamicKeyword(schema.dynamic_raw, base.to_string());
+    }
     Resolved::Dynamic(schema.dynamic, name.to_string())
+}
+
+/// `.keyword`, the OpenSearch dynamic sub-field suffix.
+const KEYWORD_PATH_SUFFIX: &str = ".keyword";
+
+/// A query that matches no document: the `.keyword` view on a split
+/// written before it existed.
+fn empty_query() -> Box<dyn Query> {
+    Box::new(EmptyQuery)
+}
+
+/// Exact-value term for `path` in the `_dynamic_raw` field. Non-string
+/// JSON literals are matched by their text form, as a keyword field
+/// coerces them in OpenSearch.
+fn raw_term(field: Field, path: &str, value: &Value) -> Term {
+    let mut term = Term::from_field_json_path(field, path, false);
+    let s = value.as_str().map(str::to_string).unwrap_or_else(|| value.to_string());
+    term.append_type_and_str(&s);
+    term
 }
 
 /// Rewrite aggregation field names the same way queries resolve them, so
@@ -74,10 +109,20 @@ pub fn rewrite_agg_fields(schema: &MappedSchema, aggs: &Value) -> Value {
                     if k == "field"
                         && let Some(name) = v.as_str()
                     {
+                        // `.keyword` aggregates the raw field's fast column
+                        // (exact values within ignore_above, as OpenSearch's
+                        // keyword doc values). The bare path is accepted too
+                        // — `_dynamic`'s fast values are whole strings — a
+                        // superset of OpenSearch, which rejects text-field
+                        // aggregations. On a legacy split the raw field is
+                        // absent and the aggregation simply has no values.
                         let rewritten = match resolve(schema, name) {
                             Resolved::Timestamp(_) => "_timestamp".to_string(),
                             Resolved::Typed(..) => name.to_string(),
                             Resolved::Dynamic(_, path) => format!("_dynamic.{path}"),
+                            Resolved::DynamicKeyword(_, path) => {
+                                format!("{}.{path}", rsearch_index::DYNAMIC_RAW_FIELD)
+                            }
                         };
                         (k.clone(), Value::String(rewritten))
                     } else if k == "interval" && v.is_string() {
@@ -413,6 +458,8 @@ fn term_query_for(schema: &MappedSchema, name: &str, value: &Value) -> SearchRes
         }
         Resolved::Typed(field, ty) => typed_term(field, ty, value)?,
         Resolved::Dynamic(field, path) => dynamic_term(field, &path, value),
+        Resolved::DynamicKeyword(Some(field), path) => raw_term(field, &path, value),
+        Resolved::DynamicKeyword(None, _) => return Ok(empty_query()),
     };
     Ok(Box::new(TermQuery::new(term, IndexRecordOption::Basic)))
 }
@@ -495,8 +542,13 @@ fn translate_range(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn 
             }
             Resolved::Typed(field, ty) => typed_term(field, ty, value),
             Resolved::Dynamic(field, path) => Ok(dynamic_term(field, &path, value)),
+            Resolved::DynamicKeyword(Some(field), path) => Ok(raw_term(field, &path, value)),
+            Resolved::DynamicKeyword(None, _) => Err(SearchError::BadRequest(String::new())),
         }
     };
+    if let Resolved::DynamicKeyword(None, _) = resolve(schema, name) {
+        return Ok(empty_query());
+    }
 
     let mut lower = Bound::Unbounded;
     let mut upper = Bound::Unbounded;
@@ -596,10 +648,11 @@ fn translate_prefix(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn
         let field = match resolve(schema, name) {
             Resolved::Typed(field, FieldType::Keyword | FieldType::Text) => field,
             Resolved::Typed(..) | Resolved::Timestamp(_) => return Err(not_string_field()),
-            Resolved::Dynamic(field, path) => {
+            Resolved::Dynamic(field, path) | Resolved::DynamicKeyword(Some(field), path) => {
                 push_dynamic_path_prefix(&mut pattern, field, &path)?;
                 field
             }
+            Resolved::DynamicKeyword(None, _) => return Ok(empty_query()),
         };
         pattern.push_str("(?i:");
         push_regex_literal_str(&mut pattern, text);
@@ -614,11 +667,12 @@ fn translate_prefix(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn
             Term::from_field_text(field, text)
         }
         Resolved::Typed(..) | Resolved::Timestamp(_) => return Err(not_string_field()),
-        Resolved::Dynamic(field, path) => {
+        Resolved::Dynamic(field, path) | Resolved::DynamicKeyword(Some(field), path) => {
             let mut term = Term::from_field_json_path(field, &path, false);
             term.append_type_and_str(text);
             term
         }
+        Resolved::DynamicKeyword(None, _) => return Ok(empty_query()),
     };
     Ok(Box::new(FuzzyTermQuery::new_prefix(term, 0, false)))
 }
@@ -673,12 +727,14 @@ fn translate_wildcard(schema: &MappedSchema, body: &Value) -> SearchResult<Box<d
                 "wildcard query requires a string field, '{name}' is not"
             )));
         }
-        // Unmapped fields: the pattern carries the `_dynamic` path key
-        // prefix literally, so only this path's string terms can match.
-        Resolved::Dynamic(field, path) => {
+        // Unmapped fields: the pattern carries the `_dynamic` (or, for
+        // `.keyword`, `_dynamic_raw`) path key prefix literally, so only
+        // this path's string terms can match.
+        Resolved::Dynamic(field, path) | Resolved::DynamicKeyword(Some(field), path) => {
             push_dynamic_path_prefix(&mut pattern, field, &path)?;
             field
         }
+        Resolved::DynamicKeyword(None, _) => return Ok(empty_query()),
     };
     if case_insensitive {
         pattern.push_str("(?i:");
@@ -701,6 +757,12 @@ fn translate_exists(schema: &MappedSchema, body: &Value) -> SearchResult<Box<dyn
         Resolved::Timestamp(_) => "_timestamp".to_string(),
         Resolved::Typed(..) => name.to_string(),
         Resolved::Dynamic(_, path) => format!("_dynamic.{path}"),
+        // `.keyword` exists only for strings within `ignore_above`: the
+        // raw field's fast column holds exactly those.
+        Resolved::DynamicKeyword(Some(_), path) => {
+            format!("{}.{path}", rsearch_index::DYNAMIC_RAW_FIELD)
+        }
+        Resolved::DynamicKeyword(None, _) => return Ok(empty_query()),
     };
     Ok(Box::new(ExistsQuery::new(field_name, true)))
 }
@@ -741,10 +803,10 @@ fn translate_match(
 
     match resolve(schema, name) {
         Resolved::Typed(field, FieldType::Text) => {
-            // Text fields use the default tokenizer (mapping subset v1).
+            // Analyze with the tokenizer the split was written with.
             let mut analyzer = index
                 .tokenizers()
-                .get("default")
+                .get(schema.text_tokenizer())
                 .ok_or_else(|| SearchError::Internal("missing tokenizer".into()))?;
             let tokens = tokenize(&mut analyzer, &text);
             if tokens.is_empty() {
@@ -784,7 +846,7 @@ fn translate_match(
         Resolved::Dynamic(field, path) => {
             let mut analyzer = index
                 .tokenizers()
-                .get("default")
+                .get(schema.text_tokenizer())
                 .ok_or_else(|| SearchError::Internal("missing tokenizer".into()))?;
             let tokens = tokenize(&mut analyzer, &text);
             if tokens.is_empty() {
@@ -817,9 +879,49 @@ fn translate_match(
                 Ok(Box::new(BooleanQuery::new(clauses)))
             }
         }
-        // Non-text mapped fields: match degrades to an exact term.
+        // `.keyword` analyzes with the keyword analyzer, i.e. the whole
+        // text is one term; non-text mapped fields likewise degrade to an
+        // exact term.
         _ => term_query_for(schema, name, spec.get("query").unwrap_or(spec)),
     }
+}
+
+/// Rewrite `name.keyword:` field prefixes in query-string syntax to
+/// `_dynamic_raw.name:` when `name` is unmapped, so Tantivy's parser
+/// targets the exact-value field (its `raw` tokenizer keeps the value
+/// whole). Only a field position is touched: the token must start the
+/// text or follow whitespace, `(`, `+`, `-` or `!`, and end in `:`.
+fn rewrite_keyword_paths(schema: &MappedSchema, text: &str) -> String {
+    let Some(_) = schema.dynamic_raw else {
+        return text.to_string();
+    };
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(pos) = rest.find(KEYWORD_PATH_SUFFIX) {
+        let after = &rest[pos + KEYWORD_PATH_SUFFIX.len()..];
+        // Field name: the run of non-space, non-syntax bytes before `.keyword`.
+        let before = &rest[..pos];
+        let start = before
+            .rfind(|c: char| c.is_whitespace() || matches!(c, '(' | '+' | '-' | '!' | ':' | '"'))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let name = &before[start..];
+        let is_field_position = after.starts_with(':')
+            && !name.is_empty()
+            && matches!(resolve(schema, name), Resolved::Dynamic(..));
+        if is_field_position {
+            out.push_str(&before[..start]);
+            out.push_str(rsearch_index::DYNAMIC_RAW_FIELD);
+            out.push('.');
+            out.push_str(name);
+            rest = after;
+        } else {
+            out.push_str(&rest[..pos + KEYWORD_PATH_SUFFIX.len()]);
+            rest = after;
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// `query_string` / `simple_query_string`. Honors `fields` (with ES `^boost`
@@ -840,6 +942,9 @@ fn translate_query_string(
         .get("query")
         .and_then(Value::as_str)
         .ok_or_else(|| SearchError::BadRequest("query_string needs 'query'".into()))?;
+    // `path.keyword:value` inside the text must reach `_dynamic_raw`, which
+    // the parser only does under that field's own name.
+    let query_text = &rewrite_keyword_paths(schema, query_text);
     let conjunction = matches!(
         body.get("default_operator").and_then(Value::as_str),
         Some(op) if op.eq_ignore_ascii_case("and")
@@ -870,6 +975,8 @@ fn translate_query_string(
     let mut default_fields: Vec<Field> = Vec::new();
     let mut boosts: Vec<(Field, f32)> = Vec::new();
     let mut dynamic_paths: Vec<(String, f32)> = Vec::new();
+    let mut raw_paths: Vec<(String, f32)> = Vec::new();
+    let mut legacy_keyword_only = false;
     if all {
         default_fields.extend(
             schema
@@ -902,9 +1009,15 @@ fn translate_query_string(
                 // Numeric/date/ip/timestamp fields can't take free text.
                 Resolved::Typed(..) | Resolved::Timestamp(_) => {}
                 Resolved::Dynamic(_, path) => dynamic_paths.push((path, boost)),
+                Resolved::DynamicKeyword(Some(_), path) => raw_paths.push((path, boost)),
+                // No raw field on this split: the clause matches nothing.
+                Resolved::DynamicKeyword(None, _) => legacy_keyword_only = true,
             }
         }
-        if default_fields.is_empty() && dynamic_paths.is_empty() {
+        if default_fields.is_empty() && dynamic_paths.is_empty() && raw_paths.is_empty() {
+            if legacy_keyword_only {
+                return Ok(empty_query());
+            }
             return Err(SearchError::BadRequest(
                 "query_string 'fields' names no searchable field".into(),
             ));
@@ -932,6 +1045,18 @@ fn translate_query_string(
         let boosts = if boost != 1.0 { vec![(schema.dynamic, boost)] } else { Vec::new() };
         clauses.push((Occur::Should, parse(vec![schema.dynamic], &boosts, &wrapped)));
     }
+    // `.keyword` fields parse against `_dynamic_raw`, whose `raw`
+    // tokenizer makes the whole text one exact term.
+    if let Some(raw) = schema.dynamic_raw {
+        for (path, boost) in raw_paths {
+            let wrapped = format!("{}.{path}:({query_text})", rsearch_index::DYNAMIC_RAW_FIELD);
+            let boosts = if boost != 1.0 { vec![(raw, boost)] } else { Vec::new() };
+            clauses.push((Occur::Should, parse(vec![raw], &boosts, &wrapped)));
+        }
+    }
+    if clauses.is_empty() {
+        return Ok(empty_query());
+    }
     Ok(match clauses.len() {
         1 => clauses.pop().map(|(_, q)| q).expect("one clause"),
         _ => Box::new(BooleanQuery::new(clauses)),
@@ -957,7 +1082,7 @@ mod tests {
     }
 
     fn index(schema: &MappedSchema) -> tantivy::Index {
-        tantivy::Index::create_in_ram(schema.schema.clone())
+        schema.create_in_ram()
     }
 
     /// Path provider for tests: scans the in-RAM index the way the real
@@ -1026,6 +1151,142 @@ mod tests {
         let q = translate_query(&idx, &s, query, &paths_of(&idx, &s))
             .unwrap_or_else(|e| panic!("{query}: {e}"));
         searcher.search(&q, &Count).unwrap()
+    }
+
+    /// Index `docs` under `schema_version` and count hits for `query`.
+    fn count_in(schema_version: u32, docs: &[serde_json::Value], query: &serde_json::Value) -> usize {
+        use rsearch_index::{DocumentConverter, IndexMapping};
+        use tantivy::collector::Count;
+        let s = MappedSchema::build_versioned(IndexMapping::default(), schema_version);
+        let idx = index(&s);
+        let converter = DocumentConverter::new(s.clone());
+        let mut writer = idx.writer_with_num_threads(1, 20 << 20).unwrap();
+        for doc in docs {
+            let (doc, _) = converter
+                .convert(doc.clone(), tantivy::DateTime::from_timestamp_millis(0))
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        let searcher = idx.reader().unwrap().searcher();
+        let q = translate_query(&idx, &s, query, &paths_of(&idx, &s))
+            .unwrap_or_else(|e| panic!("{query}: {e}"));
+        searcher.search(&q, &Count).unwrap()
+    }
+
+    /// The issue #66 documents plus one whose value is past `ignore_above`.
+    fn issue66_docs() -> Vec<serde_json::Value> {
+        vec![
+            serde_json::json!({"role": "tech_admin", "n": 1, "print_status": "printed", "tag": "Foo-Bar_baz"}),
+            serde_json::json!({"role": "super_admin", "n": 2, "print_status": "not printed", "tag": "x"}),
+            serde_json::json!({"role": "a".repeat(rsearch_index::KEYWORD_IGNORE_ABOVE + 1)}),
+        ]
+    }
+
+    /// Every expectation here was taken from OpenSearch 3.6 running the
+    /// same documents in a dynamically mapped index (issue #66).
+    #[test]
+    fn dynamic_fields_match_opensearch_semantics() {
+        let docs = issue66_docs();
+        let long = "a".repeat(rsearch_index::KEYWORD_IGNORE_ABOVE + 1);
+        let cases: Vec<(serde_json::Value, usize)> = vec![
+            // term is unanalyzed against standard-analyzer tokens: `_` joins.
+            (serde_json::json!({"term": {"role": "tech_admin"}}), 1),
+            (serde_json::json!({"term": {"role": "super_admin"}}), 1),
+            (serde_json::json!({"term": {"role": "Tech_Admin"}}), 0),
+            (serde_json::json!({"term": {"role": "admin"}}), 0),
+            (serde_json::json!({"term": {"role": "tech"}}), 0),
+            // A text-field term still matches a token inside a longer value.
+            (serde_json::json!({"term": {"print_status": "printed"}}), 2),
+            // `.keyword` is the exact value.
+            (serde_json::json!({"term": {"print_status.keyword": "printed"}}), 1),
+            (serde_json::json!({"term": {"role.keyword": "tech_admin"}}), 1),
+            (serde_json::json!({"term": {"role.keyword": {"value": "tech_admin"}}}), 1),
+            (serde_json::json!({"term": {"role.keyword": "Tech_Admin"}}), 0),
+            (serde_json::json!({"terms": {"role.keyword": ["tech_admin", "x"]}}), 1),
+            // match analyzes; on `.keyword` the whole text is one term.
+            (serde_json::json!({"match": {"role": "Tech_Admin"}}), 1),
+            (serde_json::json!({"match": {"role.keyword": "tech_admin"}}), 1),
+            (serde_json::json!({"match": {"role.keyword": "Tech_Admin"}}), 0),
+            (serde_json::json!({"match_phrase": {"print_status": "not printed"}}), 1),
+            (serde_json::json!({"match_phrase": {"print_status.keyword": "not printed"}}), 1),
+            // `-` splits, `_` joins, everything lowercases.
+            (serde_json::json!({"term": {"tag": "foo"}}), 1),
+            (serde_json::json!({"term": {"tag": "bar_baz"}}), 1),
+            // prefix / wildcard on tokens vs the exact value.
+            (serde_json::json!({"prefix": {"role": "tech"}}), 1),
+            (serde_json::json!({"prefix": {"role.keyword": "tech"}}), 1),
+            (serde_json::json!({"prefix": {"role.keyword": {"value": "TECH", "case_insensitive": true}}}), 1),
+            (serde_json::json!({"wildcard": {"role": "*admin"}}), 2),
+            (serde_json::json!({"wildcard": {"print_status": "*print*"}}), 2),
+            (serde_json::json!({"wildcard": {"print_status.keyword": "*print*"}}), 2),
+            (serde_json::json!({"wildcard": {"print_status.keyword": "not*"}}), 1),
+            // exists on `.keyword` excludes values past ignore_above.
+            (serde_json::json!({"exists": {"field": "role"}}), 3),
+            (serde_json::json!({"exists": {"field": "role.keyword"}}), 2),
+            (serde_json::json!({"range": {"role.keyword": {"gte": "s"}}}), 2),
+            (serde_json::json!({"range": {"role.keyword": {"gte": "tech_admin", "lte": "tech_admin"}}}), 1),
+            // ignore_above: no keyword value; the text field split the
+            // over-long word at max_token_length, so the whole is no term.
+            (serde_json::json!({"term": {"role.keyword": long}}), 0),
+            (serde_json::json!({"term": {"role": long}}), 0),
+            // Numbers have no `.keyword`; unknown fields match nothing.
+            (serde_json::json!({"term": {"n": 1}}), 1),
+            (serde_json::json!({"term": {"n.keyword": 1}}), 0),
+            (serde_json::json!({"term": {"nope": 1}}), 0),
+            // query_string: field syntax, bare terms, and `.keyword` paths.
+            (serde_json::json!({"query_string": {"query": "role.keyword:tech_admin"}}), 1),
+            (serde_json::json!({"query_string": {"query": "role.keyword:Tech_Admin"}}), 0),
+            (serde_json::json!({"query_string": {"query": "role:admin"}}), 0),
+            (serde_json::json!({"query_string": {"query": "admin"}}), 0),
+            (serde_json::json!({"query_string": {"query": "tech_admin"}}), 1),
+            (serde_json::json!({"query_string": {"query": "tech_admin", "fields": ["role.keyword"]}}), 1),
+            (serde_json::json!({"query_string": {"query": "\"not printed\"", "fields": ["print_status.keyword"]}}), 1),
+            (serde_json::json!({"bool": {"must_not": [{"term": {"role.keyword": "tech_admin"}}]}}), 2),
+        ];
+        for (query, expected) in cases {
+            assert_eq!(count_in(2, &docs, &query), expected, "{query}");
+        }
+    }
+
+    /// Splits written before schema version 2 have no `.keyword` view:
+    /// those clauses match nothing there rather than failing the request.
+    #[test]
+    fn keyword_clauses_are_empty_on_legacy_splits() {
+        let docs = issue66_docs();
+        for query in [
+            serde_json::json!({"term": {"role.keyword": "tech_admin"}}),
+            serde_json::json!({"terms": {"role.keyword": ["tech_admin"]}}),
+            serde_json::json!({"prefix": {"role.keyword": "tech"}}),
+            serde_json::json!({"prefix": {"role.keyword": {"value": "tech", "case_insensitive": true}}}),
+            serde_json::json!({"wildcard": {"role.keyword": "*admin"}}),
+            serde_json::json!({"exists": {"field": "role.keyword"}}),
+            serde_json::json!({"range": {"role.keyword": {"gte": "a"}}}),
+            serde_json::json!({"match": {"role.keyword": "tech_admin"}}),
+            serde_json::json!({"query_string": {"query": "tech_admin", "fields": ["role.keyword"]}}),
+            serde_json::json!({"query_string": {"query": "role.keyword:tech_admin"}}),
+        ] {
+            assert_eq!(count_in(1, &docs, &query), 0, "{query}");
+        }
+        // The legacy tokenizer is still used to read legacy splits.
+        assert_eq!(count_in(1, &docs, &serde_json::json!({"match": {"role": "admin"}})), 2);
+    }
+
+    #[test]
+    fn keyword_paths_rewrite_only_in_field_position() {
+        let s = schema();
+        assert_eq!(
+            rewrite_keyword_paths(&s, "role.keyword:x AND (city.keyword:y OR -zip.keyword:z)"),
+            "_dynamic_raw.role:x AND (_dynamic_raw.city:y OR -_dynamic_raw.zip:z)"
+        );
+        // Not a field position, a mapped field, or a bare value: untouched.
+        assert_eq!(rewrite_keyword_paths(&s, "find role.keyword here"), "find role.keyword here");
+        assert_eq!(rewrite_keyword_paths(&s, "service.keyword:api"), "service.keyword:api");
+        // Aggregations on `.keyword` read the raw field's fast column.
+        let aggs = rewrite_agg_fields(&s, &serde_json::json!({"r": {"terms": {"field": "role.keyword"}}}));
+        assert_eq!(aggs["r"]["terms"]["field"], "_dynamic_raw.role");
+        let aggs = rewrite_agg_fields(&s, &serde_json::json!({"r": {"terms": {"field": "role"}}}));
+        assert_eq!(aggs["r"]["terms"]["field"], "_dynamic.role");
     }
 
     #[test]

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -4,7 +4,7 @@
 //! the lock connection; kill the leader and another control node takes
 //! over on its next attempt.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -53,6 +53,10 @@ pub struct ControlPlane {
     /// healthy steady-state ticks don't pay a full-table scan every 15s.
     repair_scan: std::sync::Mutex<RepairScanState>,
     compaction: std::sync::Mutex<CompactionState>,
+    /// Splits whose schema-upgrade rewrite failed, with the time of the
+    /// failure: skipped for a while so one bad split can't consume the
+    /// per-tick budget forever.
+    schema_upgrade_failed: std::sync::Mutex<HashMap<String, std::time::Instant>>,
     /// Round-robin cursor for the merge job (#60): the stream_id last
     /// selected for a merge, so the next tick starts past it. In-memory
     /// only — fairness only needs to hold across one leader's consecutive
@@ -125,6 +129,7 @@ impl ControlPlane {
             metrics,
             repair_scan: std::sync::Mutex::new(RepairScanState::default()),
             compaction: std::sync::Mutex::new(CompactionState::default()),
+            schema_upgrade_failed: std::sync::Mutex::new(HashMap::new()),
             merge_cursor: std::sync::atomic::AtomicI64::new(0),
         })
     }
@@ -181,6 +186,9 @@ impl ControlPlane {
         }
         if settled && let Err(e) = self.compaction_job().await {
             error!(error = %e, "compaction job failed");
+        }
+        if settled && let Err(e) = self.schema_upgrade_job().await {
+            error!(error = %e, "schema upgrade job failed");
         }
         if let Err(e) = self.tombstone_purge_job().await {
             error!(error = %e, "tombstone purge failed");
@@ -752,6 +760,7 @@ impl ControlPlane {
                 seq_min: packaged.meta.seq_min,
                 seq_max: packaged.meta.seq_max,
                 tombstone_seq_applied: applied_through,
+                schema_version: packaged.meta.schema_version as i32,
             })
             .await?;
         self.metastore
@@ -894,6 +903,76 @@ impl ControlPlane {
         if let Err(e) = step.await {
             warn!(split_id = %split.split_id, error = %e, "compaction step failed");
         }
+    }
+
+    /// Rewrite published splits built under a layout older than
+    /// `CURRENT_SCHEMA_VERSION` (issue #66): after an upgrade the corpus
+    /// converges on one analyzer and every split gains the `.keyword`
+    /// view without operator action. Bounded per tick, newest data first.
+    /// A split whose rewrite fails is skipped for a while so it cannot
+    /// pin the whole budget every tick.
+    async fn schema_upgrade_job(&self) -> anyhow::Result<()> {
+        const RETRY_AFTER: Duration = Duration::from_secs(3600);
+        let budget = self.config.schema_upgrade_splits_per_tick;
+        if budget <= 0 {
+            return Ok(());
+        }
+        let current = rsearch_index::CURRENT_SCHEMA_VERSION as i32;
+        let skipped: Vec<String> = {
+            let mut failed = self.schema_upgrade_failed.lock().unwrap();
+            failed.retain(|_, at| at.elapsed() < RETRY_AFTER);
+            failed.keys().cloned().collect()
+        };
+        let candidates = self
+            .metastore
+            .splits_below_schema_version(current, budget + skipped.len() as i64)
+            .await?;
+        let mut streams: HashMap<i64, Option<rsearch_metastore::StreamRecord>> = HashMap::new();
+        let mut done = 0;
+        for split in candidates.iter().filter(|s| !skipped.contains(&s.split_id)) {
+            if done >= budget {
+                break;
+            }
+            done += 1;
+            let stream = match streams.entry(split.stream_id) {
+                std::collections::hash_map::Entry::Occupied(e) => e.get().clone(),
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    let fetched = match self.metastore.get_stream_by_id(split.stream_id).await {
+                        Ok(stream) => Some(stream),
+                        Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => None,
+                        Err(e) => return Err(e.into()),
+                    };
+                    e.insert(fetched).clone()
+                }
+            };
+            let Some(stream) = stream else { continue };
+            let step = async {
+                let tombstones = self.stream_tombstones(&stream).await?;
+                info!(
+                    stream = %stream.name,
+                    split_id = %split.split_id,
+                    from_version = split.schema_version,
+                    to_version = current,
+                    docs = split.doc_count,
+                    "rewriting split to the current schema version"
+                );
+                self.rebuild_splits(&stream, &[split], &tombstones).await?;
+                self.metrics
+                    .schema_upgrades
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Ok::<_, anyhow::Error>(())
+            };
+            // Most likely the split was merged or deleted under us; a
+            // persistent failure (unreadable split) is retried later.
+            if let Err(e) = step.await {
+                warn!(split_id = %split.split_id, error = %e, "schema upgrade step failed");
+                self.schema_upgrade_failed
+                    .lock()
+                    .unwrap()
+                    .insert(split.split_id.clone(), std::time::Instant::now());
+            }
+        }
+        Ok(())
     }
 
     /// Purge tombstones no split can still need (see
@@ -1137,6 +1216,7 @@ mod tests {
             seq_min: None,
             seq_max: None,
             tombstone_seq_applied: 0,
+            schema_version: 0,
         }
     }
 

--- a/crates/rsearch-server/src/metrics.rs
+++ b/crates/rsearch-server/src/metrics.rs
@@ -31,6 +31,8 @@ pub struct ControlMetrics {
     pub compactions: AtomicU64,
     /// Documents physically removed by compaction rewrites.
     pub compacted_docs: AtomicU64,
+    /// Splits rewritten from an older layout version to the current one.
+    pub schema_upgrades: AtomicU64,
     /// Tombstone rows purged from the metastore.
     pub tombstones_purged: AtomicU64,
     /// Tombstone rows pending (as of the last compaction scan).
@@ -188,6 +190,12 @@ pub async fn metrics(State(state): State<AppState>) -> Response {
             "rsearch_compacted_docs_total",
             "Document versions physically removed by compaction.",
             control.compacted_docs.load(Ordering::Relaxed),
+        );
+        counter(
+            &mut out,
+            "rsearch_schema_upgrades_total",
+            "Splits rewritten from an older layout version to the current one.",
+            control.schema_upgrades.load(Ordering::Relaxed),
         );
         gauge(
             &mut out,


### PR DESCRIPTION
Fixes #66.

## Problem
`_dynamic` was indexed with tantivy's default tokenizer, which splits on every non-alphanumeric character. `tech_admin` indexed as `tech` + `admin`, so `term role=tech_admin` returned 0 and `term role=admin` returned everything.

## Change: schema version 2
- **Standard analyzer.** New `standard` tokenizer (UAX#29 word breaks via unicode-segmentation: `_` joins, `-` splits; punctuation-only tokens dropped; 255-char max token length; lowercased). Used for mapped `text` fields and `_dynamic` strings. Registered on every index open/create site.
- **`.keyword` sub-field.** New `_dynamic_raw` JSON field (raw tokenizer, fast) holds each unmapped string ≤ 256 chars (OpenSearch's dynamic `ignore_above`), preserving nesting. `term`, `terms`, `range`, `prefix`, `wildcard`, `exists`, `match`, `match_phrase`, `query_string` (both `fields` and `path.keyword:` syntax) and aggregations on `<path>.keyword` resolve to it. Appended last so existing field ordinals are unchanged.
- **Legacy splits (v0/v1)** keep their old tokenizer for match/query_string analysis and have no raw field: `.keyword` clauses match nothing there instead of erroring, as an unmapped sub-field does in OpenSearch.
- Aggregations on the bare path stay accepted (superset of OpenSearch, which rejects text-field aggs) so Grafana/Loki users keep working.

## Background schema upgrade
The control leader rewrites published splits whose recorded layout version is below the current one, newest data first, `control.schema_upgrade_splits_per_tick` per tick (default 2, 0 disables), via the same single-split rebuild compaction uses. Failed rewrites are skipped for an hour. `rsearch_schema_upgrades_total` counts them.

Migration `20260903203230_split_schema_version`: `splits.schema_version INTEGER NOT NULL DEFAULT 0` plus a partial index on published rows. Existing rows default to 0, so every pre-existing split is a candidate, which is correct. Applied and verified on the dev database.

## Verification
- `dynamic_fields_match_opensearch_semantics`: 45 query/count pairs, every expected count taken from OpenSearch 3.6 on the same documents in a dynamically mapped index (including `term print_status=printed` matching "not printed" on the text field, which OpenSearch does too).
- Tokenizer unit tests, `ignore_above` projection tests, legacy-split no-match test, `.keyword` query-string rewrite test.
- Postgres integration tests (`--ignored`, against the dev DB): 10 passed, including the new `splits_below_schema_version` ordering test.
- `cargo check --workspace --all-targets` clean; `cargo test --workspace` all passing.

## Upgrade notes (also in README)
- New splits record tokenizer `standard`; an older binary can't run match/query_string against them. Upgrade search nodes before ingest/control nodes, or stop-all/start-all. Treat as forward-only.
- Old splits keep old tokens and no `.keyword` until the upgrade pass rewrites them; mixed results are possible in that window.
- Disk grows for string-heavy streams: a second inverted index plus a fast column for short strings.
- Should ship as a minor version (v0.5.0): index format change.

## Not in this PR
- `GET /{index}/_mapping` still lists only declared fields (#76).
- `sort` on `.keyword` / mapped keyword and numeric fields (#77).
