### PR TITLE
Release v0.5.0: OpenSearch field-semantics parity + the fixes v0.4.x missed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.5.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.4.1" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.4.1" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.4.1" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.4.1" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.4.1" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.4.1" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.5.0" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.5.0" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.5.0" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.5.0" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.5.0" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.5.0" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }

--- a/tests/cluster/run-document-mode-test.sh
+++ b/tests/cluster/run-document-mode-test.sh
@@ -21,6 +21,10 @@ cleanup() { [ -n "$PID" ] && kill -9 "$PID" 2>/dev/null || true; }
 trap cleanup EXIT
 
 set -a; source .env; set +a
+# Merging is disabled (both merge knobs 0: the target is the larger of
+# the two, and no split is smaller than 0 bytes) so the compaction job,
+# not a merge, is what makes deletes physical — the assertion below
+# checks for its log line.
 # Point the node at a dedicated test database when .env's DATABASE_URL
 # is a shared dev instance (the table wipe below is destructive).
 DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
@@ -38,6 +42,7 @@ env DATABASE_URL="$DATABASE_URL" \
   RSEARCH_INGEST__DOCUMENT_MAX_BATCH_SECS=1 \
   RSEARCH_INGEST__BALANCE_BULK=false \
   RSEARCH_CONTROL__INTERVAL_SECS=2 \
+  RSEARCH_CONTROL__MERGE_TARGET_MB=0 \
   RSEARCH_CONTROL__MERGE_MIN_MB=0 \
   RSEARCH_CONTROL__GC_GRACE_SECS=2 \
   RSEARCH_CONTROL__COMPACT_MAX_AGE_SECS=5 \


### PR DESCRIPTION
Minor release: index format change (schema version 2) for OpenSearch
field-semantics parity, plus the fixes that v0.4.0/v0.4.1 were meant to
carry. Not yet published to crates.io: the registry is still at 0.4.0.

## Highlights

- **OpenSearch dynamic-mapping parity (#66, PR #75).** Unmapped strings
  and mapped `text` fields are analyzed with the `standard` analyzer
  (Unicode word breaks: `tech_admin` is one token, `Foo-Bar` is two,
  lowercased). Every unmapped string of at most 256 characters also gets
  a `<path>.keyword` exact-value sub-field, usable in `term`, `terms`,
  `range`, `prefix`, `wildcard`, `exists`, `match`, `query_string` and
  aggregations. 45 query/count expectations verified against OpenSearch 3.6.
- **Background schema upgrade.** The control leader rewrites splits
  written under the old layout (`control.schema_upgrade_splits_per_tick`,
  default 2, newest data first; `rsearch_schema_upgrades_total`). An
  upgraded cluster converges without operator action.
- **`wildcard` query actually shipped (#53, #68, PR #69).** It was merged
  in August into an already-merged base branch and never reached main;
  v0.4.0 and v0.4.1 were cut without it.
- **Unsupported `sort` fields return 400 (#67, PR #70)** instead of a 200
  in timestamp order that also poisoned `search_after` cursors.

## Upgrade notes

- Metastore migration `20260903203230_split_schema_version` runs at
  startup (adds `splits.schema_version`, default 0).
- New splits record the `standard` tokenizer, which a pre-0.5 binary
  cannot resolve for `match`/`query_string`. Upgrade search nodes before
  ingest and control nodes, or stop all then start all. Forward-only.
- Until the upgrade pass has rewritten old splits, the same query can
  see old-tokenizer results from them and `.keyword` clauses match
  nothing there.
- Disk use grows on string-heavy streams: a second inverted index and a
  fast column for short strings.

## Follow-ups filed

- #76 `_mapping` should report discovered dynamic fields as text + keyword
- #77 sort on keyword, numeric, date and `.keyword` fields

## Pre-flight (RELEASING.md), run on this branch

| Check | Result |
|---|---|
| `cargo check --workspace --all-targets` with `-D warnings` | clean |
| `cargo test --workspace` | all passing |
| `cargo deny check bans licenses` | bans ok, licenses ok |
| `sqlx migrate run` against dev Postgres | applied `20260903203230_split_schema_version` |
| `cargo test --workspace -- --include-ignored` (Postgres + MinIO) | all passing, incl. 10 metastore_pg and 2 s3_minio |
| `CC=clang cargo build --release -p rsearch-server` | ok |
| `run-document-mode-test.sh` | PASS (after the script fix in this PR, see below) |
| `run-replicated-test.sh` | PASS |
| `run-cluster-test.sh` (MinIO topology) | PASS |
| `run-ha-compose-test.sh` | not run: it wipes the live `rsearch-ha` cluster on this host |
| `cargo package --no-verify -p rsearch-common` | ok; dependents can only be packaged once their 0.5.0 deps are on crates.io |

Notes from the run:
- The document-mode script has been failing since the merge-target change on 2026-08-21: `merge_min_mb=0` no longer disables merging, so a merge applied the tombstones before compaction and the "compacting split" assertion failed. Fixed here by also setting `merge_target_mb=0`.
- `run-cluster-test.sh` binds 127.0.0.1:9211, which the local `pvitl-rsearch` container holds; it passed with its ports shifted. Fine on a clean host.
- The repo is not rustfmt-clean (48 files); left untouched.

## To publish (not done, needs the go-ahead)

`cargo publish` in RELEASING.md order (common, storage, index, metastore, ingest, search, server), then tag `v0.5.0` on the merge commit and create the GitHub release from these notes. Note crates.io is still at 0.4.0: v0.4.1 was tagged but never published.
