### PR TITLE
OpenSearch compatibility: DELETE index, scroll, PUT _mapping, _count, dynamic-field mapping, field sorting (v0.6.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2463,11 +2463,12 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
+ "uuid",
 ]
 
 [[package]]
 name = "rsearch-storage"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.5.0" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.5.0" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.5.0" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.5.0" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.5.0" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.5.0" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.6.0" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.6.0" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.6.0" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.6.0" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.6.0" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.6.0" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ and IMDS are never touched.
 |------|-----------|
 | Ingest | `POST /_bulk`, `POST /{index}/_bulk` (`index`, `create`; plus `update`, `delete` on document-mode indices; `?refresh=true\|wait_for`) |
 | Documents | `PUT/POST/GET/HEAD/DELETE /{index}/_doc/{id}`, `POST /{index}/_doc`, `PUT/POST /{index}/_create/{id}`, `POST /{index}/_update/{id}`, `GET /{index}/_source/{id}`, `POST /{index}/_delete_by_query` (document-mode indices) |
-| Search | `POST /{index}/_search`, `POST /_msearch`, `GET /{index}/_mapping` |
-| Index admin | `PUT /{index}` (settings + mapping), `GET/HEAD /{index}`, `GET /{index}/_settings`, `GET /_cat/indices` |
+| Search | `POST/GET /{index}/_search` (`?scroll=` opens a scroll), `POST/GET /_search/scroll[/{id}]`, `DELETE /_search/scroll[/{id}\|/_all]`, `GET/POST /{index}/_count` (`?q=` or a `query` body), `POST /_msearch` |
+| Index admin | `PUT /{index}` (settings + mapping), `PUT /{index}/_mapping` (add fields), `GET /{index}/_mapping` (declared + dynamic fields), `DELETE /{index}` (name, list, or glob; `_all` and `*` refused), `GET/HEAD /{index}`, `GET /{index}/_settings`, `GET /_cat/indices` |
 | Cluster | `GET /`, `GET /_cluster/health`, `GET /_cat/nodes` |
 | Streams | `PUT /_rsearch/streams/{name}/retention`, routing rules under `/_rsearch/routing_rules` |
 | Alerts | `PUT/GET/DELETE /_rsearch/alerts[/{name}]` (scheduled query → webhook) |
@@ -246,27 +246,77 @@ Splits written before v0.5 (schema version 2) keep their old tokens and
 have no `.keyword` view until the control node rewrites them (see
 `control.schema_upgrade_splits_per_tick` below).
 
-Sorting is by timestamp only (`@timestamp`/`timestamp`/`_timestamp`,
-default descending); `_score` and `_doc` are accepted as no-ops. A
-`sort` on any other field is rejected with 400 rather than silently
-returning timestamp order.
+`GET /{index}/_mapping` (and `GET /{index}`) reports the declared
+properties plus every unmapped field the index's splits hold, typed the
+way OpenSearch's dynamic mapping would have typed it: strings as `text`
+with the `keyword` sub-field, integers `long`, fractions `float`,
+booleans `boolean`, nested objects as nested `properties`. Each split
+records its unmapped fields when it is built; splits from before this
+existed are inventoried once by the control leader (a bounded number per
+tick) and report nothing until then. `PUT /{index}/_mapping` adds fields
+to an existing index; a field that already exists must keep its type
+(400, as in OpenSearch), and `PUT /{index}` on an existing index is still
+accepted as an update rather than a 400.
 
-Deep pagination uses `search_after`: every hit's `sort` values are
-`[timestamp_millis, _seq]` — the `_seq` element is an implicit unique
-tiebreak appended to the timestamp sort, the way Elasticsearch's
-point-in-time search appends `_shard_doc` — and passing the last hit's
-values back as `search_after` (with `from` = 0) pages strictly past it.
-Each page costs only `size` per split, so it pages past
-`max_result_window`, which caps plain `from`/`size` at 10k. Totals and
-aggregations reflect the full query on every page, as in Elasticsearch;
-send `track_total_hits: false` on follow-up pages to skip recounting,
-which also lets splits wholly behind the cursor be skipped entirely.
-Always pass both sort values back: a one-element `[timestamp]` cursor
-pages strictly by timestamp and skips equal-timestamp documents at the
-page boundary (the classic ES footgun with a non-unique sort). Hits
-from legacy (pre-`_seq`) splits report `-1` as the tiebreak and page by
-timestamp only there; merging them to the current split format restores
-exact paging.
+Sorting works on any field OpenSearch can sort on: mapped `keyword`,
+`long`, `double`, `boolean`, `date` and `ip` fields, the timestamp
+(`@timestamp`/`timestamp`/`_timestamp`, the default order, newest
+first), dynamic `<path>.keyword` sub-fields and dynamic numeric or
+boolean paths, with several clauses in order. A sort on a `text` field
+(mapped, or a bare dynamic string) is a 400 with OpenSearch's fielddata
+message, and a field no document holds is a 400 (`No mapping found for
+[f] in order to sort on`) unless `unmapped_type` is given. Missing values
+sort last in either direction unless `missing: "_first"`, or a concrete
+`missing` value substitutes; `mode` accepts `min`/`max` (the default:
+multi-valued fields sort by their smallest value ascending and largest
+descending). Hits report OpenSearch's sort values, including its
+sentinels for a missing value (`null` for keywords, the extreme long,
+`"Infinity"`/`"-Infinity"` for doubles). `_score` and `_doc` are
+accepted as no-ops.
+
+Deep pagination uses `search_after`: every hit's `sort` values end with
+`[timestamp_millis, _seq]` — an implicit unique tiebreak appended to
+whatever was sorted on, the way Elasticsearch's point-in-time search
+appends `_shard_doc` — and passing the last hit's values back as
+`search_after` (with `from` = 0) pages strictly past it. Under a field
+sort the cursor may also be the field values alone, as an OpenSearch
+client would build it; a page of equal keys is then skipped at the
+boundary, exactly as there. Each page costs only `size` per split, so it
+pages past `max_result_window`, which caps plain `from`/`size` at 10k.
+Totals and aggregations reflect the full query on every page, as in
+Elasticsearch; send `track_total_hits: false` on follow-up pages to
+skip recounting, which also lets splits wholly behind a timestamp cursor
+be skipped entirely. Always pass every sort value back: a one-element
+`[timestamp]` cursor pages strictly by timestamp and skips
+equal-timestamp documents at the page boundary (the classic ES footgun
+with a non-unique sort). Hits from legacy (pre-`_seq`) splits report
+`-1` as the tiebreak and page by timestamp only there; merging them to
+the current split format restores exact paging.
+
+The scroll API is the same paging under the ES clients' `scroll`
+helpers: `POST /{index}/_search?scroll=1m` returns a `_scroll_id`,
+`POST /_search/scroll` with `{"scroll": "1m", "scroll_id": …}` returns
+the next page (the id stays the same; `hits.total` is the first page's
+count; aggregations come with the first page only), and `DELETE
+/_search/scroll` with `{"scroll_id": …}` (or `/_all`) frees it. A scroll
+context is a row in the metastore — the original search plus the last
+page's cursor — so it continues on any search node and expires after its
+keep-alive (up to `1d`). `from` and `search_after` are refused in a
+scroll context, an expired or freed id is a 404
+(`search_context_missing_exception`), and `sort: ["_doc"]` is served by
+the stable (timestamp, `_seq`) sequence.
+
+`DELETE /{index}` retires an index immediately: its splits leave the
+published set, its name is free to re-create at once (the drop half of a
+drop-and-rebuild reindex), and the control leader reclaims storage after
+`control.gc_grace_secs` and then drops the row. The path is an index
+expression — a name (404 if missing), a comma-separated list, or globs
+(a glob matching nothing is acknowledged); `_all` and a bare `*` are
+refused. A stream-scoped key may delete only indices inside its scope,
+whatever the expression expands to. Documents still buffered on an
+ingest node when the index is deleted are flushed into the re-created
+index, or re-create it, the way a `_bulk` to a missing index always has;
+other nodes forget the old index within their 10-second stream caches.
 
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,13 @@ multi-valued fields sort by their smallest value ascending and largest
 descending). Hits report OpenSearch's sort values, including its
 sentinels for a missing value (`null` for keywords, the extreme long,
 `"Infinity"`/`"-Infinity"` for doubles). `_score` and `_doc` are
-accepted as no-ops.
+accepted as no-ops. Write one field per sort entry: a single object
+naming several fields is refused with 400, because JSON object order
+does not survive parsing and the clauses could not be applied in the
+order written. Dynamic fields become sortable as their splits' field
+inventories are recorded — immediately for splits written by 0.6, and
+for older splits once the control leader's backfill has reached them
+(20 splits per tick).
 
 Deep pagination uses `search_after`: every hit's `sort` values end with
 `[timestamp_millis, _seq]` — an implicit unique tiebreak appended to
@@ -301,7 +307,11 @@ count; aggregations come with the first page only), and `DELETE
 /_search/scroll` with `{"scroll_id": …}` (or `/_all`) frees it. A scroll
 context is a row in the metastore — the original search plus the last
 page's cursor — so it continues on any search node and expires after its
-keep-alive (up to `1d`). `from` and `search_after` are refused in a
+keep-alive (up to `1d`). It is a replay from the cursor, not a snapshot:
+documents written or updated while a scroll is open can appear on a later
+page, whereas OpenSearch's scroll pins the index as it was opened.
+A stream-scoped key can only continue or free scrolls on its own streams
+(`/_all` frees just those). `from` and `search_after` are refused in a
 scroll context, an expired or freed id is a 404
 (`search_context_missing_exception`), and `sort: ["_doc"]` is served by
 the stable (timestamp, `_seq`) sequence.
@@ -314,9 +324,11 @@ expression — a name (404 if missing), a comma-separated list, or globs
 (a glob matching nothing is acknowledged); `_all` and a bare `*` are
 refused. A stream-scoped key may delete only indices inside its scope,
 whatever the expression expands to. Documents still buffered on an
-ingest node when the index is deleted are flushed into the re-created
-index, or re-create it, the way a `_bulk` to a missing index always has;
-other nodes forget the old index within their 10-second stream caches.
+ingest node when the index is deleted die with it, as in OpenSearch (the
+node logs how many it dropped); a batch that races the deletion is never
+published under the retired index, and an index re-created under the
+same name keeps the mode and mapping it was re-created with. Other
+nodes forget the old index within their 10-second stream caches.
 
 Inputs beyond HTTP: syslog (RFC 5424 + 3164, UDP/TCP, optional TLS) and
 GELF (TCP), each routable to a stream and subject to routing rules.

--- a/crates/rsearch-index/src/builder.rs
+++ b/crates/rsearch-index/src/builder.rs
@@ -128,6 +128,20 @@ impl SplitBuilder {
         self.writer.commit()?;
         self.writer.wait_merging_threads()?;
 
+        // Inventory the unmapped paths while the index is open: a
+        // skip-scan of the `_dynamic` term dictionary, proportional to the
+        // number of distinct paths. Recorded in the footer and the
+        // metastore so `_mapping` never has to open the split for it.
+        let dynamic_fields = {
+            let reader = self
+                .index
+                .reader_builder()
+                .reload_policy(tantivy::ReloadPolicy::Manual)
+                .try_into()?;
+            let searcher = reader.searcher();
+            crate::dynamic_paths::dynamic_field_types(&searcher, self.converter.schema().dynamic)?
+        };
+
         let index_dir = self.work_dir.path().join("index");
         // Ensure directory contents are fully flushed before bundling.
         drop(self.index);
@@ -142,6 +156,7 @@ impl SplitBuilder {
             schema_version: self.converter.schema().schema_version,
             seq_min: self.converter.schema().seq.map(|_| self.min_seq),
             seq_max: self.converter.schema().seq.map(|_| self.max_seq),
+            dynamic_fields: Some(dynamic_fields),
         };
 
         let file_path = self.work_dir.path().join(format!("{}.split", self.split_id));

--- a/crates/rsearch-index/src/dynamic_paths.rs
+++ b/crates/rsearch-index/src/dynamic_paths.rs
@@ -2,11 +2,14 @@
 //!
 //! A bare `query_string` must search every field, but Tantivy's parser
 //! cannot fan a term across the paths of a JSON field — each path has to
-//! be named explicitly (issue #42). This module lists the string-valued
-//! paths a segment actually contains so the query layer can do that.
+//! be named explicitly (issue #42). This module lists the paths a segment
+//! actually contains, with the value types seen under each, so the query
+//! layer can do that and `GET /{index}/_mapping` can report unmapped
+//! fields the way OpenSearch's dynamic mapping does (issue #76).
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
+use serde::{Deserialize, Serialize};
 use tantivy::schema::{Field, Type};
 use tantivy::{Searcher, TantivyError};
 
@@ -16,19 +19,59 @@ use tantivy::{Searcher, TantivyError};
 const JSON_PATH_SEGMENT_SEP: u8 = 1;
 const JSON_END_OF_PATH: u8 = 0;
 
-/// List every JSON path in `dynamic` that holds at least one string term,
-/// in query-parser form: segments joined with `.`, literal dots escaped
-/// as `\.`. Sorted and deduplicated across segments.
+/// A JSON value type seen under a dynamic path, named the way the
+/// mapping reports it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DynamicType {
+    /// A JSON string: `text` with a `.keyword` sub-field in the mapping.
+    String,
+    /// A JSON integer (Tantivy i64 or u64 term).
+    Long,
+    /// A JSON number with a fraction.
+    Double,
+    /// A JSON boolean.
+    Boolean,
+    /// A date term (never written by rSearch's converter today; reported
+    /// faithfully if a split holds one).
+    Date,
+}
+
+impl DynamicType {
+    /// The Tantivy term-type codes that map onto this type.
+    fn codes(self) -> &'static [Type] {
+        match self {
+            DynamicType::String => &[Type::Str],
+            DynamicType::Long => &[Type::I64, Type::U64],
+            DynamicType::Double => &[Type::F64],
+            DynamicType::Boolean => &[Type::Bool],
+            DynamicType::Date => &[Type::Date],
+        }
+    }
+
+    const ALL: [DynamicType; 5] = [
+        DynamicType::String,
+        DynamicType::Long,
+        DynamicType::Double,
+        DynamicType::Boolean,
+        DynamicType::Date,
+    ];
+}
+
+/// Dynamic path (query-parser form) → the value types seen under it.
+pub type DynamicFields = BTreeMap<String, BTreeSet<DynamicType>>;
+
+/// List every JSON path in `dynamic` with the value types it holds, in
+/// query-parser form: segments joined with `.`, literal dots escaped as
+/// `\.`. Sorted and deduplicated across segments.
 ///
-/// Skip-scans the term dictionary: one seek per (path, probe) pair rather
-/// than a walk of every term, so cost is proportional to the number of
-/// distinct paths, not the number of terms. Call from a blocking context
-/// (term dictionaries may be fetched from storage on first touch).
-pub fn dynamic_string_paths(
-    searcher: &Searcher,
-    dynamic: Field,
-) -> tantivy::Result<Vec<String>> {
-    let mut paths = BTreeSet::new();
+/// Skip-scans the term dictionary: one seek per (path, type probe) pair
+/// rather than a walk of every term, so cost is proportional to the
+/// number of distinct paths, not the number of terms. Call from a
+/// blocking context (term dictionaries may be fetched from storage on
+/// first touch).
+pub fn dynamic_field_types(searcher: &Searcher, dynamic: Field) -> tantivy::Result<DynamicFields> {
+    let mut paths: DynamicFields = BTreeMap::new();
     for segment in searcher.segment_readers() {
         let inverted = segment.inverted_index(dynamic)?;
         let dict = inverted.terms();
@@ -50,16 +93,22 @@ pub fn dynamic_string_paths(
             let path = key[..end].to_vec();
             drop(stream);
             // Terms of one path sort by value type code after the 0x00, so
-            // the first term seen may be numeric while string terms for the
-            // same path sit further on — probe for the string block directly.
+            // the first term seen tells only one type — probe for each
+            // type's block directly.
             let mut probe = path.clone();
             probe.push(JSON_END_OF_PATH);
-            probe.push(Type::Str.to_code());
-            let mut probe_stream = dict.range().ge(&probe).into_stream()?;
-            if probe_stream.advance() && probe_stream.key().starts_with(&probe) {
-                paths.insert(decode_path(&path));
+            let probe_len = probe.len();
+            for ty in DynamicType::ALL {
+                for code in ty.codes() {
+                    probe.truncate(probe_len);
+                    probe.push(code.to_code());
+                    let mut probe_stream = dict.range().ge(&probe).into_stream()?;
+                    if probe_stream.advance() && probe_stream.key().starts_with(&probe) {
+                        paths.entry(decode_path(&path)).or_default().insert(ty);
+                        break;
+                    }
+                }
             }
-            drop(probe_stream);
             // 0x00 (end-of-path) sorts below 0x01, so this bound skips the
             // rest of this path's terms while keeping nested child paths
             // (`path ++ 0x01 ++ …`) in range for the next iteration.
@@ -68,7 +117,22 @@ pub fn dynamic_string_paths(
             bound = Some(next);
         }
     }
-    Ok(paths.into_iter().collect())
+    Ok(paths)
+}
+
+/// The paths holding at least one string term (see
+/// [`dynamic_field_types`]).
+pub fn dynamic_string_paths(searcher: &Searcher, dynamic: Field) -> tantivy::Result<Vec<String>> {
+    Ok(string_paths(&dynamic_field_types(searcher, dynamic)?))
+}
+
+/// The string-valued paths of a [`DynamicFields`] inventory.
+pub fn string_paths(fields: &DynamicFields) -> Vec<String> {
+    fields
+        .iter()
+        .filter(|(_, types)| types.contains(&DynamicType::String))
+        .map(|(path, _)| path.clone())
+        .collect()
 }
 
 /// Encoded path bytes → query-parser path: segments joined with `.`,
@@ -87,8 +151,7 @@ mod tests {
     use super::*;
     use crate::mapping::{IndexMapping, MappedSchema};
 
-    #[test]
-    fn lists_string_paths_only() {
+    fn index_with(docs: &[serde_json::Value]) -> (MappedSchema, tantivy::Index) {
         let schema = MappedSchema::build(
             IndexMapping::from_json(&serde_json::json!({
                 "properties": {"message": {"type": "text"}}
@@ -98,19 +161,44 @@ mod tests {
         let index = schema.create_in_ram();
         let mut writer = index.writer(15_000_000).unwrap();
         let converter = crate::document::DocumentConverter::new(schema.clone());
-        for doc in [
-            serde_json::json!({"message": "mapped stays out", "level": "info", "count": 7}),
-            serde_json::json!({"ctx": {"job": "cleanup"}, "log.level": "warn"}),
-        ] {
+        for doc in docs {
             let (doc, _) = converter
-                .convert(doc, tantivy::DateTime::from_timestamp_millis(0))
+                .convert(doc.clone(), tantivy::DateTime::from_timestamp_millis(0))
                 .unwrap();
             writer.add_document(doc).unwrap();
         }
         writer.commit().unwrap();
+        (schema, index)
+    }
+
+    #[test]
+    fn lists_string_paths_only() {
+        let (schema, index) = index_with(&[
+            serde_json::json!({"message": "mapped stays out", "level": "info", "count": 7}),
+            serde_json::json!({"ctx": {"job": "cleanup"}, "log.level": "warn"}),
+        ]);
         let reader = index.reader().unwrap();
         let paths = dynamic_string_paths(&reader.searcher(), schema.dynamic).unwrap();
         // `count` is numeric-only; `message` is mapped, not dynamic.
         assert_eq!(paths, vec!["ctx.job", "level", "log\\.level"]);
+    }
+
+    #[test]
+    fn reports_every_type_under_a_path() {
+        let (schema, index) = index_with(&[
+            serde_json::json!({"n": 7, "f": 1.5, "ok": true, "s": "x", "mixed": "a"}),
+            serde_json::json!({"n": -1, "mixed": 3, "neg": -5}),
+        ]);
+        let reader = index.reader().unwrap();
+        let fields = dynamic_field_types(&reader.searcher(), schema.dynamic).unwrap();
+        let types = |p: &str| fields[p].iter().copied().collect::<Vec<_>>();
+        assert_eq!(types("n"), vec![DynamicType::Long]);
+        assert_eq!(types("neg"), vec![DynamicType::Long]);
+        assert_eq!(types("f"), vec![DynamicType::Double]);
+        assert_eq!(types("ok"), vec![DynamicType::Boolean]);
+        assert_eq!(types("s"), vec![DynamicType::String]);
+        assert_eq!(types("mixed"), vec![DynamicType::String, DynamicType::Long]);
+        assert_eq!(fields.len(), 6);
+        assert_eq!(string_paths(&fields), vec!["mixed", "s"]);
     }
 }

--- a/crates/rsearch-index/src/lib.rs
+++ b/crates/rsearch-index/src/lib.rs
@@ -14,7 +14,7 @@ mod split_file;
 mod tokenizer;
 
 pub use builder::{PackagedSplit, SplitBuilder};
-pub use dynamic_paths::dynamic_string_paths;
+pub use dynamic_paths::{DynamicFields, DynamicType, dynamic_field_types, dynamic_string_paths, string_paths};
 pub use tantivy::DateTime;
 pub use cache::SplitCache;
 pub use reader::{ReadDoc, SplitReader};

--- a/crates/rsearch-index/src/reader.rs
+++ b/crates/rsearch-index/src/reader.rs
@@ -155,11 +155,22 @@ impl SplitReader {
         if let Some(paths) = self.dynamic_paths.get() {
             return Ok(paths);
         }
-        let paths = crate::dynamic_paths::dynamic_string_paths(
+        let paths = crate::dynamic_paths::string_paths(&self.dynamic_field_types()?);
+        Ok(self.dynamic_paths.get_or_init(|| paths))
+    }
+
+    /// The unmapped paths in this split and the value types under each:
+    /// from the footer when the split recorded them at build time, else a
+    /// skip-scan of the `_dynamic` term dictionary. Call from a blocking
+    /// context.
+    pub fn dynamic_field_types(&self) -> IndexResult<crate::dynamic_paths::DynamicFields> {
+        if let Some(fields) = &self.meta.split.dynamic_fields {
+            return Ok(fields.clone());
+        }
+        Ok(crate::dynamic_paths::dynamic_field_types(
             &self.reader.searcher(),
             self.schema.dynamic,
-        )?;
-        Ok(self.dynamic_paths.get_or_init(|| paths))
+        )?)
     }
 
     /// Visit every document — used by the merge/compaction jobs to

--- a/crates/rsearch-index/src/split_file.rs
+++ b/crates/rsearch-index/src/split_file.rs
@@ -54,6 +54,11 @@ pub struct SplitMeta {
     /// Highest `_seq` in the split; None when documents carry no ids.
     #[serde(default)]
     pub seq_max: Option<i64>,
+    /// Unmapped field paths present in `_dynamic` and the value types
+    /// seen under each (issue #76); absent in footers written before it
+    /// was recorded.
+    #[serde(default)]
+    pub dynamic_fields: Option<crate::dynamic_paths::DynamicFields>,
 }
 
 /// Full footer contents: bundled file map + split metadata.

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -605,7 +605,7 @@ const WORKER_IDLE_EXIT_SECS: u64 = 600;
 async fn stream_worker(
     inner: Arc<PipelineInner>,
     stream: String,
-    stream_id: i64,
+    mut stream_id: i64,
     document_mode: bool,
     schema: MappedSchema,
     mut rx: mpsc::Receiver<WorkerMsg>,
@@ -684,13 +684,30 @@ async fn stream_worker(
             },
         };
         if flush_now {
-            // Pick up mapping changes before building the split.
-            if let Ok(record) = inner.metastore.get_stream(&stream).await
-                && record.mapping != mapping_json
-            {
-                let mapping = IndexMapping::from_json(&record.mapping).unwrap_or_default();
-                schema = MappedSchema::build(mapping);
-                mapping_json = record.mapping;
+            // Re-resolve the stream before building the split: picks up
+            // mapping changes (PUT /{index}, PUT /{index}/_mapping), and a
+            // stream deleted and re-created under the same name (#71) gets
+            // its new id — a split published under the retired id would
+            // be swept away with it. A stream that is gone is re-created,
+            // the implicit creation `_bulk` always did for a first write.
+            let resolved = match inner.metastore.get_stream(&stream).await {
+                Ok(record) => Some(record),
+                Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => {
+                    inner.metastore.ensure_stream(&stream).await.ok()
+                }
+                Err(_) => None,
+            };
+            if let Some(record) = resolved {
+                if record.id != stream_id {
+                    info!(stream, old_id = stream_id, new_id = record.id, "stream re-created; worker rebound");
+                    stream_id = record.id;
+                    inner.stream_info.write().unwrap().remove(&stream);
+                }
+                if record.mapping != mapping_json {
+                    let mapping = IndexMapping::from_json(&record.mapping).unwrap_or_default();
+                    schema = MappedSchema::build(mapping);
+                    mapping_json = record.mapping;
+                }
             }
             flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
             for done in waiters.drain(..) {
@@ -891,6 +908,11 @@ async fn flush_inner(
             seq_max: packaged.meta.seq_max,
             tombstone_seq_applied: 0,
             schema_version: packaged.meta.schema_version as i32,
+            dynamic_fields: packaged
+                .meta
+                .dynamic_fields
+                .as_ref()
+                .map(|f| serde_json::to_value(f).unwrap_or(serde_json::Value::Null)),
         })
         .await
     {

--- a/crates/rsearch-ingest/src/pipeline.rs
+++ b/crates/rsearch-ingest/src/pipeline.rs
@@ -145,6 +145,10 @@ struct WorkItem {
     /// Document identity (`_id`, `_seq`).
     identity: DocIdentity,
     pos: WalPos,
+    /// The stream row the write was accepted against. A worker that is
+    /// rebound to a re-created stream (#71) drops items of the retired
+    /// one instead of publishing them into the new index.
+    stream_id: i64,
 }
 
 /// Ingest metrics counters (monotonic).
@@ -431,12 +435,14 @@ impl IngestPipeline {
         identity: DocIdentity,
         pos: WalPos,
     ) -> IngestResult<()> {
+        let stream_id = self.stream_info(stream).await?.id;
         let tx = self.worker_for(stream).await?;
         let size = source.len() as u64;
         match tx.try_send(WorkerMsg::Doc(WorkItem {
             source,
             identity,
             pos,
+            stream_id,
         })) {
             Ok(()) => {
                 self.note_enqueued(size);
@@ -511,6 +517,7 @@ impl IngestPipeline {
                 Ok(text) => Arc::from(text),
                 Err(_) => Arc::from(String::from_utf8_lossy(&record.doc).into_owned()),
             };
+            let stream_id = self.stream_info(&record.stream).await?.id;
             let tx = self.worker_for(&record.stream).await?;
             self.inner.metrics.queue_depth.fetch_add(1, Ordering::Relaxed);
             if tx
@@ -518,6 +525,7 @@ impl IngestPipeline {
                     source,
                     identity: DocIdentity::new(record.id, record.seq),
                     pos: record.pos,
+                    stream_id,
                 }))
                 .await
                 .is_err()
@@ -602,37 +610,53 @@ impl IngestPipeline {
 /// task + bounded queue + schema for the life of the process.
 const WORKER_IDLE_EXIT_SECS: u64 = 600;
 
+/// The stream a worker flushes into, re-resolved before every flush
+/// attempt (see [`flush`]).
+struct WorkerStream {
+    name: String,
+    id: i64,
+    document_mode: bool,
+    schema: MappedSchema,
+    mapping_json: Value,
+}
+
 async fn stream_worker(
     inner: Arc<PipelineInner>,
     stream: String,
-    mut stream_id: i64,
+    stream_id: i64,
     document_mode: bool,
     schema: MappedSchema,
     mut rx: mpsc::Receiver<WorkerMsg>,
 ) {
     let max_docs = inner.config.max_batch_docs.max(1);
-    let age_secs = if document_mode {
-        inner.config.document_max_batch_secs
-    } else {
-        inner.config.max_batch_secs
-    };
-    let max_age = Duration::from_secs(age_secs.max(1));
     let idle_exit = Duration::from_secs(WORKER_IDLE_EXIT_SECS);
     let mut buffer: Vec<WorkItem> = Vec::new();
     // Refresh waiters, answered after the next flush completes.
     let mut waiters: Vec<tokio::sync::oneshot::Sender<()>> = Vec::new();
     let mut deadline = tokio::time::Instant::now() + idle_exit;
-    // Re-resolved before each flush so a mapping change (PUT /{index})
-    // takes effect on the next split, not only after a restart (L7).
-    let mut schema = schema;
-    let mut mapping_json = schema.mapping.to_json();
+    let mapping_json = schema.mapping.to_json();
+    let mut target = WorkerStream {
+        name: stream.clone(),
+        id: stream_id,
+        document_mode,
+        schema,
+        mapping_json,
+    };
+    let batch_age = |document_mode: bool| {
+        let secs = if document_mode {
+            inner.config.document_max_batch_secs
+        } else {
+            inner.config.max_batch_secs
+        };
+        Duration::from_secs(secs.max(1))
+    };
 
     loop {
         let flush_now = tokio::select! {
             msg = rx.recv() => match msg {
                 Some(WorkerMsg::Doc(item)) => {
                     if buffer.is_empty() {
-                        deadline = tokio::time::Instant::now() + max_age;
+                        deadline = tokio::time::Instant::now() + batch_age(target.document_mode);
                     }
                     buffer.push(item);
                     buffer.len() >= max_docs
@@ -650,7 +674,7 @@ async fn stream_worker(
                 None => {
                     // Channel closed: final flush then exit.
                     if !buffer.is_empty() {
-                        flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+                        flush(&inner, &mut target, &mut buffer).await;
                     }
                     return;
                 }
@@ -672,7 +696,7 @@ async fn stream_worker(
                         }
                     }
                     if !buffer.is_empty() {
-                        flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+                        flush(&inner, &mut target, &mut buffer).await;
                     }
                     for done in waiters.drain(..) {
                         let _ = done.send(());
@@ -684,32 +708,7 @@ async fn stream_worker(
             },
         };
         if flush_now {
-            // Re-resolve the stream before building the split: picks up
-            // mapping changes (PUT /{index}, PUT /{index}/_mapping), and a
-            // stream deleted and re-created under the same name (#71) gets
-            // its new id — a split published under the retired id would
-            // be swept away with it. A stream that is gone is re-created,
-            // the implicit creation `_bulk` always did for a first write.
-            let resolved = match inner.metastore.get_stream(&stream).await {
-                Ok(record) => Some(record),
-                Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => {
-                    inner.metastore.ensure_stream(&stream).await.ok()
-                }
-                Err(_) => None,
-            };
-            if let Some(record) = resolved {
-                if record.id != stream_id {
-                    info!(stream, old_id = stream_id, new_id = record.id, "stream re-created; worker rebound");
-                    stream_id = record.id;
-                    inner.stream_info.write().unwrap().remove(&stream);
-                }
-                if record.mapping != mapping_json {
-                    let mapping = IndexMapping::from_json(&record.mapping).unwrap_or_default();
-                    schema = MappedSchema::build(mapping);
-                    mapping_json = record.mapping;
-                }
-            }
-            flush(&inner, &stream, stream_id, &schema, &mut buffer).await;
+            flush(&inner, &mut target, &mut buffer).await;
             for done in waiters.drain(..) {
                 let _ = done.send(());
             }
@@ -718,17 +717,56 @@ async fn stream_worker(
     }
 }
 
-async fn flush(
-    inner: &Arc<PipelineInner>,
-    stream: &str,
-    stream_id: i64,
-    schema: &MappedSchema,
-    buffer: &mut Vec<WorkItem>,
-) {
+/// What re-resolving the worker's stream found.
+enum Resolved {
+    /// The stream exists (possibly re-created or re-mapped since).
+    Live,
+    /// No stream by that name: it was deleted.
+    Deleted,
+    /// The metastore could not be asked; keep the current binding.
+    Unknown,
+}
+
+/// Re-resolve the stream by name before a flush attempt. Picks up
+/// mapping changes (PUT /{index}, PUT /{index}/_mapping); a stream
+/// deleted and re-created under the same name (#71) rebinds the worker
+/// to the new row — its id, mode and mapping — so the split is never
+/// published under the retired id, where the purge would sweep it away.
+async fn resolve_target(inner: &Arc<PipelineInner>, target: &mut WorkerStream) -> Resolved {
+    match inner.metastore.get_stream(&target.name).await {
+        Ok(record) => {
+            if record.id != target.id {
+                info!(
+                    stream = %target.name,
+                    old_id = target.id,
+                    new_id = record.id,
+                    "stream re-created; worker rebound"
+                );
+                target.id = record.id;
+                target.document_mode = record.is_document_mode();
+                inner.stream_info.write().unwrap().remove(&target.name);
+            }
+            if record.mapping != target.mapping_json {
+                let mapping = IndexMapping::from_json(&record.mapping).unwrap_or_default();
+                target.schema = MappedSchema::build(mapping);
+                target.mapping_json = record.mapping;
+            }
+            Resolved::Live
+        }
+        Err(rsearch_metastore::MetastoreError::StreamNotFound(_)) => Resolved::Deleted,
+        Err(e) => {
+            warn!(stream = %target.name, error = %e, "stream lookup failed before flush; keeping current binding");
+            Resolved::Unknown
+        }
+    }
+}
+
+async fn flush(inner: &Arc<PipelineInner>, target: &mut WorkerStream, buffer: &mut Vec<WorkItem>) {
     let mut batch = std::mem::take(buffer);
     let count = batch.len() as u64;
     inner.metrics.queue_depth.fetch_sub(count, Ordering::Relaxed);
     let positions: Vec<WalPos> = batch.iter().map(|item| item.pos).collect();
+    let stream = target.name.clone();
 
     // Retry the flush with capped backoff on transient errors (S3/DB
     // blips). Data is already WAL-durable, so an in-process retry recovers
@@ -740,11 +778,45 @@ async fn flush(
     let mut attempt = 0u64;
     loop {
         attempt += 1;
-        match flush_inner(inner, stream, stream_id, schema, batch).await {
+        // Every attempt re-resolves the stream: a DELETE /{index} that
+        // lands between stage and publish fails the publish (the staged
+        // row was marked for delete) and must not be retried under the
+        // retired id. A deleted index takes its buffered documents with
+        // it, as in OpenSearch; their WAL entries are confirmed so replay
+        // does not resurrect them.
+        if let Resolved::Deleted = resolve_target(inner, target).await {
+            inner.wal.confirm(&positions);
+            inner.stream_info.write().unwrap().remove(&stream);
+            warn!(stream, docs = count, "index deleted; buffered documents dropped");
+            return;
+        }
+        // Items accepted against a since-retired row (the index was
+        // deleted and re-created while they were buffered) die with it;
+        // only writes accepted against the new row are published.
+        let stale: Vec<WalPos> = batch
+            .iter()
+            .filter(|item| item.stream_id != target.id)
+            .map(|item| item.pos)
+            .collect();
+        if !stale.is_empty() {
+            batch.retain(|item| item.stream_id == target.id);
+            inner.wal.confirm(&stale);
+            warn!(
+                stream,
+                docs = stale.len(),
+                "index re-created; documents buffered for the deleted one dropped"
+            );
+            if batch.is_empty() {
+                return;
+            }
+        }
+        let live: Vec<WalPos> = batch.iter().map(|item| item.pos).collect();
+        match flush_inner(inner, &stream, target.id, &target.schema, batch).await {
             Ok(Some((split_id, indexed))) => {
-                inner.wal.confirm(&positions);
+                inner.wal.confirm(&live);
                 inner.metrics.docs_indexed.fetch_add(indexed, Ordering::Relaxed);
                 inner.metrics.splits_published.fetch_add(1, Ordering::Relaxed);
+                let count = live.len() as u64;
                 if indexed < count {
                     warn!(
                         stream,
@@ -759,8 +831,8 @@ async fn flush(
                 // Nothing in the batch was indexable. The docs are still
                 // processed: confirm their WAL entries so replay doesn't
                 // resurrect (and re-skip) them forever.
-                inner.wal.confirm(&positions);
-                warn!(stream, docs = count, "batch contained no indexable docs; dropped");
+                inner.wal.confirm(&live);
+                warn!(stream, docs = live.len(), "batch contained no indexable docs; dropped");
                 return;
             }
             Err((e, returned)) => {

--- a/crates/rsearch-metastore/migrations/20260904185239_stream_soft_delete.sql
+++ b/crates/rsearch-metastore/migrations/20260904185239_stream_soft_delete.sql
@@ -1,0 +1,10 @@
+-- Index deletion (issue #71). DELETE /{index} retires a stream without
+-- touching storage inline: its splits are marked for delete (the GC job
+-- removes the objects after the grace period, then the rows), and the
+-- stream row is renamed out of the way and stamped so the name is free
+-- for immediate re-creation. The control leader deletes the row once no
+-- split references it (splits and tombstones cascade).
+ALTER TABLE streams ADD COLUMN deleted_at TIMESTAMPTZ;
+
+-- The purge job's scan.
+CREATE INDEX idx_streams_deleted ON streams (deleted_at) WHERE deleted_at IS NOT NULL;

--- a/crates/rsearch-metastore/migrations/20260904185425_split_dynamic_fields.sql
+++ b/crates/rsearch-metastore/migrations/20260904185425_split_dynamic_fields.sql
@@ -1,0 +1,7 @@
+-- Per-split inventory of the unmapped (`_dynamic`) field paths and the
+-- JSON value types seen for each, e.g. {"role": ["string"], "n": ["long"]}
+-- (issue #76). GET /{index}/_mapping unions it across the stream's
+-- published splits to report dynamic fields the way OpenSearch does.
+-- NULL on splits registered before the column existed; the control
+-- leader backfills those by scanning each split's term dictionary once.
+ALTER TABLE splits ADD COLUMN dynamic_fields JSONB;

--- a/crates/rsearch-metastore/migrations/20260904190615_scroll_contexts.sql
+++ b/crates/rsearch-metastore/migrations/20260904190615_scroll_contexts.sql
@@ -1,0 +1,20 @@
+-- Scroll contexts (issue #72): the server-side state behind
+-- `_search?scroll=` / `_search/scroll`. Kept in the metastore rather than
+-- in a node's memory so a scroll opened on one search node continues on
+-- any other. A context is the original search (minus aggregations) plus
+-- the cursor of the last page served; each page is a search_after query.
+CREATE TABLE scroll_contexts (
+    id TEXT PRIMARY KEY,
+    stream TEXT NOT NULL,
+    -- the _search body the scroll was opened with (query, size, sort, …)
+    request JSONB NOT NULL,
+    -- the last served hit's `sort` values; NULL until a page has hits
+    cursor JSONB,
+    -- hits.total of the first page, reported unchanged on every page
+    total JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+-- The control leader's expiry sweep.
+CREATE INDEX idx_scroll_contexts_expires ON scroll_contexts (expires_at);

--- a/crates/rsearch-metastore/migrations/20260904194123_split_dynamic_fields_backfill_index.sql
+++ b/crates/rsearch-metastore/migrations/20260904194123_split_dynamic_fields_backfill_index.sql
@@ -1,0 +1,6 @@
+-- The dynamic-fields backfill scans for published splits without an
+-- inventory every control tick; a partial index keeps that O(backlog)
+-- instead of O(table), and empty once the backlog is done.
+CREATE INDEX idx_splits_dynamic_fields_missing
+    ON splits (time_end_millis DESC)
+    WHERE state = 'published' AND dynamic_fields IS NULL;

--- a/crates/rsearch-metastore/src/lib.rs
+++ b/crates/rsearch-metastore/src/lib.rs
@@ -11,6 +11,7 @@ mod locations;
 mod metastore;
 mod nodes;
 mod routing;
+mod scroll;
 mod tombstones;
 mod types;
 
@@ -18,6 +19,7 @@ pub use alerts::AlertRecord;
 pub use auth::{ApiKeyRecord, UserRecord};
 pub use control::CONTROL_LEADER_LOCK;
 pub use routing::RoutingRuleRecord;
+pub use scroll::ScrollRecord;
 pub use tombstones::{NewTombstone, StreamTombstoneStats, TombstoneRecord};
 
 pub use error::{MetastoreError, MetastoreResult};

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -8,7 +8,7 @@ use crate::types::{NewSplit, SplitRecord, SplitState, StreamMode, StreamRecord, 
 
 pub(crate) const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
      size_bytes, time_start_millis, time_end_millis, footer_len, created_by, \
-     seq_min, seq_max, tombstone_seq_applied, schema_version, dynamic_fields";
+     seq_min, seq_max, tombstone_seq_applied, schema_version";
 
 /// Postgres-backed metadata store shared by every node role: streams,
 /// splits, nodes, placement, auth, routing rules, and alerts. Cloning
@@ -138,6 +138,28 @@ impl Metastore {
             return Err(MetastoreError::StreamNotFound(name.to_string()));
         }
         Ok(())
+    }
+
+    /// Replace a stream's mapping only if it still equals `expected`
+    /// (compare-and-set, so concurrent PUT /{index}/_mapping merges never
+    /// overwrite each other's fields). `Ok(false)` = the mapping changed
+    /// underneath; re-read and merge again.
+    pub async fn update_stream_mapping_if(
+        &self,
+        name: &str,
+        expected: &serde_json::Value,
+        mapping: &serde_json::Value,
+    ) -> MetastoreResult<bool> {
+        let result = sqlx::query(
+            "UPDATE streams SET mapping = $3, updated_at = now()
+             WHERE name = $1 AND deleted_at IS NULL AND mapping = $2",
+        )
+        .bind(name)
+        .bind(expected)
+        .bind(mapping)
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected() == 1)
     }
 
     /// Fetch-or-create a stream with an explicit mode. An existing stream

--- a/crates/rsearch-metastore/src/metastore.rs
+++ b/crates/rsearch-metastore/src/metastore.rs
@@ -8,7 +8,7 @@ use crate::types::{NewSplit, SplitRecord, SplitState, StreamMode, StreamRecord, 
 
 pub(crate) const SPLIT_COLUMNS: &str = "id, split_id, stream_id, state, storage_key, doc_count, \
      size_bytes, time_start_millis, time_end_millis, footer_len, created_by, \
-     seq_min, seq_max, tombstone_seq_applied, schema_version";
+     seq_min, seq_max, tombstone_seq_applied, schema_version, dynamic_fields";
 
 /// Postgres-backed metadata store shared by every node role: streams,
 /// splits, nodes, placement, auth, routing rules, and alerts. Cloning
@@ -73,7 +73,8 @@ impl Metastore {
     /// Look up a stream by name; `StreamNotFound` if missing.
     pub async fn get_stream(&self, name: &str) -> MetastoreResult<StreamRecord> {
         sqlx::query_as::<_, StreamRecord>(
-            "SELECT id, name, mapping, retention_hours, mode FROM streams WHERE name = $1",
+            "SELECT id, name, mapping, retention_hours, mode FROM streams
+             WHERE name = $1 AND deleted_at IS NULL",
         )
         .bind(name)
         .fetch_optional(&self.pool)
@@ -90,6 +91,7 @@ impl Metastore {
                     COALESCE(SUM(s.size_bytes) FILTER (WHERE s.state = 'published'), 0)::bigint AS size_bytes
              FROM streams st
              LEFT JOIN splits s ON s.stream_id = st.id
+             WHERE st.deleted_at IS NULL
              GROUP BY st.id
              ORDER BY st.name",
         )
@@ -111,7 +113,8 @@ impl Metastore {
     /// All streams, ordered by name.
     pub async fn list_streams(&self) -> MetastoreResult<Vec<StreamRecord>> {
         Ok(sqlx::query_as::<_, StreamRecord>(
-            "SELECT id, name, mapping, retention_hours, mode FROM streams ORDER BY name",
+            "SELECT id, name, mapping, retention_hours, mode FROM streams
+             WHERE deleted_at IS NULL ORDER BY name",
         )
         .fetch_all(&self.pool)
         .await?)
@@ -206,6 +209,69 @@ impl Metastore {
         Ok(())
     }
 
+    /// Retire a stream (DELETE /{index}, issue #71): every split is marked
+    /// for delete (the GC job removes the objects, then the rows), its
+    /// tombstones go now, and the row is renamed to `.deleted-{id}-{name}`
+    /// and stamped `deleted_at` so the name is immediately free for
+    /// re-creation. [`Metastore::purge_deleted_streams`] drops the row
+    /// once no split references it. `StreamNotFound` if there is no live
+    /// stream by that name.
+    pub async fn retire_stream(&self, name: &str) -> MetastoreResult<i64> {
+        let mut tx = self.pool.begin().await?;
+        let id: Option<i64> = sqlx::query_scalar(
+            "SELECT id FROM streams WHERE name = $1 AND deleted_at IS NULL FOR UPDATE",
+        )
+        .bind(name)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some(id) = id else {
+            return Err(MetastoreError::StreamNotFound(name.to_string()));
+        };
+        sqlx::query(
+            "UPDATE splits SET state = 'marked_for_delete', updated_at = now()
+             WHERE stream_id = $1 AND state <> 'marked_for_delete'",
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+        sqlx::query("DELETE FROM doc_tombstones WHERE stream_id = $1")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "UPDATE streams
+             SET name = '.deleted-' || id::text || '-' || name, deleted_at = now(),
+                 updated_at = now()
+             WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(id)
+    }
+
+    /// Finish retired streams: mark any split that landed after the
+    /// retirement (a late ingest flush), then delete every retired stream
+    /// row that no split references any more. Returns the rows deleted.
+    pub async fn purge_deleted_streams(&self) -> MetastoreResult<u64> {
+        sqlx::query(
+            "UPDATE splits SET state = 'marked_for_delete', updated_at = now()
+             WHERE state <> 'marked_for_delete'
+               AND stream_id IN (SELECT id FROM streams WHERE deleted_at IS NOT NULL)",
+        )
+        .execute(&self.pool)
+        .await?;
+        let result = sqlx::query(
+            "DELETE FROM streams
+             WHERE deleted_at IS NOT NULL
+               AND NOT EXISTS (SELECT 1 FROM splits WHERE splits.stream_id = streams.id)",
+        )
+        .execute(&self.pool)
+        .await?;
+        Ok(result.rows_affected())
+    }
+
     // ---- split lifecycle ----
 
     /// Register a freshly-uploaded split in `staged` state.
@@ -213,8 +279,9 @@ impl Metastore {
         sqlx::query(
             "INSERT INTO splits (split_id, stream_id, storage_key, doc_count, size_bytes,
                                  time_start_millis, time_end_millis, footer_len, created_by,
-                                 seq_min, seq_max, tombstone_seq_applied, schema_version)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
+                                 seq_min, seq_max, tombstone_seq_applied, schema_version,
+                                 dynamic_fields)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
         )
         .bind(split.split_id)
         .bind(split.stream_id)
@@ -229,9 +296,69 @@ impl Metastore {
         .bind(split.seq_max)
         .bind(split.tombstone_seq_applied)
         .bind(split.schema_version)
+        .bind(&split.dynamic_fields)
         .execute(&self.pool)
         .await?;
         Ok(())
+    }
+
+    /// Record a split's unmapped-field inventory (the control leader's
+    /// backfill for rows registered before the column existed, #76).
+    pub async fn set_split_dynamic_fields(
+        &self,
+        split_id: &str,
+        dynamic_fields: &serde_json::Value,
+    ) -> MetastoreResult<()> {
+        sqlx::query("UPDATE splits SET dynamic_fields = $2 WHERE split_id = $1")
+            .bind(split_id)
+            .bind(dynamic_fields)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Published splits whose unmapped-field inventory is unknown, newest
+    /// data first, at most `limit` (the backfill job's work list).
+    pub async fn splits_without_dynamic_fields(
+        &self,
+        limit: i64,
+    ) -> MetastoreResult<Vec<SplitRecord>> {
+        let query = format!(
+            "SELECT {SPLIT_COLUMNS} FROM splits
+             WHERE state = 'published' AND dynamic_fields IS NULL
+             ORDER BY time_end_millis DESC
+             LIMIT $1"
+        );
+        Ok(sqlx::query_as::<_, SplitRecord>(sqlx::AssertSqlSafe(query))
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    /// The union of a stream's unmapped fields across its published
+    /// splits: path → the value types seen (`string`, `long`, `double`,
+    /// `boolean`, `date`), sorted by path. Splits whose inventory is not
+    /// yet recorded contribute nothing until the backfill reaches them.
+    pub async fn stream_dynamic_fields(
+        &self,
+        stream_id: i64,
+    ) -> MetastoreResult<std::collections::BTreeMap<String, Vec<String>>> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            "SELECT DISTINCT kv.key, t.value
+             FROM splits s,
+                  jsonb_each(s.dynamic_fields) AS kv,
+                  jsonb_array_elements_text(kv.value) AS t
+             WHERE s.stream_id = $1 AND s.state = 'published' AND s.dynamic_fields IS NOT NULL
+             ORDER BY kv.key, t.value",
+        )
+        .bind(stream_id)
+        .fetch_all(&self.pool)
+        .await?;
+        let mut out: std::collections::BTreeMap<String, Vec<String>> = Default::default();
+        for (path, ty) in rows {
+            out.entry(path).or_default().push(ty);
+        }
+        Ok(out)
     }
 
     /// Published splits built under a layout older than `version`, newest

--- a/crates/rsearch-metastore/src/scroll.rs
+++ b/crates/rsearch-metastore/src/scroll.rs
@@ -93,6 +93,13 @@ impl Metastore {
         Ok(())
     }
 
+    /// Every live context's (id, stream), for scope filtering.
+    pub async fn list_scrolls(&self) -> MetastoreResult<Vec<(String, String)>> {
+        Ok(sqlx::query_as("SELECT id, stream FROM scroll_contexts WHERE expires_at > now()")
+            .fetch_all(self.pool())
+            .await?)
+    }
+
     /// Free scroll contexts by id; returns how many existed.
     pub async fn delete_scrolls(&self, ids: &[String]) -> MetastoreResult<u64> {
         let result = sqlx::query("DELETE FROM scroll_contexts WHERE id = ANY($1)")

--- a/crates/rsearch-metastore/src/scroll.rs
+++ b/crates/rsearch-metastore/src/scroll.rs
@@ -1,0 +1,120 @@
+//! Scroll contexts (issue #72): server-side paging state shared across
+//! search nodes.
+
+use crate::error::MetastoreResult;
+use crate::metastore::Metastore;
+
+/// A stored scroll context.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ScrollRecord {
+    /// Opaque scroll id handed to the client.
+    pub id: String,
+    /// Stream the scroll runs against.
+    pub stream: String,
+    /// The `_search` body it was opened with (aggregations removed).
+    pub request: serde_json::Value,
+    /// `sort` values of the last hit served; None until a page had hits.
+    pub cursor: Option<serde_json::Value>,
+    /// `hits.total` of the first page.
+    pub total: serde_json::Value,
+}
+
+impl Metastore {
+    /// Register a scroll opened by the first page of a search.
+    pub async fn create_scroll(
+        &self,
+        id: &str,
+        stream: &str,
+        request: &serde_json::Value,
+        cursor: Option<&serde_json::Value>,
+        total: &serde_json::Value,
+        keep_alive_secs: f64,
+    ) -> MetastoreResult<()> {
+        sqlx::query(
+            "INSERT INTO scroll_contexts (id, stream, request, cursor, total, expires_at)
+             VALUES ($1, $2, $3, $4, $5, now() + make_interval(secs => $6))",
+        )
+        .bind(id)
+        .bind(stream)
+        .bind(request)
+        .bind(cursor)
+        .bind(total)
+        .bind(keep_alive_secs)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    /// A live (unexpired) scroll context by id.
+    pub async fn get_scroll(&self, id: &str) -> MetastoreResult<Option<ScrollRecord>> {
+        Ok(sqlx::query_as::<_, ScrollRecord>(
+            "SELECT id, stream, request, cursor, total FROM scroll_contexts
+             WHERE id = $1 AND expires_at > now()",
+        )
+        .bind(id)
+        .fetch_optional(self.pool())
+        .await?)
+    }
+
+    /// Advance a scroll past the page just served and renew its expiry.
+    /// A page without hits leaves the cursor where it was.
+    pub async fn advance_scroll(
+        &self,
+        id: &str,
+        cursor: Option<&serde_json::Value>,
+        keep_alive_secs: f64,
+    ) -> MetastoreResult<()> {
+        sqlx::query(
+            "UPDATE scroll_contexts
+             SET cursor = COALESCE($2, cursor),
+                 expires_at = now() + make_interval(secs => $3)
+             WHERE id = $1",
+        )
+        .bind(id)
+        .bind(cursor)
+        .bind(keep_alive_secs)
+        .execute(self.pool())
+        .await?;
+        Ok(())
+    }
+
+    /// Advance the cursor without touching the expiry (a continuation
+    /// that passed no `scroll` keep-alive).
+    pub async fn advance_scroll_cursor(
+        &self,
+        id: &str,
+        cursor: Option<&serde_json::Value>,
+    ) -> MetastoreResult<()> {
+        sqlx::query("UPDATE scroll_contexts SET cursor = COALESCE($2, cursor) WHERE id = $1")
+            .bind(id)
+            .bind(cursor)
+            .execute(self.pool())
+            .await?;
+        Ok(())
+    }
+
+    /// Free scroll contexts by id; returns how many existed.
+    pub async fn delete_scrolls(&self, ids: &[String]) -> MetastoreResult<u64> {
+        let result = sqlx::query("DELETE FROM scroll_contexts WHERE id = ANY($1)")
+            .bind(ids)
+            .execute(self.pool())
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Free every scroll context (`DELETE /_search/scroll/_all`).
+    pub async fn delete_all_scrolls(&self) -> MetastoreResult<u64> {
+        let result = sqlx::query("DELETE FROM scroll_contexts")
+            .execute(self.pool())
+            .await?;
+        Ok(result.rows_affected())
+    }
+
+    /// Drop expired scroll contexts (control job).
+    pub async fn purge_expired_scrolls(&self) -> MetastoreResult<u64> {
+        let result = sqlx::query("DELETE FROM scroll_contexts WHERE expires_at <= now()")
+            .execute(self.pool())
+            .await?;
+        Ok(result.rows_affected())
+    }
+}

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -130,6 +130,11 @@ pub struct SplitRecord {
     /// `rsearch_index::CURRENT_SCHEMA_VERSION`); 0 for rows registered
     /// before the column existed.
     pub schema_version: i32,
+    /// Unmapped field inventory (`{"path": ["string", …]}`, issue #76);
+    /// None when unknown (splits registered before the column existed, or
+    /// read by a query that does not select it).
+    #[sqlx(default)]
+    pub dynamic_fields: Option<serde_json::Value>,
 }
 
 /// A split to register (see `Metastore::stage_split`).
@@ -161,6 +166,9 @@ pub struct NewSplit<'a> {
     pub tombstone_seq_applied: i64,
     /// Split layout version it was built under.
     pub schema_version: i32,
+    /// Unmapped field inventory as recorded in the split footer; None
+    /// when the builder did not record one.
+    pub dynamic_fields: Option<serde_json::Value>,
 }
 
 impl SplitRecord {

--- a/crates/rsearch-metastore/src/types.rs
+++ b/crates/rsearch-metastore/src/types.rs
@@ -130,11 +130,6 @@ pub struct SplitRecord {
     /// `rsearch_index::CURRENT_SCHEMA_VERSION`); 0 for rows registered
     /// before the column existed.
     pub schema_version: i32,
-    /// Unmapped field inventory (`{"path": ["string", …]}`, issue #76);
-    /// None when unknown (splits registered before the column existed, or
-    /// read by a query that does not select it).
-    #[sqlx(default)]
-    pub dynamic_fields: Option<serde_json::Value>,
 }
 
 /// A split to register (see `Metastore::stage_split`).

--- a/crates/rsearch-metastore/tests/metastore_pg.rs
+++ b/crates/rsearch-metastore/tests/metastore_pg.rs
@@ -75,6 +75,7 @@ async fn stream_mode_is_fixed_once_data_exists() {
         seq_max: None,
         tombstone_seq_applied: 0,
         schema_version: 0,
+        dynamic_fields: None,
     })
     .await
     .unwrap();
@@ -110,6 +111,7 @@ async fn split_state_machine() {
         seq_max: Some(20),
         tombstone_seq_applied: 0,
         schema_version: 0,
+        dynamic_fields: None,
     })
     .await
     .unwrap();
@@ -205,6 +207,7 @@ async fn small_published_splits_windows_per_stream() {
                 seq_max: None,
                 tombstone_seq_applied: 0,
                 schema_version: 0,
+                dynamic_fields: None,
             })
             .await
             .unwrap();
@@ -448,6 +451,7 @@ async fn tombstones_upsert_and_page_by_seq() {
         seq_max: Some(2),
         tombstone_seq_applied: applied,
         schema_version: 0,
+        dynamic_fields: None,
         }
     }
     let s1 = unique("s1");
@@ -498,6 +502,7 @@ async fn stray_object_keys_finds_placements_without_split_rows() {
         seq_max: None,
         tombstone_seq_applied: 0,
         schema_version: 0,
+        dynamic_fields: None,
     })
     .await
     .unwrap();
@@ -549,6 +554,7 @@ async fn splits_below_schema_version_lists_stale_layouts_newest_first() {
             seq_max: None,
             tombstone_seq_applied: 0,
             schema_version: version,
+            dynamic_fields: None,
         })
         .await
         .unwrap();

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -152,7 +152,6 @@ impl SearchRequest {
         // correct one to the caller, and a `search_after` cursor issued
         // from it pages over the wrong sequence (#67).
         let sort = SortSpec::parse(body.get("sort"))?;
-        let sort_desc = sort.timestamp_desc().unwrap_or(true);
         let field_sort = matches!(sort, SortSpec::Fields(_));
         // search_after: the previous page's last `sort` values. The
         // timestamp is taken verbatim as epoch millis (it is what our own
@@ -215,7 +214,6 @@ impl SearchRequest {
                 "[from] parameter must be set to 0 when [search_after] is used".into(),
             ));
         }
-        let _ = sort_desc;
         let aggs = body
             .get("aggs")
             .or_else(|| body.get("aggregations"))
@@ -296,8 +294,24 @@ struct CachedStream {
     record: rsearch_metastore::StreamRecord,
     schema: Arc<MappedSchema>,
     /// Unmapped fields its published splits hold (path → value types),
-    /// what field sorts resolve dynamic names against.
-    dynamic_fields: std::collections::BTreeMap<String, Vec<String>>,
+    /// what field sorts resolve dynamic names against. Fetched on first
+    /// use only (an aggregate over every published split), single-flight,
+    /// and reused for the record's cache lifetime.
+    dynamic_fields: tokio::sync::OnceCell<Arc<std::collections::BTreeMap<String, Vec<String>>>>,
+}
+
+impl CachedStream {
+    async fn dynamic_fields(
+        &self,
+        metastore: &Metastore,
+    ) -> SearchResult<Arc<std::collections::BTreeMap<String, Vec<String>>>> {
+        self.dynamic_fields
+            .get_or_try_init(|| async {
+                Ok(Arc::new(metastore.stream_dynamic_fields(self.record.id).await?))
+            })
+            .await
+            .cloned()
+    }
 }
 
 /// Stateless search service: metastore for pruning, storage for split
@@ -469,11 +483,10 @@ impl SearchService {
         let record = self.metastore.get_stream(name).await?;
         let mapping = IndexMapping::from_json(&record.mapping)
             .map_err(|e| SearchError::BadRequest(e.to_string()))?;
-        let dynamic_fields = self.metastore.stream_dynamic_fields(record.id).await?;
         let cached = Arc::new(CachedStream {
             schema: Arc::new(MappedSchema::build(mapping)),
             record,
-            dynamic_fields,
+            dynamic_fields: tokio::sync::OnceCell::new(),
         });
         let mut streams = self.streams.lock().unwrap();
         // Bounded so a probe flood of stream names can't grow it forever.
@@ -637,7 +650,19 @@ impl SearchService {
                 cursor: request.search_after,
             },
             SortSpec::Fields(fields) => {
-                let resolved = resolve_sort(fields, &schema, &cached.dynamic_fields)?;
+                // The dynamic inventory is only consulted for names the
+                // mapping does not settle.
+                let needs_inventory = fields.iter().any(|f| {
+                    !f.is_timestamp()
+                        && f.field != rsearch_index::SEQ_FIELD
+                        && !schema.fields.contains_key(&f.field)
+                });
+                let inventory = if needs_inventory {
+                    cached.dynamic_fields(&self.metastore).await?
+                } else {
+                    Arc::new(Default::default())
+                };
+                let resolved = resolve_sort(fields, &schema, &inventory)?;
                 let cursor = match &request.search_after_values {
                     Some(values) => Some(FieldCursor::parse(values, &resolved)?),
                     None => None,

--- a/crates/rsearch-search/src/executor.rs
+++ b/crates/rsearch-search/src/executor.rs
@@ -30,19 +30,9 @@ use crate::error::{SearchError, SearchResult};
 use crate::query_dsl::{
     extract_time_bounds, fix_date_histogram_keys, rewrite_agg_fields, translate_query,
 };
-
-const TIMESTAMP_ALIASES: [&str; 3] = ["@timestamp", "timestamp", "_timestamp"];
-
-/// Sort fields accepted as no-ops: ES allows them alongside a field
-/// sort, and our single timestamp order already fixes the sequence.
-const SORT_NOOP_FIELDS: [&str; 2] = ["_score", "_doc"];
-
-fn unsupported_sort_field(field: &str) -> SearchError {
-    SearchError::BadRequest(format!(
-        "unsupported sort field '{field}': only the timestamp \
-         (@timestamp/timestamp/_timestamp), _score and _doc can be sorted on"
-    ))
-}
+use crate::sort::{
+    FieldCursor, FieldSortCollector, FieldSortPlan, SortSpec, SortValue, cmp_hits, resolve_sort,
+};
 /// Cap on cached open split readers (LRU), across all shards.
 const READER_CACHE_CAP: usize = 256;
 /// Reader-cache shards: every split touch on every query locks the cache
@@ -111,8 +101,9 @@ pub struct SearchRequest {
     pub from: usize,
     /// Page size; defaults to 10.
     pub size: usize,
-    /// Timestamp sort direction; true (default) = newest first.
-    pub sort_desc: bool,
+    /// Requested order: timestamp (default newest first) or field
+    /// clauses (issue #77).
+    pub sort: SortSpec,
     /// ES `aggs`/`aggregations` body, if present.
     pub aggs: Option<Value>,
     /// Whether hits include `_source` (`"_source": false` disables).
@@ -124,6 +115,9 @@ pub struct SearchRequest {
     /// pages past `max_result_window` (issue #52). Totals and
     /// aggregations still reflect the full query, as in ES.
     pub search_after: Option<SearchAfter>,
+    /// The raw `search_after` values of a field sort, resolved against
+    /// the stream's mapping at execution time.
+    pub search_after_values: Option<Vec<Value>>,
 }
 
 impl SearchRequest {
@@ -151,55 +145,33 @@ impl SearchRequest {
             Some(Value::Number(n)) => n.as_u64().map(|v| v as usize),
             _ => Some(DEFAULT_TRACK_TOTAL_HITS),
         };
-        // Sort: timestamp desc default; only timestamp sorts supported in
-        // v1. Anything else is a 400 rather than a silently ignored
-        // clause: a request that succeeds in the wrong order is
-        // indistinguishable from a correct one to the caller, and a
-        // `search_after` cursor issued from it pages over the wrong
-        // sequence (#67). `_score`/`_doc` are tolerated as no-ops the way
-        // ES accepts them alongside a field sort.
-        let mut sort_desc = true;
-        if let Some(sorts) = body.get("sort") {
-            let entries: Vec<&Value> = match sorts {
-                Value::Array(items) => items.iter().collect(),
-                single => vec![single],
-            };
-            for entry in entries {
-                match entry {
-                    Value::String(s) if TIMESTAMP_ALIASES.contains(&s.as_str()) => {
-                        sort_desc = false;
-                    }
-                    Value::String(s) if SORT_NOOP_FIELDS.contains(&s.as_str()) => {}
-                    Value::String(s) => return Err(unsupported_sort_field(s)),
-                    Value::Object(map) => {
-                        for (field, spec) in map {
-                            if TIMESTAMP_ALIASES.contains(&field.as_str()) {
-                                let order = spec
-                                    .get("order")
-                                    .and_then(Value::as_str)
-                                    .unwrap_or_else(|| spec.as_str().unwrap_or("desc"));
-                                sort_desc = order != "asc";
-                            } else if !SORT_NOOP_FIELDS.contains(&field.as_str()) {
-                                return Err(unsupported_sort_field(field));
-                            }
-                        }
-                    }
-                    other => {
-                        return Err(SearchError::BadRequest(format!(
-                            "sort entries must be a field name or an object, got {other}"
-                        )));
-                    }
-                }
-            }
-        }
+        // Sort: timestamp desc by default; field sorts resolve against
+        // the mapping at execution time (#77). Anything unsortable is a
+        // 400 rather than a silently ignored clause: a request that
+        // succeeds in the wrong order is indistinguishable from a
+        // correct one to the caller, and a `search_after` cursor issued
+        // from it pages over the wrong sequence (#67).
+        let sort = SortSpec::parse(body.get("sort"))?;
+        let sort_desc = sort.timestamp_desc().unwrap_or(true);
+        let field_sort = matches!(sort, SortSpec::Fields(_));
         // search_after: the previous page's last `sort` values. The
         // timestamp is taken verbatim as epoch millis (it is what our own
         // `sort` emitted — no unit heuristic, which would rescale small
         // values), clamped to the tantivy-safe range like every other
         // timestamp input so a hostile cursor can't overflow the nanos
         // conversion.
+        let mut search_after_values = None;
         let search_after = match body.get("search_after") {
             None | Some(Value::Null) => None,
+            Some(Value::Array(vals)) if field_sort => {
+                if vals.is_empty() {
+                    return Err(SearchError::BadRequest(
+                        "search_after must be a non-empty array of sort values".into(),
+                    ));
+                }
+                search_after_values = Some(vals.clone());
+                None
+            }
             Some(Value::Array(vals)) if (1..=2).contains(&vals.len()) => {
                 // Whole-valued floats are accepted: JSON round-trips in
                 // some clients re-encode the echoed integer as a float.
@@ -238,11 +210,12 @@ impl SearchRequest {
                 ));
             }
         };
-        if search_after.is_some() && from != 0 {
+        if (search_after.is_some() || search_after_values.is_some()) && from != 0 {
             return Err(SearchError::BadRequest(
                 "[from] parameter must be set to 0 when [search_after] is used".into(),
             ));
         }
+        let _ = sort_desc;
         let aggs = body
             .get("aggs")
             .or_else(|| body.get("aggregations"))
@@ -256,13 +229,27 @@ impl SearchRequest {
             query,
             from,
             size,
-            sort_desc,
+            sort,
             aggs,
             include_source,
             track_total_hits,
             search_after,
+            search_after_values,
         })
     }
+}
+
+/// How one search orders and pages its hits, resolved against the
+/// stream.
+#[derive(Clone)]
+enum SortPlan {
+    /// (timestamp, `_seq`) order with the range-clause cursor.
+    Timestamp {
+        desc: bool,
+        cursor: Option<SearchAfter>,
+    },
+    /// Field clauses collected by [`FieldSortCollector`].
+    Fields(Arc<FieldSortPlan>),
 }
 
 /// A fetched page document: (page position, stored `_id`, `_seq`,
@@ -280,6 +267,8 @@ struct SplitHit {
     seq: Option<i64>,
     split_idx: usize,
     doc: DocAddress,
+    /// Field-sort values (None under a timestamp sort).
+    values: Option<Vec<SortValue>>,
 }
 
 /// A document-mode stream's tombstones as last fetched: ascending by
@@ -306,6 +295,9 @@ struct SplitOutcome {
 struct CachedStream {
     record: rsearch_metastore::StreamRecord,
     schema: Arc<MappedSchema>,
+    /// Unmapped fields its published splits hold (path → value types),
+    /// what field sorts resolve dynamic names against.
+    dynamic_fields: std::collections::BTreeMap<String, Vec<String>>,
 }
 
 /// Stateless search service: metastore for pruning, storage for split
@@ -477,9 +469,11 @@ impl SearchService {
         let record = self.metastore.get_stream(name).await?;
         let mapping = IndexMapping::from_json(&record.mapping)
             .map_err(|e| SearchError::BadRequest(e.to_string()))?;
+        let dynamic_fields = self.metastore.stream_dynamic_fields(record.id).await?;
         let cached = Arc::new(CachedStream {
             schema: Arc::new(MappedSchema::build(mapping)),
             record,
+            dynamic_fields,
         });
         let mut streams = self.streams.lock().unwrap();
         // Bounded so a probe flood of stream names can't grow it forever.
@@ -566,11 +560,12 @@ impl SearchService {
                 query: json!({"ids": {"values": chunk}}),
                 from: 0,
                 size: MAX_RESULT_WINDOW,
-                sort_desc: true,
+                sort: SortSpec::Timestamp { desc: true },
                 aggs: None,
                 include_source: true,
                 track_total_hits: Some(0),
                 search_after: None,
+                search_after_values: None,
             };
             let response = self.search(request).await?;
             for hit in response["hits"]["hits"].as_array().into_iter().flatten() {
@@ -633,6 +628,27 @@ impl SearchService {
             None
         };
 
+        // Resolve the sort against the stream (mapping + dynamic field
+        // inventory) before any split is opened, so an unsortable field
+        // is a 400 with OpenSearch's message and a cursor is typed.
+        let plan = match &request.sort {
+            SortSpec::Timestamp { desc } => SortPlan::Timestamp {
+                desc: *desc,
+                cursor: request.search_after,
+            },
+            SortSpec::Fields(fields) => {
+                let resolved = resolve_sort(fields, &schema, &cached.dynamic_fields)?;
+                let cursor = match &request.search_after_values {
+                    Some(values) => Some(FieldCursor::parse(values, &resolved)?),
+                    None => None,
+                };
+                SortPlan::Fields(Arc::new(FieldSortPlan {
+                    fields: resolved,
+                    cursor,
+                }))
+            }
+        };
+
         let fetch_limit = request.from + request.size;
         let query = Arc::new(request.query.clone());
         // Whether the query is exactly match_all — lets fully-covered
@@ -646,8 +662,6 @@ impl SearchService {
         // Open readers and search all splits concurrently (bounded), in
         // split order so split_idx stays meaningful.
         let track = request.track_total_hits;
-        let sort_desc = request.sort_desc;
-        let cursor = request.search_after;
         // Running total of counted matches across splits. Once it passes
         // track_total_hits, later splits skip their Count collector and the
         // response reports `"relation": "gte"` — the default 10k cap stops
@@ -681,11 +695,18 @@ impl SearchService {
                 // skipped, and when the count is skippable too the split
                 // is not even opened. (Strict compare: a split touching
                 // the boundary timestamp may still hold page docs.)
-                let outside_cursor = match cursor {
-                    Some(c) if sort_desc => split.time_start_millis > c.timestamp_millis,
-                    Some(c) => split.time_end_millis < c.timestamp_millis,
-                    None => false,
+                let outside_cursor = match &plan {
+                    SortPlan::Timestamp {
+                        desc: true,
+                        cursor: Some(c),
+                    } => split.time_start_millis > c.timestamp_millis,
+                    SortPlan::Timestamp {
+                        desc: false,
+                        cursor: Some(c),
+                    } => split.time_end_millis < c.timestamp_millis,
+                    _ => false,
                 };
+                let plan = plan.clone();
                 async move {
                     let skip_count = match track {
                         Some(cap) => counted.load(Ordering::Relaxed) >= cap,
@@ -711,8 +732,7 @@ impl SearchService {
                             &query,
                             aggregations,
                             fetch_limit,
-                            sort_desc,
-                            cursor,
+                            &plan,
                             outside_cursor,
                             skip_count,
                             idx,
@@ -753,19 +773,41 @@ impl SearchService {
         // — legacy docs without one sort as -1), then split index and doc
         // for determinism — so equal timestamps page deterministically
         // (L8) and cursors resume at the same global position (issue #52).
+        let field_orders = match &plan {
+            SortPlan::Fields(plan) => Some(plan.orders()),
+            SortPlan::Timestamp { .. } => None,
+        };
         let cmp = |a: &SplitHit, b: &SplitHit| {
-            let (ts, seq) = if request.sort_desc {
-                (
-                    b.timestamp_millis.cmp(&a.timestamp_millis),
-                    b.seq.unwrap_or(-1).cmp(&a.seq.unwrap_or(-1)),
-                )
-            } else {
-                (
-                    a.timestamp_millis.cmp(&b.timestamp_millis),
-                    a.seq.unwrap_or(-1).cmp(&b.seq.unwrap_or(-1)),
-                )
+            let primary = match &field_orders {
+                Some(orders) => cmp_hits(
+                    orders,
+                    (
+                        a.values.as_deref().unwrap_or(&[]),
+                        a.timestamp_millis,
+                        a.seq.unwrap_or(-1),
+                    ),
+                    (
+                        b.values.as_deref().unwrap_or(&[]),
+                        b.timestamp_millis,
+                        b.seq.unwrap_or(-1),
+                    ),
+                ),
+                None => {
+                    let (ts, seq) = if matches!(plan, SortPlan::Timestamp { desc: true, .. }) {
+                        (
+                            b.timestamp_millis.cmp(&a.timestamp_millis),
+                            b.seq.unwrap_or(-1).cmp(&a.seq.unwrap_or(-1)),
+                        )
+                    } else {
+                        (
+                            a.timestamp_millis.cmp(&b.timestamp_millis),
+                            a.seq.unwrap_or(-1).cmp(&b.seq.unwrap_or(-1)),
+                        )
+                    };
+                    ts.then(seq)
+                }
             };
-            ts.then(seq)
+            primary
                 .then(a.split_idx.cmp(&b.split_idx))
                 .then(a.doc.segment_ord.cmp(&b.doc.segment_ord))
                 .then(a.doc.doc_id.cmp(&b.doc.doc_id))
@@ -781,7 +823,7 @@ impl SearchService {
         // only for the final page, grouped by split so each reader is used
         // once (H4).
         let page_entries = self
-            .fetch_page_sources(&splits, &page, &request.stream, request.include_source)
+            .fetch_page_sources(&splits, &page, &request.stream, request.include_source, &plan)
             .await?;
 
         let merged_aggs = match (&aggregations, &aggs_json) {
@@ -849,6 +891,7 @@ impl SearchService {
         page: &[SplitHit],
         stream: &str,
         include_source: bool,
+        plan: &SortPlan,
     ) -> SearchResult<Vec<Value>> {
         use futures::stream::{self, StreamExt};
 
@@ -922,7 +965,7 @@ impl SearchService {
                         .and_then(|s| serde_json::from_str(s).ok())
                         .unwrap_or(Value::Null)
                 });
-                hit_envelope(hit, splits, stream, id, seq, source)
+                hit_envelope(hit, splits, stream, id, seq, source, plan)
             })
             .collect())
     }
@@ -939,18 +982,28 @@ fn hit_envelope(
     id: Option<String>,
     seq: Option<i64>,
     source: Option<Value>,
+    plan: &SortPlan,
 ) -> Value {
     let split_id = &splits[hit.split_idx].split_id;
     let id = id.unwrap_or_else(|| {
         format!("{}:{}:{}", split_id, hit.doc.segment_ord, hit.doc.doc_id)
     });
-    // `sort` is the search_after cursor: [timestamp, _seq]. Legacy docs
-    // without a `_seq` report the -1 sentinel (issue #52).
+    // `sort` is the search_after cursor: the field values (if any) then
+    // [timestamp, _seq]. Legacy docs without a `_seq` report the -1
+    // sentinel (issue #52).
+    let sort = match plan {
+        SortPlan::Fields(plan) => plan.hit_sort_json(
+            hit.values.as_deref().unwrap_or(&[]),
+            hit.timestamp_millis,
+            seq.unwrap_or(-1),
+        ),
+        SortPlan::Timestamp { .. } => json!([hit.timestamp_millis, seq.unwrap_or(-1)]),
+    };
     let mut entry = json!({
         "_index": stream,
         "_id": id,
         "_score": Value::Null,
-        "sort": [hit.timestamp_millis, seq.unwrap_or(-1)],
+        "sort": sort,
     });
     // `_version` is the write sequence: what the bulk/_doc responses
     // reported for this version of the document.
@@ -1053,8 +1106,7 @@ fn search_one_split(
     query_json: &Value,
     aggregations: Option<Aggregations>,
     fetch_limit: usize,
-    sort_desc: bool,
-    cursor: Option<SearchAfter>,
+    plan: &SortPlan,
     page_outside_cursor: bool,
     skip_count: bool,
     split_idx: usize,
@@ -1082,6 +1134,12 @@ fn search_one_split(
     }
     let searcher = reader.searcher()?;
 
+    // The timestamp plan's (desc, cursor); a field plan pages inside its
+    // collector instead.
+    let (sort_desc, cursor) = match plan {
+        SortPlan::Timestamp { desc, cursor } => (*desc, *cursor),
+        SortPlan::Fields(_) => (true, None),
+    };
     let top_collector = top_sort_key_collector(fetch_limit, sort_desc);
 
     // Resolve the collector's ((ts, seq), doc) pairs into hits,
@@ -1097,6 +1155,7 @@ fn search_one_split(
                     seq: (seq >= 0).then_some(seq),
                     split_idx,
                     doc,
+                    values: None,
                 }
             })
             .collect()
@@ -1105,10 +1164,30 @@ fn search_one_split(
     // aggregations keep reflecting the full query, as in ES. A split
     // wholly on the paged side of the cursor skips the pass entirely.
     // Builds its own collector so the combined-collector arms below can
-    // consume the shared one.
-    let page_search = |base: Box<dyn Query>| -> SearchResult<Vec<((i64, i64), DocAddress)>> {
+    // consume the shared one. Under a field sort the page always runs
+    // as its own pass (the collector applies the cursor per document).
+    let page_search = |base: Box<dyn Query>| -> SearchResult<Vec<SplitHit>> {
         if page_outside_cursor {
             return Ok(Vec::new());
+        }
+        if let SortPlan::Fields(field_plan) = plan {
+            let collector = FieldSortCollector::new(
+                field_plan.clone(),
+                reader.mapped_schema().clone(),
+                fetch_limit,
+            );
+            return Ok(searcher
+                .search(&base, &collector)
+                .map_err(SearchError::Tantivy)?
+                .into_iter()
+                .map(|hit| SplitHit {
+                    timestamp_millis: hit.timestamp_millis,
+                    seq: (hit.seq >= 0).then_some(hit.seq),
+                    split_idx,
+                    doc: hit.doc,
+                    values: Some(hit.values),
+                })
+                .collect());
         }
         let collector = top_sort_key_collector(fetch_limit, sort_desc);
         let page_query: Box<dyn Query> = match cursor {
@@ -1118,16 +1197,20 @@ fn search_one_split(
             ])),
             None => base,
         };
-        searcher
-            .search(&page_query, &collector)
-            .map_err(SearchError::Tantivy)
+        Ok(make_hits(
+            searcher
+                .search(&page_query, &collector)
+                .map_err(SearchError::Tantivy)?,
+        ))
     };
+    // Whether the page needs its own pass (a cursor, or a field sort).
+    let separate_page = cursor.is_some() || matches!(plan, SortPlan::Fields(_));
 
     // match_all over a fully-covered split: the count is the split's
     // doc_count; skip the Count collector entirely (H3). Still runs the
     // top-k collector for the page.
     if fully_covered && aggregations.is_none() {
-        let hits = make_hits(page_search(query)?);
+        let hits = page_search(query)?;
         return Ok(SplitOutcome {
             count: doc_count,
             count_is_lower_bound: false,
@@ -1142,52 +1225,50 @@ fn search_one_split(
     // their collector, and counting is free alongside their full scan.
     // With a search_after cursor the page runs as its own search, so the
     // count/agg pass over the full query stays separate.
-    let (count, count_is_lower_bound, top, agg_result) = match (aggregations, skip_count, cursor) {
-        (Some(aggs), _, cursor) => {
-            let agg_collector = tantivy::aggregation::DistributedAggregationCollector::from_aggs(
-                aggs,
-                tantivy::aggregation::AggContextParams::new(
-                    default_limits(),
-                    index.tokenizers().clone(),
-                ),
-            );
-            match cursor {
-                None => {
-                    let (count, top, aggs) = searcher
-                        .search(&query, &(Count, top_collector, agg_collector))
-                        .map_err(SearchError::Tantivy)?;
-                    (count, false, top, Some(aggs))
-                }
-                Some(_) => {
+    let (count, count_is_lower_bound, hits, agg_result) =
+        match (aggregations, skip_count, separate_page) {
+            (Some(aggs), _, separate_page) => {
+                let agg_collector =
+                    tantivy::aggregation::DistributedAggregationCollector::from_aggs(
+                        aggs,
+                        tantivy::aggregation::AggContextParams::new(
+                            default_limits(),
+                            index.tokenizers().clone(),
+                        ),
+                    );
+                if separate_page {
                     let (count, aggs) = searcher
                         .search(&query, &(Count, agg_collector))
                         .map_err(SearchError::Tantivy)?;
-                    let top = page_search(query)?;
-                    (count, false, top, Some(aggs))
+                    let hits = page_search(query)?;
+                    (count, false, hits, Some(aggs))
+                } else {
+                    let (count, top, aggs) = searcher
+                        .search(&query, &(Count, top_collector, agg_collector))
+                        .map_err(SearchError::Tantivy)?;
+                    (count, false, make_hits(top), Some(aggs))
                 }
             }
-        }
-        (None, true, _) => {
-            let top = page_search(query)?;
-            // Lower bound: at least the number of hits we returned.
-            (top.len(), true, top, None)
-        }
-        (None, false, None) => {
-            let (count, top) = searcher
-                .search(&query, &(Count, top_collector))
-                .map_err(SearchError::Tantivy)?;
-            (count, false, top, None)
-        }
-        (None, false, Some(_)) => {
-            let count = searcher.search(&query, &Count).map_err(SearchError::Tantivy)?;
-            let top = page_search(query)?;
-            (count, false, top, None)
-        }
-    };
+            (None, true, _) => {
+                let hits = page_search(query)?;
+                // Lower bound: at least the number of hits we returned.
+                (hits.len(), true, hits, None)
+            }
+            (None, false, false) => {
+                let (count, top) = searcher
+                    .search(&query, &(Count, top_collector))
+                    .map_err(SearchError::Tantivy)?;
+                (count, false, make_hits(top), None)
+            }
+            (None, false, true) => {
+                let count = searcher.search(&query, &Count).map_err(SearchError::Tantivy)?;
+                let hits = page_search(query)?;
+                (count, false, hits, None)
+            }
+        };
 
     // Source is fetched later, only for the merged final page — here we
     // just record references (H4).
-    let hits = make_hits(top);
     Ok(SplitOutcome {
         count,
         count_is_lower_bound,
@@ -1248,7 +1329,10 @@ mod tests {
     #[test]
     fn parses_sort() {
         // Default and explicit timestamp sorts.
-        assert!(SearchRequest::parse("logs", &json!({})).unwrap().sort_desc);
+        assert_eq!(
+            SearchRequest::parse("logs", &json!({})).unwrap().sort,
+            SortSpec::Timestamp { desc: true }
+        );
         for body in [
             json!({"sort": "@timestamp"}),
             json!({"sort": ["timestamp"]}),
@@ -1258,26 +1342,40 @@ mod tests {
             json!({"sort": [{"@timestamp": "asc"}, "_score", {"_doc": "asc"}]}),
         ] {
             let parsed = SearchRequest::parse("logs", &body).unwrap();
-            assert!(!parsed.sort_desc, "{body}");
+            assert_eq!(parsed.sort, SortSpec::Timestamp { desc: false }, "{body}");
         }
-        assert!(
+        assert_eq!(
             SearchRequest::parse("logs", &json!({"sort": [{"@timestamp": "desc"}]}))
                 .unwrap()
-                .sort_desc
+                .sort,
+            SortSpec::Timestamp { desc: true }
         );
     }
 
     #[test]
-    fn sort_rejects_unsupported_fields() {
-        // A sort we cannot honour is a 400, never a 200 in timestamp
-        // order: the caller cannot tell the difference, and a
-        // search_after cursor from it pages the wrong sequence (#67).
+    fn field_sorts_parse_and_defer_resolution() {
+        // A field sort is resolved against the mapping at execution time
+        // (#77); the parse only shapes it. Its search_after is kept raw.
         for body in [
             json!({"sort": [{"n": "asc"}]}),
             json!({"sort": [{"id": {"order": "desc"}}]}),
             json!({"sort": "n"}),
             json!({"sort": [{"@timestamp": "asc"}, {"n": "asc"}]}),
+        ] {
+            let parsed = SearchRequest::parse("logs", &body).unwrap();
+            assert!(matches!(parsed.sort, SortSpec::Fields(_)), "{body}");
+        }
+        let parsed =
+            SearchRequest::parse("logs", &json!({"sort": [{"n": "asc"}], "search_after": [5, 1000, 3]}))
+                .unwrap();
+        assert_eq!(parsed.search_after_values, Some(vec![json!(5), json!(1000), json!(3)]));
+        assert!(parsed.search_after.is_none());
+        // Malformed entries and from + search_after are still 400s.
+        for body in [
             json!({"sort": [42]}),
+            json!({"sort": [{"n": "sideways"}]}),
+            json!({"sort": [{"n": "asc"}], "search_after": []}),
+            json!({"sort": [{"n": "asc"}], "search_after": [1], "from": 3}),
         ] {
             let err = SearchRequest::parse("logs", &body).unwrap_err();
             assert!(matches!(err, SearchError::BadRequest(_)), "{body}");

--- a/crates/rsearch-search/src/lib.rs
+++ b/crates/rsearch-search/src/lib.rs
@@ -6,7 +6,9 @@ mod error;
 mod executor;
 pub mod logql;
 mod query_dsl;
+mod sort;
 
 pub use error::{SearchError, SearchResult};
 pub use executor::{FoundDocument, SearchAfter, SearchRequest, SearchService};
 pub use query_dsl::{extract_time_bounds, rewrite_agg_fields, translate_query};
+pub use sort::{SortField, SortSpec, SortType, SortValue};

--- a/crates/rsearch-search/src/query_dsl.rs
+++ b/crates/rsearch-search/src/query_dsl.rs
@@ -201,7 +201,7 @@ fn float_as_exact_i64(value: &Value) -> Option<i64> {
 }
 
 /// Parse a timestamp literal (RFC 3339, epoch secs/millis, or "now").
-fn parse_time_millis(value: &Value) -> Option<i64> {
+pub(crate) fn parse_time_millis(value: &Value) -> Option<i64> {
     match value {
         Value::String(s) => {
             if s == "now" {

--- a/crates/rsearch-search/src/sort.rs
+++ b/crates/rsearch-search/src/sort.rs
@@ -71,6 +71,18 @@ pub struct SortField {
     /// `unmapped_type`: sort on a field no document holds, as all
     /// missing, instead of a 400.
     pub unmapped_type: Option<String>,
+    /// `mode`: which of a multi-valued field's values represents the
+    /// document — `max` or `min` (default: min ascending, max descending).
+    pub mode: Option<SortMode>,
+}
+
+/// Which value of a multi-valued field a document sorts by.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortMode {
+    /// The smallest value.
+    Min,
+    /// The largest value.
+    Max,
 }
 
 impl SortField {
@@ -82,6 +94,17 @@ impl SortField {
         match entry {
             Value::String(name) => Ok(Self::named(name)),
             Value::Object(map) => {
+                // OpenSearch applies a multi-key object as ordered clauses;
+                // JSON object order does not survive parsing here, so the
+                // order could not be honoured — refuse rather than sort in
+                // an order the caller did not ask for.
+                if map.len() > 1 {
+                    return Err(SearchError::BadRequest(format!(
+                        "sort object with {} fields: use one field per sort entry, e.g. \
+                         [{{\"a\": \"asc\"}}, {{\"b\": \"desc\"}}]",
+                        map.len()
+                    )));
+                }
                 let mut parsed = None;
                 for (name, spec) in map {
                     let Some(mut field) = Self::named(name) else { continue };
@@ -103,16 +126,19 @@ impl SortField {
                                         field.unmapped_type =
                                             Some(value.as_str().unwrap_or("").to_string());
                                     }
-                                    // Multi-valued fields sort by their
-                                    // min (asc) / max (desc), the default
-                                    // mode; other modes are not supported.
+                                    // Multi-valued fields sort by one
+                                    // representative value; avg/sum/median
+                                    // are not supported.
                                     "mode" => {
-                                        let mode = value.as_str().unwrap_or("");
-                                        if mode != "min" && mode != "max" {
-                                            return Err(SearchError::BadRequest(format!(
-                                                "sort mode [{mode}] on [{name}] is not supported"
-                                            )));
-                                        }
+                                        field.mode = match value.as_str().unwrap_or("") {
+                                            "min" => Some(SortMode::Min),
+                                            "max" => Some(SortMode::Max),
+                                            other => {
+                                                return Err(SearchError::BadRequest(format!(
+                                                    "sort mode [{other}] on [{name}] is not supported"
+                                                )));
+                                            }
+                                        };
                                     }
                                     other => {
                                         return Err(SearchError::BadRequest(format!(
@@ -150,6 +176,7 @@ impl SortField {
             desc: false,
             missing: None,
             unmapped_type: None,
+            mode: None,
         })
     }
 
@@ -160,7 +187,8 @@ impl SortField {
 }
 
 fn parse_order(name: &str, order: &str) -> SearchResult<bool> {
-    match order {
+    // Case-insensitive, as OpenSearch's SortOrder.fromString.
+    match order.to_ascii_lowercase().as_str() {
         "asc" => Ok(false),
         "desc" => Ok(true),
         other => Err(SearchError::BadRequest(format!(
@@ -244,6 +272,8 @@ pub struct ResolvedSort {
     pub ty: SortType,
     /// Descending order.
     pub desc: bool,
+    /// A multi-valued document sorts by its largest value (else smallest).
+    pub use_max: bool,
     /// Missing documents sort as if they held the maximum value.
     pub null_is_max: bool,
     /// Substitute value for missing documents (`missing: <value>`).
@@ -449,6 +479,11 @@ pub fn resolve_sort(
                 target,
                 ty,
                 desc: field.desc,
+                use_max: match field.mode {
+                    Some(SortMode::Max) => true,
+                    Some(SortMode::Min) => false,
+                    None => field.desc,
+                },
                 null_is_max,
                 substitute,
             })
@@ -691,7 +726,8 @@ enum SegAccessor {
 }
 
 impl SegAccessor {
-    /// The document's key: min of its values for asc, max for desc.
+    /// The document's key: the largest of its values when `desc`
+    /// (`use_max`), else the smallest.
     fn key(&self, doc: DocId, desc: bool) -> SegKey {
         fn pick<T: Copy, I: Iterator<Item = T>>(
             iter: I,
@@ -930,7 +966,7 @@ impl FieldSortSegmentCollector {
             .zip(&self.fields.fields)
             .zip(&self.substitutes)
             .map(|((accessor, sort), substitute)| {
-                let key = accessor.key(doc, sort.desc);
+                let key = accessor.key(doc, sort.use_max);
                 match (key, substitute) {
                     (SegKey::Missing, Some(sub)) => *sub,
                     (key, _) => key,
@@ -1189,12 +1225,18 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(f.desc && f.missing == Some(json!("_first")) && f.unmapped_type.as_deref() == Some("long"));
+        assert_eq!(f.mode, Some(SortMode::Max));
+        // Order is case-insensitive, as in OpenSearch.
+        assert!(SortField::parse(&json!({"age": "DESC"})).unwrap().unwrap().desc);
+        assert!(!SortField::parse(&json!({"age": {"order": "Asc"}})).unwrap().unwrap().desc);
         assert!(SortField::parse(&json!("_score")).unwrap().is_none());
         assert!(SortField::parse(&json!({"_doc": "asc"})).unwrap().is_none());
         for bad in [
             json!({"age": "sideways"}),
             json!({"age": {"order": "asc", "nested": {}}}),
             json!({"age": {"mode": "avg"}}),
+            // A multi-key object cannot be applied in the caller's order.
+            json!({"age": "desc", "name": "asc"}),
             json!(42),
         ] {
             assert!(SortField::parse(&bad).is_err(), "{bad}");
@@ -1299,6 +1341,26 @@ mod tests {
         let cursor = FieldCursor::parse(&[json!("b")], &resolved).unwrap();
         let plan = FieldSortPlan { fields: resolved, cursor: Some(cursor) };
         assert_eq!(ids(&run(&index, &schema, plan, 10)), vec![0, 2]);
+    }
+
+    #[test]
+    fn mode_picks_the_representative_value() {
+        let docs = vec![json!({"tags": [1, 100]}), json!({"tags": [50, 60]})];
+        let (schema, index) = index(serde_json::from_str(MAPPING).unwrap(), &docs);
+        let resolve_tags = |sort: Value| {
+            let fields: Vec<SortField> = vec![SortField::parse(&sort).unwrap().unwrap()];
+            resolve_sort(&fields, &schema, &dynamic(&[("tags", &["long"])])).unwrap()
+        };
+        let run_ids = |sort: Value| {
+            let plan = FieldSortPlan { fields: resolve_tags(sort), cursor: None };
+            ids(&run(&index, &schema, plan, 10))
+        };
+        // Defaults: min ascending, max descending (OpenSearch).
+        assert_eq!(run_ids(json!({"tags": "asc"})), vec![0, 1]);
+        assert_eq!(run_ids(json!({"tags": "desc"})), vec![0, 1]);
+        // Explicit modes flip the representative value.
+        assert_eq!(run_ids(json!({"tags": {"order": "asc", "mode": "max"}})), vec![1, 0]);
+        assert_eq!(run_ids(json!({"tags": {"order": "desc", "mode": "min"}})), vec![1, 0]);
     }
 
     #[test]

--- a/crates/rsearch-search/src/sort.rs
+++ b/crates/rsearch-search/src/sort.rs
@@ -1,0 +1,1321 @@
+//! Field sorting (issue #77): `sort` on keyword, numeric, boolean, date
+//! and ip fields — mapped or dynamic (`<path>.keyword`, numeric paths)
+//! — with OpenSearch's missing-value placement, `search_after` cursors
+//! over the full sort key, and its refusals (text fields, unknown
+//! fields without `unmapped_type`).
+//!
+//! Collection is per split: a segment collector keeps the top-k by a
+//! cheap per-segment key (term ordinals for strings, raw numbers
+//! otherwise), and only the survivors are materialized into comparable
+//! values for the cross-segment and cross-split merges. The implicit
+//! final tiebreak is always (timestamp desc, `_seq` desc), appended to
+//! every hit's `sort` values so a cursor built from them is unique.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::net::Ipv6Addr;
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tantivy::collector::{Collector, SegmentCollector};
+use tantivy::columnar::{Column, DynamicColumn, StrColumn};
+use tantivy::columnar::TermOrdHit;
+use tantivy::{DocAddress, DocId, Score, SegmentOrdinal, SegmentReader};
+
+use rsearch_index::{FieldType, MappedSchema};
+
+use crate::error::{SearchError, SearchResult};
+
+const TIMESTAMP_ALIASES: [&str; 3] = ["@timestamp", "timestamp", "_timestamp"];
+
+/// The value type a sort key is compared and reported as.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortType {
+    /// Exact string (mapped keyword, dynamic `.keyword`).
+    Keyword,
+    /// Integer (mapped long, dynamic integer path, `_seq`).
+    Long,
+    /// Floating point (mapped double, dynamic fractional path).
+    Double,
+    /// Boolean.
+    Boolean,
+    /// Date, as epoch millis.
+    Date,
+    /// IP address.
+    Ip,
+}
+
+impl SortType {
+    fn parse_unmapped(name: &str) -> Option<Self> {
+        match name {
+            "keyword" => Some(Self::Keyword),
+            "long" | "integer" | "short" | "byte" => Some(Self::Long),
+            "double" | "float" | "half_float" => Some(Self::Double),
+            "boolean" => Some(Self::Boolean),
+            "date" => Some(Self::Date),
+            "ip" => Some(Self::Ip),
+            _ => None,
+        }
+    }
+}
+
+/// One `sort` clause as written in the request body.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SortField {
+    /// Field name as requested.
+    pub field: String,
+    /// `order: desc` (`asc` is the default, as in OpenSearch).
+    pub desc: bool,
+    /// `missing`: `_first`, `_last` (default) or a substitute value.
+    pub missing: Option<Value>,
+    /// `unmapped_type`: sort on a field no document holds, as all
+    /// missing, instead of a 400.
+    pub unmapped_type: Option<String>,
+}
+
+impl SortField {
+    /// Parse one entry of a `sort` array: a bare field name or
+    /// `{field: order}` / `{field: {order, missing, unmapped_type, mode}}`.
+    /// `_score` and `_doc` are no-ops (None), as they are alongside a
+    /// field sort in OpenSearch.
+    pub fn parse(entry: &Value) -> SearchResult<Option<Self>> {
+        match entry {
+            Value::String(name) => Ok(Self::named(name)),
+            Value::Object(map) => {
+                let mut parsed = None;
+                for (name, spec) in map {
+                    let Some(mut field) = Self::named(name) else { continue };
+                    match spec {
+                        Value::String(order) => field.desc = parse_order(name, order)?,
+                        Value::Object(opts) => {
+                            for (key, value) in opts {
+                                match key.as_str() {
+                                    "order" => {
+                                        let order = value.as_str().ok_or_else(|| {
+                                            SearchError::BadRequest(format!(
+                                                "sort order for [{name}] must be a string"
+                                            ))
+                                        })?;
+                                        field.desc = parse_order(name, order)?;
+                                    }
+                                    "missing" => field.missing = Some(value.clone()),
+                                    "unmapped_type" => {
+                                        field.unmapped_type =
+                                            Some(value.as_str().unwrap_or("").to_string());
+                                    }
+                                    // Multi-valued fields sort by their
+                                    // min (asc) / max (desc), the default
+                                    // mode; other modes are not supported.
+                                    "mode" => {
+                                        let mode = value.as_str().unwrap_or("");
+                                        if mode != "min" && mode != "max" {
+                                            return Err(SearchError::BadRequest(format!(
+                                                "sort mode [{mode}] on [{name}] is not supported"
+                                            )));
+                                        }
+                                    }
+                                    other => {
+                                        return Err(SearchError::BadRequest(format!(
+                                            "sort option [{other}] on [{name}] is not supported"
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                        other => {
+                            return Err(SearchError::BadRequest(format!(
+                                "sort spec for [{name}] must be an order or an object, got {other}"
+                            )));
+                        }
+                    }
+                    parsed = Some(field);
+                }
+                Ok(parsed)
+            }
+            other => Err(SearchError::BadRequest(format!(
+                "sort entries must be a field name or an object, got {other}"
+            ))),
+        }
+    }
+
+    fn named(name: &str) -> Option<Self> {
+        if name == "_score" || name == "_doc" {
+            return None;
+        }
+        // A bare field name sorts ascending, as in OpenSearch (the
+        // request-level default of newest-first applies only when no
+        // sort is given at all).
+        Some(Self {
+            field: name.to_string(),
+            desc: false,
+            missing: None,
+            unmapped_type: None,
+        })
+    }
+
+    /// Whether this is the timestamp field itself.
+    pub fn is_timestamp(&self) -> bool {
+        TIMESTAMP_ALIASES.contains(&self.field.as_str())
+    }
+}
+
+fn parse_order(name: &str, order: &str) -> SearchResult<bool> {
+    match order {
+        "asc" => Ok(false),
+        "desc" => Ok(true),
+        other => Err(SearchError::BadRequest(format!(
+            "sort order [{other}] on [{name}] is not valid (asc or desc)"
+        ))),
+    }
+}
+
+/// The requested sort of a search.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SortSpec {
+    /// Timestamp order only (the default: newest first).
+    Timestamp {
+        /// Newest first.
+        desc: bool,
+    },
+    /// One or more field clauses, in order (the timestamp may be among
+    /// them); ties broken by (timestamp desc, `_seq` desc).
+    Fields(Vec<SortField>),
+}
+
+impl SortSpec {
+    /// Parse a request's `sort` value (a single entry or an array).
+    /// Clauses on the timestamp alone keep the timestamp fast path; any
+    /// other field switches to a field sort. `_score`/`_doc` are no-ops.
+    pub fn parse(sort: Option<&Value>) -> SearchResult<Self> {
+        let Some(sort) = sort else {
+            return Ok(Self::Timestamp { desc: true });
+        };
+        let entries: Vec<&Value> = match sort {
+            Value::Array(items) => items.iter().collect(),
+            single => vec![single],
+        };
+        let mut fields = Vec::new();
+        for entry in entries {
+            if let Some(field) = SortField::parse(entry)? {
+                fields.push(field);
+            }
+        }
+        if fields.iter().all(|f| f.is_timestamp() && f.missing.is_none()) {
+            let desc = fields.last().map(|f| f.desc).unwrap_or(true);
+            return Ok(Self::Timestamp { desc });
+        }
+        Ok(Self::Fields(fields))
+    }
+
+    /// Timestamp direction when this is a timestamp sort.
+    pub fn timestamp_desc(&self) -> Option<bool> {
+        match self {
+            Self::Timestamp { desc } => Some(*desc),
+            Self::Fields(_) => None,
+        }
+    }
+}
+
+/// Where a resolved sort field's values live.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SortTarget {
+    /// The reserved `_timestamp` column.
+    Timestamp,
+    /// The reserved `_seq` column.
+    Seq,
+    /// An explicitly mapped field (by name).
+    Mapped(String),
+    /// `<path>.keyword` on an unmapped path: the `_dynamic_raw` column.
+    DynamicKeyword(String),
+    /// A numeric or boolean unmapped path: the `_dynamic` column(s).
+    DynamicPath(String),
+    /// No document holds it (`unmapped_type`): every value is missing.
+    Unmapped,
+}
+
+/// A sort clause resolved against the stream.
+#[derive(Clone, Debug)]
+pub struct ResolvedSort {
+    /// Field name as requested.
+    pub field: String,
+    /// Where the values come from.
+    pub target: SortTarget,
+    /// Compared/reported type.
+    pub ty: SortType,
+    /// Descending order.
+    pub desc: bool,
+    /// Missing documents sort as if they held the maximum value.
+    pub null_is_max: bool,
+    /// Substitute value for missing documents (`missing: <value>`).
+    pub substitute: Option<SortValue>,
+}
+
+impl ResolvedSort {
+    fn order(&self) -> FieldOrder {
+        FieldOrder {
+            desc: self.desc,
+            null_is_max: self.null_is_max,
+        }
+    }
+}
+
+/// A materialized sort value: comparable across segments and splits.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SortValue {
+    /// The document has no value for the field.
+    Missing,
+    /// String value.
+    Str(String),
+    /// Integer (long, date millis, `_seq`).
+    I64(i64),
+    /// Floating point.
+    F64(f64),
+    /// Boolean.
+    Bool(bool),
+    /// IP address.
+    Ip(Ipv6Addr),
+}
+
+impl SortValue {
+    /// Natural (ascending) comparison; missing values are placed by
+    /// `null_is_max`.
+    pub fn cmp_natural(&self, other: &Self, null_is_max: bool) -> Ordering {
+        match (self, other) {
+            (SortValue::Missing, SortValue::Missing) => Ordering::Equal,
+            (SortValue::Missing, _) => {
+                if null_is_max { Ordering::Greater } else { Ordering::Less }
+            }
+            (_, SortValue::Missing) => {
+                if null_is_max { Ordering::Less } else { Ordering::Greater }
+            }
+            (SortValue::Str(a), SortValue::Str(b)) => a.cmp(b),
+            (SortValue::I64(a), SortValue::I64(b)) => a.cmp(b),
+            (SortValue::F64(a), SortValue::F64(b)) => a.total_cmp(b),
+            (SortValue::I64(a), SortValue::F64(b)) => (*a as f64).total_cmp(b),
+            (SortValue::F64(a), SortValue::I64(b)) => a.total_cmp(&(*b as f64)),
+            (SortValue::Bool(a), SortValue::Bool(b)) => a.cmp(b),
+            (SortValue::Ip(a), SortValue::Ip(b)) => a.cmp(b),
+            (a, b) => rank(a).cmp(&rank(b)),
+        }
+    }
+
+    /// The JSON value a hit reports for this sort key: OpenSearch's
+    /// sentinels for a missing value (`null` for keywords, the extreme
+    /// long/double in the direction the missing docs were placed).
+    pub fn to_json(&self, ty: SortType, null_is_max: bool) -> Value {
+        match self {
+            SortValue::Missing => match ty {
+                SortType::Keyword | SortType::Ip => Value::Null,
+                SortType::Long | SortType::Date => {
+                    json!(if null_is_max { i64::MAX } else { i64::MIN })
+                }
+                SortType::Double => json!(if null_is_max { "Infinity" } else { "-Infinity" }),
+                SortType::Boolean => json!(if null_is_max { i32::MAX } else { i32::MIN }),
+            },
+            SortValue::Str(s) => json!(s),
+            SortValue::I64(n) => json!(n),
+            SortValue::F64(f) => json!(f),
+            SortValue::Bool(b) => json!(if *b { 1 } else { 0 }),
+            SortValue::Ip(ip) => json!(format_ip(ip)),
+        }
+    }
+}
+
+fn rank(v: &SortValue) -> u8 {
+    match v {
+        SortValue::Missing => 0,
+        SortValue::Bool(_) => 1,
+        SortValue::I64(_) | SortValue::F64(_) => 2,
+        SortValue::Str(_) => 3,
+        SortValue::Ip(_) => 4,
+    }
+}
+
+fn format_ip(ip: &Ipv6Addr) -> String {
+    match ip.to_ipv4_mapped() {
+        Some(v4) => v4.to_string(),
+        None => ip.to_string(),
+    }
+}
+
+/// Direction and missing placement of one sort field, all the merge
+/// needs to order two keys.
+#[derive(Clone, Copy, Debug)]
+pub struct FieldOrder {
+    /// Descending.
+    pub desc: bool,
+    /// Missing values sort as the maximum (before the direction flip).
+    pub null_is_max: bool,
+}
+
+/// Compare two full sort keys in result order (Less = earlier), then by
+/// the implicit (timestamp desc, `_seq` desc) tiebreak.
+pub fn cmp_hits(
+    orders: &[FieldOrder],
+    a: (&[SortValue], i64, i64),
+    b: (&[SortValue], i64, i64),
+) -> Ordering {
+    for (i, order) in orders.iter().enumerate() {
+        let av = a.0.get(i).unwrap_or(&SortValue::Missing);
+        let bv = b.0.get(i).unwrap_or(&SortValue::Missing);
+        let natural = av.cmp_natural(bv, order.null_is_max);
+        let directed = if order.desc { natural.reverse() } else { natural };
+        if directed != Ordering::Equal {
+            return directed;
+        }
+    }
+    b.1.cmp(&a.1).then(b.2.cmp(&a.2))
+}
+
+/// Resolve the requested clauses against the stream: its mapping plus
+/// the inventory of unmapped fields its splits hold (`dynamic`: path →
+/// value types, see `Metastore::stream_dynamic_fields`). Errors match
+/// OpenSearch's: a text field cannot be sorted, an unknown field needs
+/// `unmapped_type`.
+pub fn resolve_sort(
+    fields: &[SortField],
+    schema: &MappedSchema,
+    dynamic: &std::collections::BTreeMap<String, Vec<String>>,
+) -> SearchResult<Vec<ResolvedSort>> {
+    fields
+        .iter()
+        .map(|field| {
+            let name = field.field.as_str();
+            let (target, ty) = if field.is_timestamp() {
+                (SortTarget::Timestamp, SortType::Date)
+            } else if name == rsearch_index::SEQ_FIELD {
+                (SortTarget::Seq, SortType::Long)
+            } else if let Some((_, mapped)) = schema.fields.get(name) {
+                let ty = match mapped {
+                    FieldType::Keyword => SortType::Keyword,
+                    FieldType::Long => SortType::Long,
+                    FieldType::Double => SortType::Double,
+                    FieldType::Boolean => SortType::Boolean,
+                    FieldType::Date => SortType::Date,
+                    FieldType::Ip => SortType::Ip,
+                    FieldType::Text => return Err(text_fielddata(name)),
+                };
+                (SortTarget::Mapped(name.to_string()), ty)
+            } else if let Some(base) = name.strip_suffix(".keyword")
+                && !base.is_empty()
+                && !schema.fields.contains_key(base)
+                && dynamic.get(base).is_some_and(|t| t.iter().any(|t| t == "string"))
+            {
+                (SortTarget::DynamicKeyword(base.to_string()), SortType::Keyword)
+            } else if let Some(types) = dynamic.get(name) {
+                let has = |t: &str| types.iter().any(|x| x == t);
+                if has("string") {
+                    return Err(text_fielddata(name));
+                }
+                let ty = if has("double") {
+                    SortType::Double
+                } else if has("long") {
+                    SortType::Long
+                } else if has("boolean") {
+                    SortType::Boolean
+                } else {
+                    SortType::Date
+                };
+                (SortTarget::DynamicPath(name.to_string()), ty)
+            } else if let Some(unmapped) = &field.unmapped_type {
+                let ty = SortType::parse_unmapped(unmapped).ok_or_else(|| {
+                    SearchError::BadRequest(format!(
+                        "unmapped_type [{unmapped}] on [{name}] is not a sortable type"
+                    ))
+                })?;
+                (SortTarget::Unmapped, ty)
+            } else {
+                return Err(SearchError::BadRequest(format!(
+                    "No mapping found for [{name}] in order to sort on"
+                )));
+            };
+            // OpenSearch places missing documents last in either direction
+            // unless told `_first`; a concrete `missing` value substitutes.
+            let (null_is_max, substitute) = match &field.missing {
+                None => (!field.desc, None),
+                Some(Value::String(s)) if s == "_last" => (!field.desc, None),
+                Some(Value::String(s)) if s == "_first" => (field.desc, None),
+                Some(value) => {
+                    let substitute = parse_sort_value(value, ty).ok_or_else(|| {
+                        SearchError::BadRequest(format!(
+                            "missing value {value} for [{name}] is not a valid {ty:?}"
+                        ))
+                    })?;
+                    (!field.desc, Some(substitute))
+                }
+            };
+            Ok(ResolvedSort {
+                field: name.to_string(),
+                target,
+                ty,
+                desc: field.desc,
+                null_is_max,
+                substitute,
+            })
+        })
+        .collect()
+}
+
+fn text_fielddata(name: &str) -> SearchError {
+    SearchError::BadRequest(format!(
+        "Text fields are not optimised for operations that require per-document field data \
+         like aggregations and sorting, so these operations are disabled by default. Please \
+         use a keyword field instead. Alternatively, set fielddata=true on [{name}] in order \
+         to load field data by uninverting the inverted index. Note that this can use \
+         significant memory."
+    ))
+}
+
+/// Parse a JSON sort value of the given type (a `search_after` element
+/// or a `missing` substitute). `None` = not a value of that type.
+/// OpenSearch's missing-value sentinels parse back as `Missing`.
+pub fn parse_sort_value(value: &Value, ty: SortType) -> Option<SortValue> {
+    if value.is_null() {
+        return Some(SortValue::Missing);
+    }
+    let whole = |v: &Value| {
+        v.as_i64().or_else(|| {
+            v.as_f64()
+                .filter(|f| f.fract() == 0.0 && f.abs() <= 9_007_199_254_740_992.0)
+                .map(|f| f as i64)
+        })
+    };
+    match ty {
+        SortType::Keyword => Some(match value {
+            Value::String(s) => SortValue::Str(s.clone()),
+            other => SortValue::Str(other.to_string()),
+        }),
+        SortType::Long => {
+            let n = whole(value).or_else(|| value.as_str().and_then(|s| s.parse().ok()))?;
+            Some(if n == i64::MAX || n == i64::MIN { SortValue::Missing } else { SortValue::I64(n) })
+        }
+        SortType::Date => {
+            let n = whole(value)
+                .or_else(|| value.as_str().and_then(|s| s.parse().ok()))
+                .or_else(|| crate::query_dsl::parse_time_millis(value))?;
+            Some(if n == i64::MAX || n == i64::MIN { SortValue::Missing } else { SortValue::I64(n) })
+        }
+        SortType::Double => match value {
+            Value::Number(n) => n.as_f64().map(SortValue::F64),
+            Value::String(s) if s == "Infinity" || s == "-Infinity" => Some(SortValue::Missing),
+            Value::String(s) => s.parse::<f64>().ok().map(SortValue::F64),
+            _ => None,
+        },
+        SortType::Boolean => match value {
+            Value::Bool(b) => Some(SortValue::Bool(*b)),
+            Value::Number(n) => match n.as_i64()? {
+                0 => Some(SortValue::Bool(false)),
+                1 => Some(SortValue::Bool(true)),
+                n if n == i32::MAX as i64 || n == i32::MIN as i64 => Some(SortValue::Missing),
+                _ => None,
+            },
+            Value::String(s) => s.parse::<bool>().ok().map(SortValue::Bool),
+            _ => None,
+        },
+        SortType::Ip => {
+            let ip: std::net::IpAddr = value.as_str()?.parse().ok()?;
+            Some(SortValue::Ip(match ip {
+                std::net::IpAddr::V4(v4) => v4.to_ipv6_mapped(),
+                std::net::IpAddr::V6(v6) => v6,
+            }))
+        }
+    }
+}
+
+/// A `search_after` cursor over a field sort: the previous page's sort
+/// values, optionally followed by the implicit (timestamp, `_seq`)
+/// tiebreak values the hits reported.
+#[derive(Clone, Debug)]
+pub struct FieldCursor {
+    /// One value per sort field.
+    pub values: Vec<SortValue>,
+    /// Timestamp tiebreak (epoch millis), when passed back.
+    pub timestamp_millis: Option<i64>,
+    /// `_seq` tiebreak, when passed back.
+    pub seq: Option<i64>,
+}
+
+impl FieldCursor {
+    /// Parse the `search_after` array against the resolved sort: `n`
+    /// values (the field values only: a page of equal keys is skipped,
+    /// as in OpenSearch with a non-unique sort), or `n + 2` with the
+    /// tiebreak values a hit reported (`n + 1` with the timestamp only).
+    pub fn parse(values: &[Value], resolved: &[ResolvedSort]) -> SearchResult<Self> {
+        let n = resolved.len();
+        if values.len() < n || values.len() > n + 2 {
+            return Err(SearchError::BadRequest(format!(
+                "search_after has {} value(s) but sort has {n}.",
+                values.len()
+            )));
+        }
+        let mut parsed = Vec::with_capacity(n);
+        for (value, sort) in values.iter().zip(resolved) {
+            parsed.push(parse_sort_value(value, sort.ty).ok_or_else(|| {
+                SearchError::BadRequest(format!(
+                    "search_after value {value} for [{}] is not a valid {:?}",
+                    sort.field, sort.ty
+                ))
+            })?);
+        }
+        let as_i64 = |v: &Value, what: &str| {
+            parse_sort_value(v, SortType::Long)
+                .and_then(|p| match p {
+                    SortValue::I64(n) => Some(n),
+                    SortValue::Missing => Some(-1),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    SearchError::BadRequest(format!("search_after {what} must be an integer"))
+                })
+        };
+        let timestamp_millis = values
+            .get(n)
+            .map(|v| as_i64(v, "timestamp tiebreak"))
+            .transpose()?
+            .map(|ms| ms.clamp(-rsearch_index::MAX_SAFE_MILLIS, rsearch_index::MAX_SAFE_MILLIS));
+        let seq = values.get(n + 1).map(|v| as_i64(v, "_seq tiebreak")).transpose()?;
+        Ok(Self {
+            values: parsed,
+            timestamp_millis,
+            seq,
+        })
+    }
+}
+
+/// The complete field-sort plan for one search.
+#[derive(Clone, Debug)]
+pub struct FieldSortPlan {
+    /// Resolved clauses, in order.
+    pub fields: Vec<ResolvedSort>,
+    /// Resume strictly past this position.
+    pub cursor: Option<FieldCursor>,
+}
+
+impl FieldSortPlan {
+    /// Per-field direction and missing placement.
+    pub fn orders(&self) -> Vec<FieldOrder> {
+        self.fields.iter().map(ResolvedSort::order).collect()
+    }
+
+    /// The `sort` values a hit reports: the field values, then the
+    /// (timestamp, `_seq`) tiebreak.
+    pub fn hit_sort_json(&self, values: &[SortValue], ts: i64, seq: i64) -> Value {
+        let mut out: Vec<Value> = self
+            .fields
+            .iter()
+            .enumerate()
+            .map(|(i, f)| {
+                values
+                    .get(i)
+                    .unwrap_or(&SortValue::Missing)
+                    .to_json(f.ty, f.null_is_max)
+            })
+            .collect();
+        out.push(json!(ts));
+        out.push(json!(seq));
+        Value::Array(out)
+    }
+}
+
+/// A hit as collected by [`FieldSortCollector`].
+#[derive(Clone, Debug)]
+pub struct SortedHit {
+    /// Materialized sort values, one per field.
+    pub values: Vec<SortValue>,
+    /// Timestamp tiebreak (epoch millis).
+    pub timestamp_millis: i64,
+    /// `_seq` tiebreak (-1 on legacy splits).
+    pub seq: i64,
+    /// The document.
+    pub doc: DocAddress,
+}
+
+/// Cheap per-segment key: term ordinals stand in for strings (doubled,
+/// with +1 for an exact term, so a cursor string absent from the
+/// dictionary sits between two ordinals), numbers and booleans as they
+/// are. Comparable only within one segment.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum SegKey {
+    Missing,
+    Ord(u64),
+    I64(i64),
+    F64(f64),
+    Bool(bool),
+    Ip(u128),
+}
+
+impl SegKey {
+    fn cmp_natural(&self, other: &Self, null_is_max: bool) -> Ordering {
+        match (self, other) {
+            (SegKey::Missing, SegKey::Missing) => Ordering::Equal,
+            (SegKey::Missing, _) => {
+                if null_is_max { Ordering::Greater } else { Ordering::Less }
+            }
+            (_, SegKey::Missing) => {
+                if null_is_max { Ordering::Less } else { Ordering::Greater }
+            }
+            (SegKey::Ord(a), SegKey::Ord(b)) => a.cmp(b),
+            (SegKey::I64(a), SegKey::I64(b)) => a.cmp(b),
+            (SegKey::F64(a), SegKey::F64(b)) => a.total_cmp(b),
+            (SegKey::I64(a), SegKey::F64(b)) => (*a as f64).total_cmp(b),
+            (SegKey::F64(a), SegKey::I64(b)) => a.total_cmp(&(*b as f64)),
+            (SegKey::Bool(a), SegKey::Bool(b)) => a.cmp(b),
+            (SegKey::Ip(a), SegKey::Ip(b)) => a.cmp(b),
+            // Mixed kinds only arise from a cursor typed differently from
+            // the segment's column; order them by kind, consistently.
+            (a, b) => a.kind().cmp(&b.kind()),
+        }
+    }
+
+    fn kind(&self) -> u8 {
+        match self {
+            SegKey::Missing => 0,
+            SegKey::Bool(_) => 1,
+            SegKey::I64(_) | SegKey::F64(_) => 2,
+            SegKey::Ord(_) => 3,
+            SegKey::Ip(_) => 4,
+        }
+    }
+}
+
+/// How one sort field reads its value in one segment.
+enum SegAccessor {
+    /// The field has no column here: every document is missing.
+    None,
+    Str(StrColumn),
+    I64(Column<i64>),
+    F64(Column<f64>),
+    Bool(Column<bool>),
+    Date(Column<tantivy::DateTime>),
+    Ip(Column<Ipv6Addr>),
+}
+
+impl SegAccessor {
+    /// The document's key: min of its values for asc, max for desc.
+    fn key(&self, doc: DocId, desc: bool) -> SegKey {
+        fn pick<T: Copy, I: Iterator<Item = T>>(
+            iter: I,
+            desc: bool,
+            cmp: impl Fn(&T, &T) -> Ordering,
+        ) -> Option<T> {
+            if desc {
+                iter.max_by(|a, b| cmp(a, b))
+            } else {
+                iter.min_by(|a, b| cmp(a, b))
+            }
+        }
+        match self {
+            SegAccessor::None => SegKey::Missing,
+            SegAccessor::Str(col) => pick(col.term_ords(doc), desc, |a, b| a.cmp(b))
+                .map(|o| SegKey::Ord(o * 2 + 1))
+                .unwrap_or(SegKey::Missing),
+            SegAccessor::I64(col) => pick(col.values_for_doc(doc), desc, |a, b| a.cmp(b))
+                .map(SegKey::I64)
+                .unwrap_or(SegKey::Missing),
+            SegAccessor::F64(col) => pick(col.values_for_doc(doc), desc, |a, b| a.total_cmp(b))
+                .map(SegKey::F64)
+                .unwrap_or(SegKey::Missing),
+            SegAccessor::Bool(col) => pick(col.values_for_doc(doc), desc, |a, b| a.cmp(b))
+                .map(SegKey::Bool)
+                .unwrap_or(SegKey::Missing),
+            SegAccessor::Date(col) => pick(
+                col.values_for_doc(doc).map(|d| d.into_timestamp_millis()),
+                desc,
+                |a, b| a.cmp(b),
+            )
+            .map(SegKey::I64)
+            .unwrap_or(SegKey::Missing),
+            SegAccessor::Ip(col) => pick(col.values_for_doc(doc), desc, |a, b| a.cmp(b))
+                .map(|ip| SegKey::Ip(ip.to_bits()))
+                .unwrap_or(SegKey::Missing),
+        }
+    }
+
+    /// A materialized value's position in this segment's key space.
+    fn key_for(&self, value: &SortValue) -> SegKey {
+        match (self, value) {
+            (_, SortValue::Missing) => SegKey::Missing,
+            (SegAccessor::Str(col), SortValue::Str(s)) => {
+                match col.dictionary().term_ord_or_next(s.as_bytes()) {
+                    Ok(TermOrdHit::Exact(o)) => SegKey::Ord(o * 2 + 1),
+                    Ok(TermOrdHit::Next(o)) => SegKey::Ord(o.saturating_mul(2)),
+                    Err(_) => SegKey::Ord(0),
+                }
+            }
+            (_, SortValue::Str(_)) => SegKey::Ord(0),
+            (_, SortValue::I64(n)) => SegKey::I64(*n),
+            (_, SortValue::F64(f)) => SegKey::F64(*f),
+            (_, SortValue::Bool(b)) => SegKey::Bool(*b),
+            (_, SortValue::Ip(ip)) => SegKey::Ip(ip.to_bits()),
+        }
+    }
+
+    /// Materialize a key collected from this segment.
+    fn materialize(&self, key: SegKey) -> SortValue {
+        match (self, key) {
+            (_, SegKey::Missing) => SortValue::Missing,
+            (SegAccessor::Str(col), SegKey::Ord(o)) => {
+                let mut out = String::new();
+                match col.ord_to_str(o / 2, &mut out) {
+                    Ok(true) => SortValue::Str(out),
+                    _ => SortValue::Missing,
+                }
+            }
+            (_, SegKey::Ord(_)) => SortValue::Missing,
+            (_, SegKey::I64(n)) => SortValue::I64(n),
+            (_, SegKey::F64(f)) => SortValue::F64(f),
+            (_, SegKey::Bool(b)) => SortValue::Bool(b),
+            (_, SegKey::Ip(bits)) => SortValue::Ip(Ipv6Addr::from_bits(bits)),
+        }
+    }
+}
+
+/// Open the column a resolved sort reads in `segment`, under the split's
+/// own schema (a field mapped after the split was written is read from
+/// its dynamic path there).
+fn open_accessor(
+    segment: &SegmentReader,
+    schema: &MappedSchema,
+    sort: &ResolvedSort,
+) -> SegAccessor {
+    let ff = segment.fast_fields();
+    let typed = |name: &str, ty: SortType| -> SegAccessor {
+        match ty {
+            SortType::Keyword => ff.str(name).ok().flatten().map(SegAccessor::Str),
+            SortType::Long => ff.column_opt::<i64>(name).ok().flatten().map(SegAccessor::I64),
+            SortType::Double => ff.column_opt::<f64>(name).ok().flatten().map(SegAccessor::F64),
+            SortType::Boolean => ff.column_opt::<bool>(name).ok().flatten().map(SegAccessor::Bool),
+            SortType::Date => ff
+                .column_opt::<tantivy::DateTime>(name)
+                .ok()
+                .flatten()
+                .map(SegAccessor::Date),
+            SortType::Ip => ff.column_opt::<Ipv6Addr>(name).ok().flatten().map(SegAccessor::Ip),
+        }
+        .unwrap_or(SegAccessor::None)
+    };
+    // A numeric path in `_dynamic` may hold i64, u64 and f64 columns;
+    // read them as one numeric column of the requested kind.
+    let dynamic_numeric = |path: &str, ty: SortType| -> SegAccessor {
+        let name = format!("{}.{path}", rsearch_index::DYNAMIC_FIELD);
+        match ty {
+            SortType::Boolean => typed(&name, SortType::Boolean),
+            SortType::Long | SortType::Double | SortType::Date => {
+                let handles = ff.dynamic_column_handles(&name).unwrap_or_default();
+                let numeric = handles
+                    .into_iter()
+                    .find(|h| h.column_type().numerical_type().is_some());
+                let Some(handle) = numeric else { return SegAccessor::None };
+                let Ok(column) = handle.open() else { return SegAccessor::None };
+                let target = if ty == SortType::Double {
+                    tantivy::columnar::NumericalType::F64
+                } else {
+                    tantivy::columnar::NumericalType::I64
+                };
+                match column.coerce_numerical(target) {
+                    Some(DynamicColumn::I64(col)) => SegAccessor::I64(col),
+                    Some(DynamicColumn::F64(col)) => SegAccessor::F64(col),
+                    _ => SegAccessor::None,
+                }
+            }
+            _ => SegAccessor::None,
+        }
+    };
+    match &sort.target {
+        SortTarget::Timestamp => typed(rsearch_index::TIMESTAMP_FIELD, SortType::Date),
+        SortTarget::Seq => typed(rsearch_index::SEQ_FIELD, SortType::Long),
+        SortTarget::Mapped(name) => {
+            if schema.fields.contains_key(name) {
+                typed(name, sort.ty)
+            } else if sort.ty == SortType::Keyword {
+                typed(&format!("{}.{name}", rsearch_index::DYNAMIC_RAW_FIELD), sort.ty)
+            } else {
+                dynamic_numeric(name, sort.ty)
+            }
+        }
+        SortTarget::DynamicKeyword(path) => {
+            typed(&format!("{}.{path}", rsearch_index::DYNAMIC_RAW_FIELD), SortType::Keyword)
+        }
+        SortTarget::DynamicPath(path) => dynamic_numeric(path, sort.ty),
+        SortTarget::Unmapped => SegAccessor::None,
+    }
+}
+
+/// Top-k collector ordered by a field sort, with the cursor applied per
+/// document. Fruit: the split's page candidates in result order.
+pub struct FieldSortCollector {
+    plan: Arc<FieldSortPlan>,
+    schema: Arc<MappedSchema>,
+    limit: usize,
+}
+
+impl FieldSortCollector {
+    /// Collect at most `limit` hits ordered by `plan` from a split built
+    /// under `schema`.
+    pub fn new(plan: Arc<FieldSortPlan>, schema: Arc<MappedSchema>, limit: usize) -> Self {
+        Self {
+            plan,
+            schema,
+            limit: limit.max(1),
+        }
+    }
+}
+
+/// A collected document, ordered by the segment's key space.
+struct Ranked {
+    keys: Vec<SegKey>,
+    ts: i64,
+    seq: i64,
+    doc: DocId,
+}
+
+/// Compare in result order (Less = earlier), tiebreak by doc id.
+fn cmp_ranked(orders: &[FieldOrder], a: &Ranked, b: &Ranked) -> Ordering {
+    for (i, order) in orders.iter().enumerate() {
+        let natural = a.keys[i].cmp_natural(&b.keys[i], order.null_is_max);
+        let directed = if order.desc { natural.reverse() } else { natural };
+        if directed != Ordering::Equal {
+            return directed;
+        }
+    }
+    b.ts.cmp(&a.ts)
+        .then(b.seq.cmp(&a.seq))
+        .then(a.doc.cmp(&b.doc))
+}
+
+/// Heap element: the result-order comparison makes the heap's max the
+/// last-ranked entry, i.e. the one to evict.
+struct HeapItem {
+    ranked: Ranked,
+    orders: Arc<[FieldOrder]>,
+}
+
+impl PartialEq for HeapItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for HeapItem {}
+impl PartialOrd for HeapItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for HeapItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        cmp_ranked(&self.orders, &self.ranked, &other.ranked)
+    }
+}
+
+/// Per-segment state of [`FieldSortCollector`].
+pub struct FieldSortSegmentCollector {
+    accessors: Vec<SegAccessor>,
+    fields: Arc<FieldSortPlan>,
+    orders: Arc<[FieldOrder]>,
+    /// Cursor in this segment's key space, with the tiebreak values.
+    cursor: Option<(Vec<SegKey>, Option<i64>, Option<i64>)>,
+    /// Substitute keys for `missing: <value>` fields, per field.
+    substitutes: Vec<Option<SegKey>>,
+    ts: Option<Column<tantivy::DateTime>>,
+    seq: Option<Column<i64>>,
+    segment_ord: SegmentOrdinal,
+    limit: usize,
+    heap: BinaryHeap<HeapItem>,
+}
+
+impl FieldSortSegmentCollector {
+    fn keys_for(&self, doc: DocId) -> Vec<SegKey> {
+        self.accessors
+            .iter()
+            .zip(&self.fields.fields)
+            .zip(&self.substitutes)
+            .map(|((accessor, sort), substitute)| {
+                let key = accessor.key(doc, sort.desc);
+                match (key, substitute) {
+                    (SegKey::Missing, Some(sub)) => *sub,
+                    (key, _) => key,
+                }
+            })
+            .collect()
+    }
+
+    /// Strictly past the cursor in result order?
+    fn after_cursor(&self, ranked: &Ranked) -> bool {
+        let Some((keys, ts, seq)) = &self.cursor else { return true };
+        for (i, order) in self.orders.iter().enumerate() {
+            let natural = ranked.keys[i].cmp_natural(&keys[i], order.null_is_max);
+            let directed = if order.desc { natural.reverse() } else { natural };
+            match directed {
+                Ordering::Less => return false,
+                Ordering::Greater => return true,
+                Ordering::Equal => {}
+            }
+        }
+        let Some(cursor_ts) = ts else { return false };
+        // Tiebreak: timestamp desc, then seq desc.
+        match cursor_ts.cmp(&ranked.ts) {
+            Ordering::Less => false,
+            Ordering::Greater => true,
+            Ordering::Equal => match seq {
+                Some(cursor_seq) => ranked.seq < *cursor_seq,
+                None => false,
+            },
+        }
+    }
+}
+
+impl Collector for FieldSortCollector {
+    type Fruit = Vec<SortedHit>;
+    type Child = FieldSortSegmentCollector;
+
+    fn for_segment(
+        &self,
+        segment_ord: SegmentOrdinal,
+        segment: &SegmentReader,
+    ) -> tantivy::Result<Self::Child> {
+        let accessors: Vec<SegAccessor> = self
+            .plan
+            .fields
+            .iter()
+            .map(|sort| open_accessor(segment, &self.schema, sort))
+            .collect();
+        let substitutes = accessors
+            .iter()
+            .zip(&self.plan.fields)
+            .map(|(accessor, sort)| sort.substitute.as_ref().map(|v| accessor.key_for(v)))
+            .collect();
+        let cursor = self.plan.cursor.as_ref().map(|c| {
+            let keys = accessors
+                .iter()
+                .zip(&c.values)
+                .map(|(accessor, value)| accessor.key_for(value))
+                .collect();
+            (keys, c.timestamp_millis, c.seq)
+        });
+        let ff = segment.fast_fields();
+        Ok(FieldSortSegmentCollector {
+            accessors,
+            fields: self.plan.clone(),
+            orders: self.plan.orders().into(),
+            cursor,
+            substitutes,
+            ts: ff.column_opt::<tantivy::DateTime>(rsearch_index::TIMESTAMP_FIELD)?,
+            seq: ff.column_opt::<i64>(rsearch_index::SEQ_FIELD)?,
+            segment_ord,
+            limit: self.limit,
+            heap: BinaryHeap::with_capacity(self.limit + 1),
+        })
+    }
+
+    fn requires_scoring(&self) -> bool {
+        false
+    }
+
+    fn merge_fruits(&self, segment_fruits: Vec<Vec<SortedHit>>) -> tantivy::Result<Self::Fruit> {
+        let orders = self.plan.orders();
+        let mut all: Vec<SortedHit> = segment_fruits.into_iter().flatten().collect();
+        all.sort_by(|a, b| {
+            cmp_hits(
+                &orders,
+                (&a.values, a.timestamp_millis, a.seq),
+                (&b.values, b.timestamp_millis, b.seq),
+            )
+            .then(a.doc.cmp(&b.doc))
+        });
+        all.truncate(self.limit);
+        Ok(all)
+    }
+}
+
+impl SegmentCollector for FieldSortSegmentCollector {
+    type Fruit = Vec<SortedHit>;
+
+    fn collect(&mut self, doc: DocId, _score: Score) {
+        let ranked = Ranked {
+            keys: self.keys_for(doc),
+            ts: self
+                .ts
+                .as_ref()
+                .and_then(|c| c.first(doc))
+                .map(|d| d.into_timestamp_millis())
+                .unwrap_or_default(),
+            seq: self.seq.as_ref().and_then(|c| c.first(doc)).unwrap_or(-1),
+            doc,
+        };
+        if !self.after_cursor(&ranked) {
+            return;
+        }
+        if self.heap.len() < self.limit {
+            self.heap.push(HeapItem {
+                ranked,
+                orders: self.orders.clone(),
+            });
+            return;
+        }
+        if let Some(top) = self.heap.peek()
+            && cmp_ranked(&self.orders, &ranked, &top.ranked) == Ordering::Less
+        {
+            self.heap.pop();
+            self.heap.push(HeapItem {
+                ranked,
+                orders: self.orders.clone(),
+            });
+        }
+    }
+
+    fn harvest(self) -> Self::Fruit {
+        let mut out: Vec<SortedHit> = self
+            .heap
+            .into_sorted_vec()
+            .into_iter()
+            .map(|item| {
+                let values = item
+                    .ranked
+                    .keys
+                    .iter()
+                    .zip(&self.accessors)
+                    .zip(&self.fields.fields)
+                    .zip(&self.substitutes)
+                    .map(|(((key, accessor), sort), substitute)| {
+                        if substitute.is_some_and(|s| s == *key) {
+                            sort.substitute.clone().unwrap_or(SortValue::Missing)
+                        } else {
+                            accessor.materialize(*key)
+                        }
+                    })
+                    .collect();
+                SortedHit {
+                    values,
+                    timestamp_millis: item.ranked.ts,
+                    seq: item.ranked.seq,
+                    doc: DocAddress::new(self.segment_ord, item.ranked.doc),
+                }
+            })
+            .collect();
+        // into_sorted_vec is ascending by Ord, i.e. result order already.
+        out.shrink_to_fit();
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rsearch_index::{DocIdentity, DocumentConverter, IndexMapping};
+    use tantivy::query::AllQuery;
+
+    fn index(mapping: Value, docs: &[Value]) -> (Arc<MappedSchema>, tantivy::Index) {
+        let schema = MappedSchema::build(IndexMapping::from_json(&mapping).unwrap());
+        let index = schema.create_in_ram();
+        let converter = DocumentConverter::new(schema.clone());
+        let mut writer = index.writer_with_num_threads(1, 20 << 20).unwrap();
+        for (i, doc) in docs.iter().enumerate() {
+            let identity = DocIdentity::new(format!("d{i}"), i as i64 + 1);
+            let (doc, _) = converter
+                .convert_with_source(
+                    doc.clone(),
+                    None,
+                    &identity,
+                    tantivy::DateTime::from_timestamp_millis(1_000 + i as i64),
+                )
+                .unwrap();
+            writer.add_document(doc).unwrap();
+        }
+        writer.commit().unwrap();
+        (Arc::new(schema), index)
+    }
+
+    fn dynamic(entries: &[(&str, &[&str])]) -> std::collections::BTreeMap<String, Vec<String>> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.iter().map(|s| s.to_string()).collect()))
+            .collect()
+    }
+
+    fn run(
+        index: &tantivy::Index,
+        schema: &Arc<MappedSchema>,
+        plan: FieldSortPlan,
+        limit: usize,
+    ) -> Vec<SortedHit> {
+        let searcher = index.reader().unwrap().searcher();
+        searcher
+            .search(
+                &AllQuery,
+                &FieldSortCollector::new(Arc::new(plan), schema.clone(), limit),
+            )
+            .unwrap()
+    }
+
+    fn ids(hits: &[SortedHit]) -> Vec<u32> {
+        hits.iter().map(|h| h.doc.doc_id).collect()
+    }
+
+    const MAPPING: &str = r#"{"properties": {"name": {"type": "keyword"}, "age": {"type": "long"},
+        "score": {"type": "double"}, "ok": {"type": "boolean"}, "born": {"type": "date"},
+        "bio": {"type": "text"}, "ip": {"type": "ip"}}}"#;
+
+    fn docs() -> Vec<Value> {
+        vec![
+            json!({"name": "bob", "age": 30, "score": 1.5, "ok": true, "born": "1990-01-01T00:00:00Z", "role": "tech_admin", "n": 2, "ip": "10.0.0.2"}),
+            json!({"name": "alice", "age": 25, "score": 2.0, "ok": false, "born": "1995-06-01T00:00:00Z", "role": "user", "n": 1.5, "ip": "10.0.0.1"}),
+            json!({"name": "carol", "bio": "e f", "n": 3}),
+        ]
+    }
+
+    fn resolve(sort: Value, schema: &MappedSchema) -> SearchResult<Vec<ResolvedSort>> {
+        let entries: Vec<Value> = match sort {
+            Value::Array(items) => items,
+            single => vec![single],
+        };
+        let fields: Vec<SortField> = entries
+            .iter()
+            .filter_map(|e| SortField::parse(e).transpose())
+            .collect::<SearchResult<_>>()?;
+        resolve_sort(
+            &fields,
+            schema,
+            &dynamic(&[("role", &["string"]), ("n", &["long", "double"])]),
+        )
+    }
+
+    #[test]
+    fn parses_sort_entries() {
+        let f = SortField::parse(&json!("name")).unwrap().unwrap();
+        assert_eq!((f.field.as_str(), f.desc), ("name", false));
+        let f = SortField::parse(&json!({"@timestamp": "asc"})).unwrap().unwrap();
+        assert_eq!((f.field.as_str(), f.desc), ("@timestamp", false));
+        let f = SortField::parse(&json!({"age": {"order": "desc", "missing": "_first", "unmapped_type": "long", "mode": "max"}}))
+            .unwrap()
+            .unwrap();
+        assert!(f.desc && f.missing == Some(json!("_first")) && f.unmapped_type.as_deref() == Some("long"));
+        assert!(SortField::parse(&json!("_score")).unwrap().is_none());
+        assert!(SortField::parse(&json!({"_doc": "asc"})).unwrap().is_none());
+        for bad in [
+            json!({"age": "sideways"}),
+            json!({"age": {"order": "asc", "nested": {}}}),
+            json!({"age": {"mode": "avg"}}),
+            json!(42),
+        ] {
+            assert!(SortField::parse(&bad).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn resolves_like_opensearch() {
+        let (schema, _) = index(serde_json::from_str(MAPPING).unwrap(), &[]);
+        let ok = |sort: Value| resolve(sort, &schema).unwrap();
+        assert_eq!(ok(json!([{"name": "asc"}]))[0].ty, SortType::Keyword);
+        assert_eq!(ok(json!([{"age": "asc"}]))[0].ty, SortType::Long);
+        assert_eq!(ok(json!([{"born": "asc"}]))[0].ty, SortType::Date);
+        assert_eq!(ok(json!([{"ip": "asc"}]))[0].ty, SortType::Ip);
+        assert_eq!(ok(json!([{"role.keyword": "asc"}]))[0].target, SortTarget::DynamicKeyword("role".into()));
+        assert_eq!(ok(json!([{"n": "asc"}]))[0].ty, SortType::Double);
+        assert_eq!(ok(json!([{"zzz": {"unmapped_type": "long"}}]))[0].target, SortTarget::Unmapped);
+        // Missing placement: last in both directions unless _first.
+        assert!(ok(json!([{"age": "asc"}]))[0].null_is_max);
+        assert!(!ok(json!([{"age": "desc"}]))[0].null_is_max);
+        assert!(!ok(json!([{"age": {"order": "asc", "missing": "_first"}}]))[0].null_is_max);
+        assert_eq!(
+            ok(json!([{"age": {"order": "asc", "missing": 27}}]))[0].substitute,
+            Some(SortValue::I64(27))
+        );
+        let err = |sort: Value| resolve(sort, &schema).unwrap_err().to_string();
+        assert!(err(json!([{"bio": "asc"}])).starts_with("Text fields are not optimised"));
+        assert!(err(json!([{"role": "asc"}])).starts_with("Text fields are not optimised"));
+        assert_eq!(err(json!([{"zzz": "asc"}])), "No mapping found for [zzz] in order to sort on");
+        assert_eq!(err(json!([{"name.keyword": "asc"}])), "No mapping found for [name.keyword] in order to sort on");
+    }
+
+    #[test]
+    fn sorts_every_type_with_missing_last() {
+        let (schema, index) = index(serde_json::from_str(MAPPING).unwrap(), &docs());
+        let plan = |sort: Value| FieldSortPlan {
+            fields: resolve(sort, &schema).unwrap(),
+            cursor: None,
+        };
+        // docs: 0=bob 1=alice 2=carol(missing most fields)
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"name": "asc"}])), 10)), vec![1, 0, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"name": "desc"}])), 10)), vec![2, 0, 1]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"age": "asc"}])), 10)), vec![1, 0, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"age": "desc"}])), 10)), vec![0, 1, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"age": {"order": "asc", "missing": "_first"}}])), 10)), vec![2, 1, 0]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"age": {"order": "asc", "missing": 27}}])), 10)), vec![1, 2, 0]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"score": "desc"}])), 10)), vec![1, 0, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"ok": "asc"}])), 10)), vec![1, 0, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"born": "asc"}])), 10)), vec![0, 1, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"ip": "desc"}])), 10)), vec![0, 1, 2]);
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"role.keyword": "desc"}])), 10)), vec![1, 0, 2]);
+        // Dynamic numeric path mixing integers and fractions.
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"n": "asc"}])), 10)), vec![1, 0, 2]);
+        // Unmapped: all missing, falls to the (ts desc) tiebreak.
+        assert_eq!(ids(&run(&index, &schema, plan(json!([{"zzz": {"order": "asc", "unmapped_type": "long"}}])), 10)), vec![2, 1, 0]);
+        // Reported values.
+        let hits = run(&index, &schema, plan(json!([{"age": "asc"}])), 10);
+        let p = plan(json!([{"age": "asc"}]));
+        assert_eq!(p.hit_sort_json(&hits[0].values, hits[0].timestamp_millis, hits[0].seq), json!([25, 1001, 2]));
+        assert_eq!(p.hit_sort_json(&hits[2].values, hits[2].timestamp_millis, hits[2].seq), json!([i64::MAX, 1002, 3]));
+        let hits = run(&index, &schema, plan(json!([{"role.keyword": "desc"}])), 10);
+        let p = plan(json!([{"role.keyword": "desc"}]));
+        assert_eq!(p.hit_sort_json(&hits[2].values, hits[2].timestamp_millis, hits[2].seq), json!([Value::Null, 1002, 3]));
+        let hits = run(&index, &schema, plan(json!([{"score": "desc"}])), 10);
+        let p = plan(json!([{"score": "desc"}]));
+        assert_eq!(p.hit_sort_json(&hits[2].values, hits[2].timestamp_millis, hits[2].seq), json!(["-Infinity", 1002, 3]));
+        let hits = run(&index, &schema, plan(json!([{"ip": "desc"}])), 10);
+        let p = plan(json!([{"ip": "desc"}]));
+        assert_eq!(p.hit_sort_json(&hits[0].values, hits[0].timestamp_millis, hits[0].seq), json!(["10.0.0.2", 1000, 1]));
+    }
+
+    #[test]
+    fn cursor_pages_without_gaps_or_repeats() {
+        let (schema, index) = index(serde_json::from_str(MAPPING).unwrap(), &docs());
+        let resolved = resolve(json!([{"age": "asc"}, {"name": "desc"}]), &schema).unwrap();
+        let mut seen = Vec::new();
+        let mut cursor: Option<FieldCursor> = None;
+        loop {
+            let plan = FieldSortPlan {
+                fields: resolved.clone(),
+                cursor: cursor.clone(),
+            };
+            let page = run(&index, &schema, plan.clone(), 1);
+            let Some(hit) = page.first() else { break };
+            seen.push(hit.doc.doc_id);
+            let sort = plan.hit_sort_json(&hit.values, hit.timestamp_millis, hit.seq);
+            cursor = Some(FieldCursor::parse(sort.as_array().unwrap(), &resolved).unwrap());
+            assert!(seen.len() <= 3, "looped");
+        }
+        assert_eq!(seen, vec![1, 0, 2]);
+        // Field-only cursor (as an OpenSearch client would pass) at the
+        // missing sentinel: the missing doc is not repeated.
+        let cursor = FieldCursor::parse(&[json!(i64::MAX), json!(Value::Null)], &resolved).unwrap();
+        assert_eq!(cursor.values, vec![SortValue::Missing, SortValue::Missing]);
+        let plan = FieldSortPlan { fields: resolved.clone(), cursor: Some(cursor) };
+        assert!(run(&index, &schema, plan, 10).is_empty());
+        // Wrong arity.
+        assert!(FieldCursor::parse(&[json!(1)], &resolved).is_err());
+        assert!(FieldCursor::parse(&[json!(1), json!("a"), json!(1), json!(1), json!(1)], &resolved).is_err());
+        // A string cursor between two dictionary terms resumes correctly.
+        let resolved = resolve(json!([{"name": "asc"}]), &schema).unwrap();
+        let cursor = FieldCursor::parse(&[json!("b")], &resolved).unwrap();
+        let plan = FieldSortPlan { fields: resolved, cursor: Some(cursor) };
+        assert_eq!(ids(&run(&index, &schema, plan, 10)), vec![0, 2]);
+    }
+
+    #[test]
+    fn heap_keeps_the_right_end_of_large_groups() {
+        let docs: Vec<Value> = (0..50).map(|i| json!({"age": i % 5, "name": format!("n{i:02}")})).collect();
+        let (schema, index) = index(serde_json::from_str(MAPPING).unwrap(), &docs);
+        let resolved = resolve(json!([{"age": "desc"}, {"name": "asc"}]), &schema).unwrap();
+        let plan = FieldSortPlan { fields: resolved, cursor: None };
+        let hits = run(&index, &schema, plan, 3);
+        let names: Vec<String> = hits
+            .iter()
+            .map(|h| match &h.values[1] {
+                SortValue::Str(s) => s.clone(),
+                _ => unreachable!(),
+            })
+            .collect();
+        // age 4 is docs 4, 9, 14, …: names n04, n09, n14 first.
+        assert_eq!(names, vec!["n04", "n09", "n14"]);
+    }
+}

--- a/crates/rsearch-server/Cargo.toml
+++ b/crates/rsearch-server/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 tokio.workspace = true
 axum.workspace = true
 serde_json.workspace = true
+uuid.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 clap.workspace = true

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -151,7 +151,8 @@ pub struct Identity {
 }
 
 impl Identity {
-    fn allows_stream(&self, stream: &str) -> bool {
+    /// Whether this identity's stream scope covers `stream`.
+    pub fn allows_stream(&self, stream: &str) -> bool {
         self.streams.iter().any(|s| stream_glob_matches(s, stream))
     }
 }
@@ -186,6 +187,9 @@ enum Action {
     Open,
     Ingest(Option<String>),
     Search(Option<String>),
+    /// Search on a stream named by server-side state (a scroll context)
+    /// rather than the path; the handler checks the stream scope.
+    SearchContext,
     Admin,
 }
 
@@ -214,8 +218,16 @@ fn classify(method: &str, path: &str) -> Action {
             Action::Search(Some(index.to_string()))
         }
         // Search / read
-        (_, [index, "_search"]) => Action::Search(Some(index.to_string())),
+        (_, [index, "_search"]) | (_, [index, "_count"]) => {
+            Action::Search(Some(index.to_string()))
+        }
+        // Mapping updates are index setup, the same level as PUT /{index}.
+        ("PUT", [index, "_mapping"]) => Action::Ingest(Some(index.to_string())),
         ("POST", ["_msearch"]) => Action::Search(None),
+        // Scroll continuation/clear (#72): the stream is in the stored
+        // context, not the path — the handler checks it against the
+        // identity's scope.
+        (_, ["_search", "scroll", ..]) => Action::SearchContext,
         ("GET", [index, "_mapping"]) | ("GET", [index, "_settings"]) => {
             Action::Search(Some(index.to_string()))
         }
@@ -228,7 +240,11 @@ fn classify(method: &str, path: &str) -> Action {
         // above. Index creation / mapping update is an ingest-level action:
         // an ingest key scoped to a stream already creates it implicitly
         // via _bulk, so PUT /{index} (mode + mapping) needs no more.
-        ("PUT", [index]) if !index.starts_with('_') => {
+        // DELETE /{index} is the drop half of an application's
+        // drop-and-rebuild reindex, so it sits at the same level; the
+        // handler re-checks every stream a wildcard or list resolves to
+        // against the identity's scope.
+        ("PUT" | "DELETE", [index]) if !index.starts_with('_') => {
             Action::Ingest(Some(index.to_string()))
         }
         ("GET" | "HEAD", [index]) if !index.starts_with('_') => {
@@ -395,6 +411,7 @@ pub async fn require(
                     None => identity.streams.iter().any(|s| s == "*"),
                 }
         }
+        Action::SearchContext => identity.actions.contains("search"),
     };
     if !allowed {
         return forbidden(&format!(

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -1096,32 +1096,37 @@ impl ControlPlane {
         const PER_TICK: i64 = 20;
         let candidates = self.metastore.splits_without_dynamic_fields(PER_TICK).await?;
         for split in candidates {
-            let step = async {
+            let scan = async {
                 let reader = SplitReader::open(
                     self.storage.clone(),
                     &split.storage_key,
                     self.cache.clone(),
                 )
                 .await?;
-                let fields = tokio::task::spawn_blocking(move || reader.dynamic_field_types())
-                    .await??;
-                self.metastore
-                    .set_split_dynamic_fields(&split.split_id, &serde_json::to_value(fields)?)
-                    .await?;
-                Ok::<_, anyhow::Error>(())
+                tokio::task::spawn_blocking(move || reader.dynamic_field_types())
+                    .await
+                    .map_err(|e| rsearch_index::IndexError::InvalidDocument(e.to_string()))?
             };
-            match step.await {
-                Ok(()) => info!(split_id = %split.split_id, "dynamic fields recorded"),
-                // Unreadable split: record an empty inventory so it does
-                // not pin the budget every tick; a rewrite (merge,
-                // compaction) records the real one.
-                Err(e) => {
-                    warn!(split_id = %split.split_id, error = %e, "dynamic-fields scan failed; recording none");
-                    self.metastore
-                        .set_split_dynamic_fields(&split.split_id, &serde_json::json!({}))
-                        .await?;
+            let inventory = match scan.await {
+                Ok(fields) => serde_json::to_value(fields)?,
+                // A malformed split will never scan: record an empty
+                // inventory so it does not pin the budget every tick (a
+                // rewrite — merge, compaction — records the real one).
+                // Anything else (storage, I/O) is transient: leave the
+                // row NULL and retry next tick.
+                Err(rsearch_index::IndexError::InvalidDocument(reason)) => {
+                    warn!(split_id = %split.split_id, reason, "split unreadable; recording an empty dynamic-field inventory");
+                    serde_json::json!({})
                 }
-            }
+                Err(e) => {
+                    warn!(split_id = %split.split_id, error = %e, "dynamic-fields scan failed; will retry");
+                    continue;
+                }
+            };
+            self.metastore
+                .set_split_dynamic_fields(&split.split_id, &inventory)
+                .await?;
+            info!(split_id = %split.split_id, "dynamic fields recorded");
         }
         Ok(())
     }
@@ -1280,7 +1285,6 @@ mod tests {
             seq_max: None,
             tombstone_seq_applied: 0,
             schema_version: 0,
-            dynamic_fields: None,
         }
     }
 

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -208,6 +208,15 @@ impl ControlPlane {
         if let Err(e) = self.gc_job().await {
             error!(error = %e, "gc job failed");
         }
+        if let Err(e) = self.stream_purge_job().await {
+            error!(error = %e, "stream purge failed");
+        }
+        if let Err(e) = self.dynamic_fields_backfill_job().await {
+            error!(error = %e, "dynamic-fields backfill failed");
+        }
+        if let Err(e) = self.metastore.purge_expired_scrolls().await {
+            error!(error = %e, "scroll expiry sweep failed");
+        }
         if let Err(e) = self.metastore.expire_dead_nodes(3600.0).await {
             error!(error = %e, "node expiry failed");
         }
@@ -761,6 +770,11 @@ impl ControlPlane {
                 seq_max: packaged.meta.seq_max,
                 tombstone_seq_applied: applied_through,
                 schema_version: packaged.meta.schema_version as i32,
+                dynamic_fields: packaged
+                    .meta
+                    .dynamic_fields
+                    .as_ref()
+                    .map(|f| serde_json::to_value(f).unwrap_or(serde_json::Value::Null)),
             })
             .await?;
         self.metastore
@@ -1073,6 +1087,55 @@ impl ControlPlane {
         Ok(())
     }
 
+    /// Record the unmapped-field inventory of splits registered before
+    /// it was tracked (#76): each is opened once and its `_dynamic` term
+    /// dictionary skip-scanned, newest data first, a bounded number per
+    /// tick. Until a split is reached, `_mapping` omits the dynamic
+    /// fields only it holds.
+    async fn dynamic_fields_backfill_job(&self) -> anyhow::Result<()> {
+        const PER_TICK: i64 = 20;
+        let candidates = self.metastore.splits_without_dynamic_fields(PER_TICK).await?;
+        for split in candidates {
+            let step = async {
+                let reader = SplitReader::open(
+                    self.storage.clone(),
+                    &split.storage_key,
+                    self.cache.clone(),
+                )
+                .await?;
+                let fields = tokio::task::spawn_blocking(move || reader.dynamic_field_types())
+                    .await??;
+                self.metastore
+                    .set_split_dynamic_fields(&split.split_id, &serde_json::to_value(fields)?)
+                    .await?;
+                Ok::<_, anyhow::Error>(())
+            };
+            match step.await {
+                Ok(()) => info!(split_id = %split.split_id, "dynamic fields recorded"),
+                // Unreadable split: record an empty inventory so it does
+                // not pin the budget every tick; a rewrite (merge,
+                // compaction) records the real one.
+                Err(e) => {
+                    warn!(split_id = %split.split_id, error = %e, "dynamic-fields scan failed; recording none");
+                    self.metastore
+                        .set_split_dynamic_fields(&split.split_id, &serde_json::json!({}))
+                        .await?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Drop retired stream rows (DELETE /{index}, #71) once GC has removed
+    /// every split; a split flushed after the retirement is marked here.
+    async fn stream_purge_job(&self) -> anyhow::Result<()> {
+        let purged = self.metastore.purge_deleted_streams().await?;
+        if purged > 0 {
+            info!(purged, "stream purge: retired streams removed");
+        }
+        Ok(())
+    }
+
     async fn gc_job(&self) -> anyhow::Result<()> {
         let candidates = self
             .metastore
@@ -1217,6 +1280,7 @@ mod tests {
             seq_max: None,
             tombstone_seq_applied: 0,
             schema_version: 0,
+            dynamic_fields: None,
         }
     }
 

--- a/crates/rsearch-server/src/doc_api.rs
+++ b/crates/rsearch-server/src/doc_api.rs
@@ -321,11 +321,12 @@ pub async fn delete_by_query(
             query: query.clone(),
             from: 0,
             size: DELETE_BY_QUERY_PAGE,
-            sort_desc: true,
+            sort: rsearch_search::SortSpec::Timestamp { desc: true },
             aggs: None,
             include_source: false,
             track_total_hits: Some(0),
             search_after: None,
+            search_after_values: None,
         };
         let response = match lookup.search(request).await {
             Ok(response) => response,

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -39,6 +39,19 @@ pub fn router(state: AppState) -> Router {
             post(search_api::search).get(search_api::search),
         )
         .route("/_msearch", post(search_api::msearch))
+        // Scroll API (#72): continue with POST/GET, free with DELETE.
+        .route(
+            "/_search/scroll",
+            post(search_api::scroll_next)
+                .get(search_api::scroll_next)
+                .delete(search_api::clear_scroll),
+        )
+        .route(
+            "/_search/scroll/{scroll_id}",
+            post(search_api::scroll_next_by_path)
+                .get(search_api::scroll_next_by_path)
+                .delete(search_api::clear_scroll_by_path),
+        )
         // Loki-compatible query API subset (#11): lets Grafana's built-in
         // Loki datasource and Logs Drilldown run against rSearch.
         .route("/ready", get(crate::loki_api::ready))
@@ -92,13 +105,21 @@ pub fn router(state: AppState) -> Router {
         .route("/{index}/_update/{id}", post(crate::doc_api::update_doc))
         .route("/{index}/_source/{id}", get(crate::doc_api::get_source))
         .route("/{index}/_delete_by_query", post(crate::doc_api::delete_by_query))
-        .route("/{index}/_mapping", get(search_api::get_mapping))
+        .route(
+            "/{index}/_mapping",
+            get(search_api::get_mapping).put(search_api::put_mapping),
+        )
+        .route(
+            "/{index}/_count",
+            get(search_api::count).post(search_api::count),
+        )
         .route("/{index}/_settings", get(search_api::get_settings))
         .route(
             "/{index}",
             axum::routing::put(search_api::put_index)
                 .get(search_api::get_index)
-                .head(search_api::head_index),
+                .head(search_api::head_index)
+                .delete(search_api::delete_index),
         )
         .route("/_cat/indices", get(crate::admin_api::cat_indices))
         .route("/_rsearch/routing_rules", get(crate::admin_api::list_rules))

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -9,10 +9,11 @@ use rsearch_search::{SearchError, SearchRequest};
 
 use crate::state::AppState;
 
-/// POST/GET /{index}/_search
+/// POST/GET /{index}/_search (`?scroll=<keep-alive>` opens a scroll).
 pub async fn search(
     State(state): State<AppState>,
     Path(index): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: String,
 ) -> Response {
     let Some(service) = state.search.clone() else {
@@ -22,7 +23,7 @@ pub async fn search(
             "this node does not run the search role",
         );
     };
-    let body_json: Value = if body.trim().is_empty() {
+    let mut body_json: Value = if body.trim().is_empty() {
         json!({})
     } else {
         match serde_json::from_str(&body) {
@@ -36,13 +37,367 @@ pub async fn search(
             }
         }
     };
+    let keep_alive = match params.get("scroll").map(|s| parse_keep_alive(s)) {
+        None => None,
+        Some(Ok(secs)) => Some(secs),
+        Some(Err(response)) => return response,
+    };
+    if keep_alive.is_some() {
+        // OpenSearch's validations for a scroll context.
+        if body_json.get("from").and_then(Value::as_u64).unwrap_or(0) != 0 {
+            return es_error(
+                StatusCode::BAD_REQUEST,
+                "action_request_validation_exception",
+                "Validation Failed: 1: using [from] is not allowed in a scroll context;",
+            );
+        }
+        if body_json.get("search_after").is_some_and(|v| !v.is_null()) {
+            return es_error(
+                StatusCode::BAD_REQUEST,
+                "search_exception",
+                "`search_after` cannot be used in a scroll context.",
+            );
+        }
+        // `_doc` order is the scroll idiom: our stable (timestamp, _seq)
+        // sequence serves it; a `size` must survive into every page.
+        if !body_json.is_object() {
+            body_json = json!({});
+        }
+    }
     let request = match SearchRequest::parse(&index, &body_json) {
         Ok(request) => request,
         Err(e) => return map_search_error(e),
     };
-    match service.search(request).await {
-        Ok(response) => Json(response).into_response(),
-        Err(e) => map_search_error(e),
+    let mut response = match service.search(request).await {
+        Ok(response) => response,
+        Err(e) => return map_search_error(e),
+    };
+    if let Some(keep_alive) = keep_alive {
+        // Later pages re-run the search from the last hit's cursor;
+        // aggregations belong to the first page only, as in OpenSearch.
+        let mut stored = body_json.clone();
+        if let Some(map) = stored.as_object_mut() {
+            map.remove("aggs");
+            map.remove("aggregations");
+        }
+        let cursor = last_hit_sort(&response);
+        let total = response["hits"]["total"].clone();
+        let id = uuid::Uuid::new_v4().simple().to_string();
+        if let Err(e) = state
+            .metastore
+            .create_scroll(&id, &index, &stored, cursor.as_ref(), &total, keep_alive)
+            .await
+        {
+            return es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string());
+        }
+        response["_scroll_id"] = json!(id);
+    }
+    Json(response).into_response()
+}
+
+/// The `sort` values of a page's last hit — the next page's cursor.
+fn last_hit_sort(response: &Value) -> Option<Value> {
+    response["hits"]["hits"]
+        .as_array()
+        .and_then(|hits| hits.last())
+        .and_then(|hit| hit.get("sort"))
+        .filter(|sort| sort.is_array())
+        .cloned()
+}
+
+/// Longest scroll keep-alive accepted (OpenSearch's
+/// `search.max_keep_alive` default).
+const MAX_KEEP_ALIVE_SECS: f64 = 24.0 * 3600.0;
+
+/// Parse an ES time value (`1m`, `30s`, `2h`, `500ms`, `1d`) into
+/// seconds; a 400 for anything else or beyond the ceiling.
+fn parse_keep_alive(value: &str) -> Result<f64, Response> {
+    let value = value.trim();
+    let split = value
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .unwrap_or(value.len());
+    let (number, unit) = value.split_at(split);
+    let amount: f64 = match number.parse() {
+        Ok(n) if number.is_empty() => n,
+        Ok(n) => n,
+        Err(_) => f64::NAN,
+    };
+    let secs = match unit {
+        "ms" => amount / 1000.0,
+        "s" => amount,
+        "m" => amount * 60.0,
+        "h" => amount * 3600.0,
+        "d" => amount * 86_400.0,
+        _ => f64::NAN,
+    };
+    if number.is_empty() || !secs.is_finite() || secs < 0.0 {
+        return Err(es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            &format!(
+                "failed to parse setting [scroll] with value [{value}] as a time value: \
+                 unit is missing or unrecognized"
+            ),
+        ));
+    }
+    if secs > MAX_KEEP_ALIVE_SECS {
+        return Err(es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            &format!(
+                "Keep alive for scroll ({value}) is too large. It must be less than (1d). \
+                 This limit can be set by changing the [search.max_keep_alive] cluster level setting."
+            ),
+        ));
+    }
+    Ok(secs)
+}
+
+/// Scroll ids are UUIDs in simple form: anything else cannot be ours.
+fn valid_scroll_id(id: &str) -> bool {
+    id.len() == 32 && id.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+fn scroll_id_unparseable() -> Response {
+    es_error(
+        StatusCode::BAD_REQUEST,
+        "illegal_argument_exception",
+        "Cannot parse scroll id",
+    )
+}
+
+/// Body/query parameters of a scroll continuation or clear.
+struct ScrollParams {
+    ids: Vec<String>,
+    keep_alive: Option<Result<f64, Response>>,
+}
+
+fn scroll_params(
+    params: &std::collections::HashMap<String, String>,
+    body: &str,
+    path_id: Option<&str>,
+) -> Result<ScrollParams, Response> {
+    let body_json: Value = if body.trim().is_empty() {
+        json!({})
+    } else {
+        match serde_json::from_str(body) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(es_error(
+                    StatusCode::BAD_REQUEST,
+                    "parse_exception",
+                    &format!("invalid scroll body: {e}"),
+                ));
+            }
+        }
+    };
+    let mut ids: Vec<String> = Vec::new();
+    if let Some(id) = path_id {
+        ids.extend(id.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()));
+    }
+    match body_json.get("scroll_id") {
+        Some(Value::String(id)) => ids.push(id.clone()),
+        Some(Value::Array(items)) => {
+            ids.extend(items.iter().filter_map(Value::as_str).map(str::to_string));
+        }
+        _ => {}
+    }
+    if let Some(id) = params.get("scroll_id") {
+        ids.extend(id.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()));
+    }
+    let keep_alive = body_json
+        .get("scroll")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| params.get("scroll").cloned())
+        .map(|v| parse_keep_alive(&v));
+    Ok(ScrollParams { ids, keep_alive })
+}
+
+/// POST/GET /_search/scroll — the next page of a scroll (issue #72).
+pub async fn scroll_next(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+    body: String,
+) -> Response {
+    scroll_page(state, params, identity, body, None).await
+}
+
+/// POST/GET /_search/scroll/{scroll_id}
+pub async fn scroll_next_by_path(
+    State(state): State<AppState>,
+    Path(scroll_id): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+    body: String,
+) -> Response {
+    scroll_page(state, params, identity, body, Some(&scroll_id)).await
+}
+
+async fn scroll_page(
+    state: AppState,
+    params: std::collections::HashMap<String, String>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+    body: String,
+    path_id: Option<&str>,
+) -> Response {
+    let Some(service) = state.search.clone() else {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            "this node does not run the search role",
+        );
+    };
+    let parsed = match scroll_params(&params, &body, path_id) {
+        Ok(parsed) => parsed,
+        Err(response) => return response,
+    };
+    let Some(id) = parsed.ids.first().cloned() else {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            "scroll_id is required",
+        );
+    };
+    if !valid_scroll_id(&id) {
+        return scroll_id_unparseable();
+    }
+    let keep_alive = match parsed.keep_alive {
+        Some(Ok(secs)) => Some(secs),
+        Some(Err(response)) => return response,
+        None => None,
+    };
+    let context = match state.metastore.get_scroll(&id).await {
+        Ok(Some(context)) => context,
+        Ok(None) => return scroll_context_missing(&id),
+        Err(e) => {
+            return es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string());
+        }
+    };
+    if let Some(axum::Extension(identity)) = &identity
+        && !identity.is_admin
+        && !identity.allows_stream(&context.stream)
+    {
+        return es_error(
+            StatusCode::FORBIDDEN,
+            "security_exception",
+            &format!(
+                "identity '{}' is not permitted to read index [{}]",
+                identity.name, context.stream
+            ),
+        );
+    }
+    let mut page_body = context.request.clone();
+    let mut response = match &context.cursor {
+        // The first page had no hits: nothing follows.
+        None => empty_scroll_page(&context),
+        Some(cursor) => {
+            page_body["search_after"] = cursor.clone();
+            // Totals come from the first page; skipping the recount also
+            // lets splits wholly behind the cursor be skipped.
+            page_body["track_total_hits"] = json!(false);
+            let request = match SearchRequest::parse(&context.stream, &page_body) {
+                Ok(request) => request,
+                Err(e) => return map_search_error(e),
+            };
+            match service.search(request).await {
+                Ok(response) => response,
+                Err(e) => return map_search_error(e),
+            }
+        }
+    };
+    response["hits"]["total"] = context.total.clone();
+    let cursor = last_hit_sort(&response);
+    // A continuation without `scroll` keeps the context alive only for
+    // the remainder of its current window, as in OpenSearch.
+    let advanced = match keep_alive {
+        Some(secs) => state.metastore.advance_scroll(&id, cursor.as_ref(), secs).await,
+        None => state.metastore.advance_scroll_cursor(&id, cursor.as_ref()).await,
+    };
+    if let Err(e) = advanced {
+        return es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string());
+    }
+    response["_scroll_id"] = json!(id);
+    Json(response).into_response()
+}
+
+fn empty_scroll_page(context: &rsearch_metastore::ScrollRecord) -> Value {
+    json!({
+        "took": 0,
+        "timed_out": false,
+        "_shards": {"total": 0, "successful": 0, "skipped": 0, "failed": 0},
+        "hits": {"total": context.total, "max_score": Value::Null, "hits": []},
+    })
+}
+
+fn scroll_context_missing(id: &str) -> Response {
+    let reason = format!("No search context found for id [{id}]");
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "error": {
+                "type": "search_phase_execution_exception",
+                "reason": "all shards failed",
+                "phase": "query",
+                "grouped": true,
+                "root_cause": [{"type": "search_context_missing_exception", "reason": reason}],
+                "caused_by": {"type": "search_context_missing_exception", "reason": reason},
+            },
+            "status": 404,
+        })),
+    )
+        .into_response()
+}
+
+/// DELETE /_search/scroll — free scroll contexts (`scroll_id` in the
+/// body, a string or an array).
+pub async fn clear_scroll(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    body: String,
+) -> Response {
+    clear_scrolls(state, params, body, None).await
+}
+
+/// DELETE /_search/scroll/{scroll_id} (`_all` frees every context).
+pub async fn clear_scroll_by_path(
+    State(state): State<AppState>,
+    Path(scroll_id): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    body: String,
+) -> Response {
+    clear_scrolls(state, params, body, Some(&scroll_id)).await
+}
+
+async fn clear_scrolls(
+    state: AppState,
+    params: std::collections::HashMap<String, String>,
+    body: String,
+    path_id: Option<&str>,
+) -> Response {
+    let parsed = match scroll_params(&params, &body, path_id) {
+        Ok(parsed) => parsed,
+        Err(response) => return response,
+    };
+    let freed = if parsed.ids.iter().any(|id| id == "_all") {
+        state.metastore.delete_all_scrolls().await
+    } else {
+        if parsed.ids.is_empty() {
+            return es_error(
+                StatusCode::BAD_REQUEST,
+                "illegal_argument_exception",
+                "scroll_id is required",
+            );
+        }
+        if parsed.ids.iter().any(|id| !valid_scroll_id(id)) {
+            return scroll_id_unparseable();
+        }
+        state.metastore.delete_scrolls(&parsed.ids).await
+    };
+    match freed {
+        Ok(n) => Json(json!({"succeeded": true, "num_freed": n})).into_response(),
+        Err(e) => es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string()),
     }
 }
 
@@ -204,7 +559,10 @@ fn glob_match(pattern: &str, name: &str) -> bool {
 /// GET /{index}/_mapping — Grafana fetches this to discover fields.
 pub async fn get_mapping(State(state): State<AppState>, Path(index): Path<String>) -> Response {
     match state.metastore.get_stream(&index).await {
-        Ok(stream) => Json(json!({ index: {"mappings": mappings_json(&stream)} })).into_response(),
+        Ok(stream) => {
+            let mappings = mappings_json(&state, &stream).await;
+            Json(json!({ index: {"mappings": mappings} })).into_response()
+        }
         Err(MetastoreError::StreamNotFound(_)) => index_not_found(&index),
         Err(e) => es_error(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -212,6 +570,170 @@ pub async fn get_mapping(State(state): State<AppState>, Path(index): Path<String
             &e.to_string(),
         ),
     }
+}
+
+/// GET/POST /{index}/_count — the ES `count` helper. The body may carry a
+/// `query` (nothing else: OpenSearch rejects `size`, `sort`, `aggs`, …
+/// with a parsing_exception), or `?q=` runs a `query_string`.
+pub async fn count(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    body: String,
+) -> Response {
+    let Some(service) = state.search.clone() else {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            "this node does not run the search role",
+        );
+    };
+    let body_json: Value = if body.trim().is_empty() {
+        json!({})
+    } else {
+        match serde_json::from_str(&body) {
+            Ok(v) => v,
+            Err(e) => {
+                return es_error(
+                    StatusCode::BAD_REQUEST,
+                    "parse_exception",
+                    &format!("invalid count body: {e}"),
+                );
+            }
+        }
+    };
+    let Some(map) = body_json.as_object() else {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "parsing_exception",
+            "count body must be an object",
+        );
+    };
+    if let Some(key) = map.keys().find(|k| k.as_str() != "query") {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "parsing_exception",
+            &format!("request does not support [{key}]"),
+        );
+    }
+    let mut search_body = json!({"size": 0, "track_total_hits": true});
+    if let Some(query) = map.get("query") {
+        search_body["query"] = query.clone();
+    } else if let Some(q) = params.get("q") {
+        search_body["query"] = json!({"query_string": {"query": q}});
+    }
+    let mut request = match SearchRequest::parse(&index, &search_body) {
+        Ok(request) => request,
+        Err(e) => return map_search_error(e),
+    };
+    // Exact count, never the 10k lower bound a search reports.
+    request.track_total_hits = None;
+    match service.search(request).await {
+        Ok(response) => {
+            let count = response["hits"]["total"]["value"].clone();
+            let shards = response["_shards"].clone();
+            Json(json!({"count": count, "_shards": shards})).into_response()
+        }
+        Err(e) => map_search_error(e),
+    }
+}
+
+/// PUT /{index}/_mapping — add fields to an existing index's mapping
+/// (issue #73). OpenSearch semantics: new fields are added, a field that
+/// already exists must keep its type (400 otherwise), and the index must
+/// exist (404). The body is `{"properties": {...}}`.
+pub async fn put_mapping(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    body: String,
+) -> Response {
+    let body_json: Value = match serde_json::from_str(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return es_error(
+                StatusCode::BAD_REQUEST,
+                "parse_exception",
+                &format!("invalid body: {e}"),
+            );
+        }
+    };
+    let incoming = match rsearch_index::IndexMapping::from_json(&body_json) {
+        Ok(mapping) => mapping,
+        Err(e) => {
+            return es_error(
+                StatusCode::BAD_REQUEST,
+                "mapper_parsing_exception",
+                &e.to_string(),
+            );
+        }
+    };
+    let stream = match state.metastore.get_stream(&index).await {
+        Ok(stream) => stream,
+        Err(MetastoreError::StreamNotFound(_)) => return index_not_found(&index),
+        Err(e) => {
+            return es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string());
+        }
+    };
+    let existing = rsearch_index::IndexMapping::from_json(&stream.mapping).unwrap_or_default();
+    // Merge: keep every existing field's declaration, add the new ones.
+    // Types are compared normalized (`integer` and `long` are one type
+    // here), so re-declaring a field the way it already is is a no-op.
+    let mut merged = stream
+        .mapping
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    let incoming_props = body_json
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (name, ty) in &incoming.properties {
+        match existing.properties.get(name) {
+            Some(current) if current != ty => {
+                let from = serde_json::to_value(current).unwrap_or(Value::Null);
+                let to = serde_json::to_value(ty).unwrap_or(Value::Null);
+                return es_error(
+                    StatusCode::BAD_REQUEST,
+                    "illegal_argument_exception",
+                    &format!(
+                        "mapper [{name}] cannot be changed from type [{}] to [{}]",
+                        from.as_str().unwrap_or("?"),
+                        to.as_str().unwrap_or("?")
+                    ),
+                );
+            }
+            Some(_) => {}
+            None => {
+                if let Some(spec) = incoming_props.get(name) {
+                    merged.insert(name.clone(), spec.clone());
+                }
+            }
+        }
+    }
+    let mut mapping = stream.mapping.clone();
+    if !mapping.is_object() {
+        mapping = json!({});
+    }
+    mapping["properties"] = Value::Object(merged);
+    if let Err(e) = state.metastore.update_stream_mapping(&index, &mapping).await {
+        return match e {
+            MetastoreError::StreamNotFound(_) => index_not_found(&index),
+            other => es_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                &other.to_string(),
+            ),
+        };
+    }
+    // This node's search cache sees the new mapping now; other nodes
+    // within their 10s stream-cache TTL. Ingest workers re-read the
+    // mapping before every flush.
+    for service in [&state.search, &state.doc_lookup].into_iter().flatten() {
+        service.invalidate_stream(&index);
+    }
+    Json(json!({"acknowledged": true})).into_response()
 }
 
 /// Read the stream mode out of a `PUT /{index}` body: ES-shaped
@@ -315,6 +837,92 @@ pub async fn put_index(
     }
 }
 
+/// DELETE /{index} — delete one or more indices (issue #71). The path is
+/// an index expression: a name, a comma-separated list, or globs. As in
+/// OpenSearch a named index that does not exist is a 404 and a glob that
+/// matches nothing is acknowledged; unlike OpenSearch's default, `_all`
+/// and a bare `*` are refused (`action.destructive_requires_name`).
+///
+/// Deletion is immediate for readers and writers — the stream's splits
+/// leave the published set and the name is free to re-create at once —
+/// while storage is reclaimed by the control leader's GC after its grace
+/// period. Documents still buffered on an ingest node when the index is
+/// deleted are flushed into the re-created index (or re-create it), the
+/// way a `_bulk` to a missing index always has.
+pub async fn delete_index(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+) -> Response {
+    let expression = index.trim();
+    if expression.is_empty() || expression == "_all" || expression.split(',').any(|p| p.trim() == "*") {
+        return es_error(
+            StatusCode::BAD_REQUEST,
+            "illegal_argument_exception",
+            "Wildcard expressions or all indices are not allowed",
+        );
+    }
+    let names = match state.metastore.list_streams().await {
+        Ok(streams) => streams.into_iter().map(|s| s.name).collect::<Vec<_>>(),
+        Err(e) => {
+            return es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string());
+        }
+    };
+    let mut targets: Vec<String> = Vec::new();
+    for part in expression.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+        if part.contains('*') {
+            targets.extend(names.iter().filter(|n| glob_match(part, n)).cloned());
+        } else if names.iter().any(|n| n == part) {
+            targets.push(part.to_string());
+        } else {
+            return index_not_found(part);
+        }
+    }
+    targets.sort();
+    targets.dedup();
+    // A glob or list must stay inside the caller's stream scope: the
+    // middleware matched the raw expression, not what it expands to.
+    if let Some(axum::Extension(identity)) = &identity
+        && !identity.is_admin
+        && let Some(outside) = targets.iter().find(|t| !identity.allows_stream(t))
+    {
+        return es_error(
+            StatusCode::FORBIDDEN,
+            "security_exception",
+            &format!(
+                "identity '{}' is not permitted to delete index [{outside}]",
+                identity.name
+            ),
+        );
+    }
+    for target in &targets {
+        match state.metastore.retire_stream(target).await {
+            // Raced with another delete of the same name: already gone.
+            Ok(_) | Err(MetastoreError::StreamNotFound(_)) => {}
+            Err(e) => {
+                return es_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "internal_error",
+                    &e.to_string(),
+                );
+            }
+        }
+        // This node forgets the stream now; peers within their 10s
+        // stream-cache TTLs (their queries see no published splits
+        // meanwhile, and their ingest workers rebind at the next flush).
+        if let Some(pipeline) = &state.pipeline {
+            pipeline.forget_stream(target);
+        }
+        for service in [&state.search, &state.doc_lookup].into_iter().flatten() {
+            service.invalidate_stream(target);
+        }
+        state.label_fields.lock().unwrap().remove(target);
+        state.audit("delete_index", target, "").await;
+    }
+    *state.stream_names.lock().unwrap() = None;
+    Json(json!({"acknowledged": true})).into_response()
+}
+
 /// ES-shaped settings block for a stream.
 fn settings_json(stream: &rsearch_metastore::StreamRecord) -> Value {
     json!({
@@ -327,16 +935,103 @@ fn settings_json(stream: &rsearch_metastore::StreamRecord) -> Value {
     })
 }
 
-/// ES-shaped mappings block for a stream.
-fn mappings_json(stream: &rsearch_metastore::StreamRecord) -> Value {
+/// ES-shaped mappings block for a stream: the declared properties, the
+/// always-present `@timestamp`, and every unmapped field its published
+/// splits hold, reported the way OpenSearch's dynamic mapping would
+/// have typed it (issue #76): a string is `text` with a `keyword`
+/// sub-field (`ignore_above` 256), an integer `long`, a fraction
+/// `float`, a boolean `boolean`. Nested paths become nested
+/// `properties`.
+async fn mappings_json(state: &AppState, stream: &rsearch_metastore::StreamRecord) -> Value {
     let mut properties = stream
         .mapping
         .get("properties")
         .cloned()
         .unwrap_or_else(|| json!({}));
+    if !properties.is_object() {
+        properties = json!({});
+    }
+    let dynamic = match state.metastore.stream_dynamic_fields(stream.id).await {
+        Ok(fields) => fields,
+        Err(e) => {
+            tracing::warn!(stream = %stream.name, error = %e, "dynamic field inventory unavailable");
+            Default::default()
+        }
+    };
+    for (path, types) in dynamic {
+        let spec = dynamic_field_spec(&types);
+        insert_dynamic_property(&mut properties, &path, spec);
+    }
     // The timestamp field is always present and always a date.
     properties["@timestamp"] = json!({"type": "date"});
     json!({"properties": properties})
+}
+
+/// The mapping entry OpenSearch reports for a dynamic field seen with
+/// these value types. A path seen as both a string and a number reports
+/// as text: OpenSearch keeps whichever it saw first, and text is the
+/// only view that accepts every value.
+fn dynamic_field_spec(types: &[String]) -> Value {
+    let has = |t: &str| types.iter().any(|x| x == t);
+    if has("string") {
+        json!({
+            "type": "text",
+            "fields": {
+                "keyword": {"type": "keyword", "ignore_above": rsearch_index::KEYWORD_IGNORE_ABOVE}
+            }
+        })
+    } else if has("double") {
+        json!({"type": "float"})
+    } else if has("long") {
+        json!({"type": "long"})
+    } else if has("boolean") {
+        json!({"type": "boolean"})
+    } else {
+        json!({"type": "date"})
+    }
+}
+
+/// Place `spec` at `path` inside a `properties` object, creating object
+/// levels for `a.b.c` paths. A `\.` in the path is a literal dot in one
+/// key (rSearch does not expand dots), kept as part of the name. A
+/// declared property is never overwritten: the mapped field wins, and a
+/// dynamic path beneath a mapped scalar is dropped.
+fn insert_dynamic_property(properties: &mut Value, path: &str, spec: Value) {
+    let mut segments: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut chars = path.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' if chars.peek() == Some(&'.') => {
+                current.push('.');
+                chars.next();
+            }
+            '.' => segments.push(std::mem::take(&mut current)),
+            other => current.push(other),
+        }
+    }
+    segments.push(current);
+    let Some((last, parents)) = segments.split_last() else { return };
+    let mut node = properties;
+    for parent in parents {
+        let Some(map) = node.as_object_mut() else { return };
+        let entry = map
+            .entry(parent.clone())
+            .or_insert_with(|| json!({"properties": {}}));
+        if !entry.is_object() || entry.get("type").is_some() {
+            // A mapped scalar field sits where an object would go.
+            return;
+        }
+        if entry.get("properties").is_none() {
+            entry["properties"] = json!({});
+        }
+        node = &mut entry["properties"];
+    }
+    if let Some(map) = node.as_object_mut()
+        && !map.contains_key(last)
+    {
+        map.insert(last.clone(), spec);
+    }
 }
 
 /// GET /{index}/_settings
@@ -352,14 +1047,17 @@ pub async fn get_settings(State(state): State<AppState>, Path(index): Path<Strin
 /// discover an index).
 pub async fn get_index(State(state): State<AppState>, Path(index): Path<String>) -> Response {
     match state.metastore.get_stream(&index).await {
-        Ok(stream) => Json(json!({
-            index: {
-                "aliases": {},
-                "mappings": mappings_json(&stream),
-                "settings": settings_json(&stream),
-            }
-        }))
-        .into_response(),
+        Ok(stream) => {
+            let mappings = mappings_json(&state, &stream).await;
+            Json(json!({
+                index: {
+                    "aliases": {},
+                    "mappings": mappings,
+                    "settings": settings_json(&stream),
+                }
+            }))
+            .into_response()
+        }
         Err(MetastoreError::StreamNotFound(_)) => index_not_found(&index),
         Err(e) => es_error(StatusCode::INTERNAL_SERVER_ERROR, "internal_error", &e.to_string()),
     }
@@ -434,4 +1132,67 @@ fn es_error(status: StatusCode, error_type: &str, reason: &str) -> Response {
         })),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keep_alive_parses_es_time_values() {
+        for (input, secs) in [("1m", 60.0), ("30s", 30.0), ("2h", 7200.0), ("500ms", 0.5), ("1d", 86_400.0)] {
+            assert_eq!(parse_keep_alive(input).ok(), Some(secs), "{input}");
+        }
+        for bad in ["1x", "m", "", "abc", "2d"] {
+            assert!(parse_keep_alive(bad).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn scroll_ids_are_uuid_simple() {
+        assert!(valid_scroll_id(&uuid::Uuid::new_v4().simple().to_string()));
+        assert!(!valid_scroll_id("bogus"));
+        assert!(!valid_scroll_id(""));
+    }
+
+    #[test]
+    fn dynamic_fields_render_like_opensearch() {
+        let s = |types: &[&str]| dynamic_field_spec(&types.iter().map(|t| t.to_string()).collect::<Vec<_>>());
+        assert_eq!(
+            s(&["string"]),
+            json!({"type": "text", "fields": {"keyword": {"type": "keyword", "ignore_above": 256}}})
+        );
+        assert_eq!(s(&["long"]), json!({"type": "long"}));
+        assert_eq!(s(&["double", "long"]), json!({"type": "float"}));
+        assert_eq!(s(&["boolean"]), json!({"type": "boolean"}));
+        // A path seen as string and number is text.
+        assert_eq!(s(&["long", "string"])["type"], json!("text"));
+
+        let mut props = json!({"age": {"type": "long"}, "meta": {"type": "keyword"}});
+        insert_dynamic_property(&mut props, "role", json!({"type": "text"}));
+        insert_dynamic_property(&mut props, "ctx.job", json!({"type": "text"}));
+        insert_dynamic_property(&mut props, "ctx.tries", json!({"type": "long"}));
+        insert_dynamic_property(&mut props, "log\\.level", json!({"type": "text"}));
+        // Declared properties win; a path beneath a mapped scalar is dropped.
+        insert_dynamic_property(&mut props, "age", json!({"type": "text"}));
+        insert_dynamic_property(&mut props, "meta.x", json!({"type": "text"}));
+        assert_eq!(
+            props,
+            json!({
+                "age": {"type": "long"},
+                "meta": {"type": "keyword"},
+                "role": {"type": "text"},
+                "ctx": {"properties": {"job": {"type": "text"}, "tries": {"type": "long"}}},
+                "log.level": {"type": "text"},
+            })
+        );
+    }
+
+    #[test]
+    fn glob_matches_index_expressions() {
+        assert!(glob_match("tmp_*", "tmp_termrepro"));
+        assert!(glob_match("*", "anything"));
+        assert!(!glob_match("tmp_*", "people"));
+        assert!(glob_match("people", "people"));
+    }
 }

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -355,9 +355,10 @@ fn scroll_context_missing(id: &str) -> Response {
 pub async fn clear_scroll(
     State(state): State<AppState>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
     body: String,
 ) -> Response {
-    clear_scrolls(state, params, body, None).await
+    clear_scrolls(state, params, identity, body, None).await
 }
 
 /// DELETE /_search/scroll/{scroll_id} (`_all` frees every context).
@@ -365,14 +366,19 @@ pub async fn clear_scroll_by_path(
     State(state): State<AppState>,
     Path(scroll_id): Path<String>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
     body: String,
 ) -> Response {
-    clear_scrolls(state, params, body, Some(&scroll_id)).await
+    clear_scrolls(state, params, identity, body, Some(&scroll_id)).await
 }
 
+/// A scoped identity frees only contexts on streams inside its scope:
+/// `_all` clears its own, and a foreign id is a 403 (never a silent
+/// no-op, so a tenant cannot probe for other tenants' ids).
 async fn clear_scrolls(
     state: AppState,
     params: std::collections::HashMap<String, String>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
     body: String,
     path_id: Option<&str>,
 ) -> Response {
@@ -380,9 +386,12 @@ async fn clear_scrolls(
         Ok(parsed) => parsed,
         Err(response) => return response,
     };
-    let freed = if parsed.ids.iter().any(|id| id == "_all") {
-        state.metastore.delete_all_scrolls().await
-    } else {
+    let scoped = identity
+        .as_ref()
+        .map(|axum::Extension(identity)| identity)
+        .filter(|identity| !identity.is_admin && !identity.streams.iter().any(|s| s == "*"));
+    let all = parsed.ids.iter().any(|id| id == "_all");
+    if !all {
         if parsed.ids.is_empty() {
             return es_error(
                 StatusCode::BAD_REQUEST,
@@ -393,7 +402,37 @@ async fn clear_scrolls(
         if parsed.ids.iter().any(|id| !valid_scroll_id(id)) {
             return scroll_id_unparseable();
         }
-        state.metastore.delete_scrolls(&parsed.ids).await
+    }
+    let freed = match (scoped, all) {
+        (None, true) => state.metastore.delete_all_scrolls().await,
+        (None, false) => state.metastore.delete_scrolls(&parsed.ids).await,
+        (Some(identity), all) => match state.metastore.list_scrolls().await {
+            Ok(live) => {
+                let mine: Vec<String> = live
+                    .iter()
+                    .filter(|(id, stream)| {
+                        identity.allows_stream(stream) && (all || parsed.ids.contains(id))
+                    })
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                if !all
+                    && let Some((_, stream)) = live
+                        .iter()
+                        .find(|(id, stream)| parsed.ids.contains(id) && !identity.allows_stream(stream))
+                {
+                    return es_error(
+                        StatusCode::FORBIDDEN,
+                        "security_exception",
+                        &format!(
+                            "identity '{}' is not permitted to read index [{stream}]",
+                            identity.name
+                        ),
+                    );
+                }
+                state.metastore.delete_scrolls(&mine).await
+            }
+            Err(e) => Err(e),
+        },
     };
     match freed {
         Ok(n) => Json(json!({"succeeded": true, "num_freed": n})).into_response(),
@@ -521,7 +560,7 @@ async fn resolve_stream(state: &AppState, pattern: &str) -> Result<String, Strin
         .map_err(|e| e.to_string())?;
     let matches: Vec<String> = streams
         .iter()
-        .filter(|name| glob_match(pattern, name))
+        .filter(|name| crate::auth::stream_glob_matches(pattern, name))
         .cloned()
         .collect();
     match matches.len() {
@@ -531,29 +570,6 @@ async fn resolve_stream(state: &AppState, pattern: &str) -> Result<String, Strin
             "'{pattern}' matches {n} streams; multi-stream search is not supported yet"
         )),
     }
-}
-
-/// Minimal glob: '*' matches any run of characters.
-fn glob_match(pattern: &str, name: &str) -> bool {
-    let parts: Vec<&str> = pattern.split('*').collect();
-    let mut rest = name;
-    for (i, part) in parts.iter().enumerate() {
-        if part.is_empty() {
-            continue;
-        }
-        match rest.find(part) {
-            Some(pos) => {
-                // First part must anchor at the start.
-                if i == 0 && pos != 0 {
-                    return false;
-                }
-                rest = &rest[pos + part.len()..];
-            }
-            None => return false,
-        }
-    }
-    // Last part must anchor at the end unless the pattern ends with '*'.
-    pattern.ends_with('*') || parts.last().map(|p| rest.is_empty() || p.is_empty()).unwrap_or(true)
 }
 
 /// GET /{index}/_mapping — Grafana fetches this to discover fields.
@@ -871,7 +887,12 @@ pub async fn delete_index(
     let mut targets: Vec<String> = Vec::new();
     for part in expression.split(',').map(str::trim).filter(|p| !p.is_empty()) {
         if part.contains('*') {
-            targets.extend(names.iter().filter(|n| glob_match(part, n)).cloned());
+            targets.extend(
+                names
+                    .iter()
+                    .filter(|n| crate::auth::stream_glob_matches(part, n))
+                    .cloned(),
+            );
         } else if names.iter().any(|n| n == part) {
             targets.push(part.to_string());
         } else {
@@ -1186,13 +1207,5 @@ mod tests {
                 "log.level": {"type": "text"},
             })
         );
-    }
-
-    #[test]
-    fn glob_matches_index_expressions() {
-        assert!(glob_match("tmp_*", "tmp_termrepro"));
-        assert!(glob_match("*", "anything"));
-        assert!(!glob_match("tmp_*", "people"));
-        assert!(glob_match("people", "people"));
     }
 }

--- a/tests/cluster/run-compat-test.sh
+++ b/tests/cluster/run-compat-test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# OpenSearch-compatibility end-to-end test for issues #71–#77: index
+# deletion, scroll, PUT _mapping, _count, dynamic fields in _mapping and
+# field sorting. One all-roles node on the fs backend + Postgres. Every
+# expected shape below was taken from a real OpenSearch 3.6.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+BIN=./target/release/rsearch
+LOGDIR=/tmp/rsearch-compat
+PORT=9270
+U="http://127.0.0.1:$PORT"
+say() { echo "==> $*"; }
+pause() { perl -e "select(undef,undef,undef,$1)"; }
+fail() { echo "FAIL: $*"; exit 1; }
+
+PID=""
+cleanup() { [ -n "$PID" ] && kill -9 "$PID" 2>/dev/null || true; }
+trap cleanup EXIT
+
+set -a; source .env; set +a
+DATABASE_URL=${RSEARCH_TEST_DATABASE_URL:-$DATABASE_URL}
+rm -rf "$LOGDIR"; mkdir -p "$LOGDIR"
+# scroll_contexts arrives with this release's migrations (the node applies
+# them at startup), so it may not exist yet on a fresh test database.
+psql "$DATABASE_URL" -qc "DELETE FROM streams; DELETE FROM nodes; DELETE FROM users; DELETE FROM api_keys; DELETE FROM sessions;
+  DO \$\$ BEGIN IF to_regclass('scroll_contexts') IS NOT NULL THEN DELETE FROM scroll_contexts; END IF; END \$\$;" >/dev/null
+
+say "starting node"
+env DATABASE_URL="$DATABASE_URL" \
+  RSEARCH_NODE__ID=compat-1 \
+  RSEARCH_NODE__DATA_DIR="$LOGDIR/node" \
+  RSEARCH_HTTP__BIND_ADDR="127.0.0.1:$PORT" \
+  RSEARCH_STORAGE__BACKEND=fs \
+  RSEARCH_STORAGE__ROOT="$LOGDIR/store" \
+  RSEARCH_INGEST__MAX_BATCH_SECS=3 \
+  RSEARCH_INGEST__DOCUMENT_MAX_BATCH_SECS=1 \
+  RSEARCH_INGEST__BALANCE_BULK=false \
+  RSEARCH_CONTROL__INTERVAL_SECS=2 \
+  RSEARCH_CONTROL__MERGE_TARGET_MB=0 \
+  RSEARCH_CONTROL__MERGE_MIN_MB=0 \
+  RSEARCH_CONTROL__GC_GRACE_SECS=2 \
+  "$BIN" --roles ingest,search,control >"$LOGDIR/node.log" 2>&1 &
+PID=$!
+for i in $(seq 1 60); do curl -sf "$U/health" >/dev/null && break; pause 0.25; done
+curl -sf "$U/health" >/dev/null || fail "node did not come up"
+
+J='Content-Type: application/json'
+ND='Content-Type: application/x-ndjson'
+code() { curl -s -o /dev/null -w '%{http_code}' "$@"; }
+sql() { psql "$DATABASE_URL" -Atc "$1"; }
+# ids of a search in order
+order() { curl -s -XPOST "$U/people/_search" -H "$J" -d "$1" | jq -r '[.hits.hits[]._id] | join(",")'; }
+sortvals() { curl -s -XPOST "$U/people/_search" -H "$J" -d "$1" | jq -c "[.hits.hits[].sort[0]]"; }
+reason() { curl -s -XPOST "$U/people/_search" -H "$J" -d "$1" | jq -r '.error.root_cause[0].reason'; }
+
+say "#73 PUT _mapping"
+curl -s -XPUT "$U/people" -H "$J" -d '{"settings":{"index":{"mode":"document"}},"mappings":{"properties":{"name":{"type":"keyword"},"age":{"type":"long"},"born":{"type":"date"},"bio":{"type":"text"},"ip":{"type":"ip"}}}}' | jq -e '.acknowledged' >/dev/null || fail "create index"
+[ "$(curl -s -XPUT "$U/people/_mapping" -H "$J" -d '{"properties":{"city":{"type":"keyword"}}}')" = '{"acknowledged":true}' ] || fail "put_mapping add field"
+R=$(curl -s -XPUT "$U/people/_mapping" -H "$J" -d '{"properties":{"age":{"type":"keyword"}}}')
+[ "$(echo "$R" | jq -r .status)" = 400 ] || fail "type change must be 400: $R"
+[ "$(echo "$R" | jq -r '.error.root_cause[0].reason')" = "mapper [age] cannot be changed from type [long] to [keyword]" ] || fail "type change reason: $R"
+[ "$(code -XPUT "$U/people/_mapping" -H "$J" -d '{"properties":{"age":{"type":"integer"}}}')" = 200 ] || fail "same (aliased) type is a no-op"
+[ "$(code -XPUT "$U/nope/_mapping" -H "$J" -d '{"properties":{"age":{"type":"long"}}}')" = 404 ] || fail "put_mapping on missing index is 404"
+[ "$(curl -s "$U/people/_mapping" | jq -r '.people.mappings.properties.city.type')" = keyword ] || fail "mapping shows the added field"
+
+say "documents"
+curl -s -XPOST "$U/people/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"1"}}\n{"name":"bob","age":30,"born":"1990-01-01T00:00:00Z","bio":"a b","role":"tech_admin","score":1.5,"ok":true,"ip":"10.0.0.2","@timestamp":"2026-01-01T00:00:01Z"}\n{"index":{"_id":"2"}}\n{"name":"alice","age":25,"born":"1995-06-01T00:00:00Z","bio":"c d","role":"user","score":2,"ok":false,"ip":"10.0.0.1","@timestamp":"2026-01-01T00:00:02Z"}\n{"index":{"_id":"3"}}\n{"name":"carol","bio":"e f","nested":{"k":"v"},"@timestamp":"2026-01-01T00:00:03Z"}\n' | jq -e '.errors == false' >/dev/null || fail "bulk"
+
+say "#74 _count"
+[ "$(curl -s "$U/people/_count" | jq -cS .)" = '{"_shards":{"failed":0,"skipped":0,"successful":1,"total":1},"count":3}' ] || fail "GET _count: $(curl -s "$U/people/_count")"
+[ "$(curl -s -XPOST "$U/people/_count" -H "$J" -d '{"query":{"term":{"name":"bob"}}}' | jq -r .count)" = 1 ] || fail "POST _count with query"
+[ "$(curl -s "$U/people/_count?q=name:bob" | jq -r .count)" = 1 ] || fail "_count ?q"
+[ "$(code "$U/nope/_count")" = 404 ] || fail "_count missing index"
+R=$(curl -s -XPOST "$U/people/_count" -H "$J" -d '{"size":1}')
+[ "$(echo "$R" | jq -r '.error.root_cause[0].reason')" = "request does not support [size]" ] || fail "_count rejects size: $R"
+
+say "#76 dynamic fields in _mapping"
+M=$(curl -s "$U/people/_mapping")
+[ "$(echo "$M" | jq -cS '.people.mappings.properties.role')" = '{"fields":{"keyword":{"ignore_above":256,"type":"keyword"}},"type":"text"}' ] || fail "role mapping: $M"
+[ "$(echo "$M" | jq -r '.people.mappings.properties.score.type')" = float ] || fail "score float"
+[ "$(echo "$M" | jq -r '.people.mappings.properties.ok.type')" = boolean ] || fail "ok boolean"
+[ "$(echo "$M" | jq -r '.people.mappings.properties.nested.properties.k.type')" = text ] || fail "nested object"
+[ "$(echo "$M" | jq -r '.people.mappings.properties.name.type')" = keyword ] || fail "mapped field kept"
+[ "$(echo "$M" | jq -r '.people.mappings.properties["@timestamp"].type')" = date ] || fail "@timestamp"
+[ "$(curl -s "$U/people" | jq -r '.people.mappings.properties.role.type')" = text ] || fail "GET /{index} carries dynamic fields too"
+
+say "#77 sort"
+[ "$(order '{"sort":[{"name":"asc"}]}')" = "2,1,3" ] || fail "keyword asc"
+[ "$(order '{"sort":[{"name":"desc"}]}')" = "3,1,2" ] || fail "keyword desc (missing last)"
+[ "$(order '{"sort":"name"}')" = "2,1,3" ] || fail "string-form sort"
+[ "$(order '{"sort":[{"age":"desc"}]}')" = "1,2,3" ] || fail "long desc"
+[ "$(sortvals '{"sort":[{"age":"desc"}]}')" = "[30,25,-9223372036854775808]" ] || fail "long desc values: $(sortvals '{"sort":[{"age":"desc"}]}')"
+[ "$(order '{"sort":[{"age":"asc"}]}')" = "2,1,3" ] || fail "long asc"
+[ "$(sortvals '{"sort":[{"age":"asc"}]}')" = "[25,30,9223372036854775807]" ] || fail "long asc values"
+[ "$(order '{"sort":[{"born":"asc"}]}')" = "1,2,3" ] || fail "date asc"
+[ "$(sortvals '{"sort":[{"born":"asc"}]}' | jq -c '.[0]')" = 631152000000 ] || fail "date sort value is epoch millis"
+[ "$(order '{"sort":[{"score":"desc"}]}')" = "2,1,3" ] || fail "float desc"
+[ "$(sortvals '{"sort":[{"score":"desc"}]}')" = '[2.0,1.5,"-Infinity"]' ] || fail "float values: $(sortvals '{"sort":[{"score":"desc"}]}')"
+[ "$(order '{"sort":[{"ok":"asc"}]}')" = "2,1,3" ] || fail "boolean asc"
+[ "$(sortvals '{"sort":[{"ok":"asc"}]}')" = "[0,1,2147483647]" ] || fail "boolean values"
+[ "$(order '{"sort":[{"ip":"desc"}]}')" = "1,2,3" ] || fail "ip desc"
+[ "$(sortvals '{"sort":[{"ip":"desc"}]}' | jq -r '.[0]')" = "10.0.0.2" ] || fail "ip sort value"
+[ "$(order '{"sort":[{"role.keyword":"desc"}]}')" = "2,1,3" ] || fail "dynamic .keyword desc"
+[ "$(sortvals '{"sort":[{"role.keyword":"desc"}]}')" = '["user","tech_admin",null]' ] || fail "keyword values"
+[ "$(order '{"sort":[{"score":"asc"},{"name":"desc"}]}')" = "1,2,3" ] || fail "dynamic numeric asc"
+[ "$(reason '{"sort":[{"role":"desc"}]}' | cut -c1-40)" = "Text fields are not optimised for operat" ] || fail "dynamic text sort is 400"
+[ "$(reason '{"sort":[{"bio":"desc"}]}' | cut -c1-40)" = "Text fields are not optimised for operat" ] || fail "mapped text sort is 400"
+[ "$(reason '{"sort":[{"zzz":"desc"}]}')" = "No mapping found for [zzz] in order to sort on" ] || fail "unknown field is 400"
+[ "$(sortvals '{"sort":[{"zzz":{"order":"desc","unmapped_type":"long"}}]}')" = "[-9223372036854775808,-9223372036854775808,-9223372036854775808]" ] || fail "unmapped_type sorts all-missing"
+[ "$(order '{"sort":[{"age":{"order":"asc","missing":"_first"}}]}')" = "3,2,1" ] || fail "missing _first"
+[ "$(order '{"sort":[{"age":{"order":"asc","missing":27}}]}')" = "2,3,1" ] || fail "missing value"
+[ "$(sortvals '{"sort":[{"age":{"order":"asc","missing":27}}]}')" = "[25,27,30]" ] || fail "missing value reported"
+[ "$(order '{"sort":[{"age":{"order":"asc","mode":"min"}}]}')" = "2,1,3" ] || fail "mode min accepted"
+R=$(curl -s -XPOST "$U/people/_search" -H "$J" -d '{"size":1,"sort":[{"age":"asc"},{"name":"desc"}],"_source":false}')
+[ "$(echo "$R" | jq -r '.hits.hits[0]._id')" = 2 ] || fail "multi sort first"
+SA=$(echo "$R" | jq -c '.hits.hits[0].sort')
+[ "$(echo "$SA" | jq -c '.[0:2]')" = '[25,"alice"]' ] || fail "multi sort values: $SA"
+[ "$(curl -s -XPOST "$U/people/_search" -H "$J" -d "{\"size\":1,\"sort\":[{\"age\":\"asc\"},{\"name\":\"desc\"}],\"search_after\":$SA}" | jq -r '.hits.hits[0]._id')" = 1 ] || fail "search_after with full cursor"
+[ "$(curl -s -XPOST "$U/people/_search" -H "$J" -d '{"size":1,"sort":[{"age":"asc"},{"name":"desc"}],"search_after":[25,"alice"]}' | jq -r '.hits.hits[0]._id')" = 1 ] || fail "search_after with field-only cursor"
+[ "$(reason '{"size":1,"sort":[{"age":"asc"},{"name":"desc"}],"search_after":[1]}')" = "search_after has 1 value(s) but sort has 2." ] || fail "search_after arity"
+# paging by cursor to exhaustion never repeats or loops
+seen=""; cur="null"
+for i in 1 2 3 4 5; do
+  R=$(curl -s -XPOST "$U/people/_search" -H "$J" -d "{\"size\":1,\"sort\":[{\"role.keyword\":\"asc\"}],\"_source\":false,\"search_after\":$cur}")
+  id=$(echo "$R" | jq -r '.hits.hits[0]._id // empty'); [ -n "$id" ] || break
+  seen="$seen$id,"; cur=$(echo "$R" | jq -c '.hits.hits[0].sort')
+done
+[ "$seen" = "1,2,3," ] || fail "cursor paging over keyword with missing: $seen"
+
+say "#72 scroll"
+R=$(curl -s -XPOST "$U/people/_search?scroll=1m" -H "$J" -d '{"size":2,"sort":["_doc"],"_source":false}')
+SID=$(echo "$R" | jq -r '._scroll_id'); [ -n "$SID" ] && [ "$SID" != null ] || fail "scroll id: $R"
+[ "$(echo "$R" | jq -r '.hits.hits | length')" = 2 ] || fail "first page size"
+[ "$(echo "$R" | jq -r '.hits.total.value')" = 3 ] || fail "total on first page"
+R=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}")
+[ "$(echo "$R" | jq -r '.hits.hits | length')" = 1 ] || fail "second page: $R"
+[ "$(echo "$R" | jq -r '._scroll_id')" = "$SID" ] || fail "scroll id stable"
+[ "$(echo "$R" | jq -r '.hits.total.value')" = 3 ] || fail "total carried on later pages"
+R=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}")
+[ "$(echo "$R" | jq -r '.hits.hits | length')" = 0 ] || fail "exhausted page: $R"
+[ "$(curl -s "$U/_search/scroll?scroll=1m&scroll_id=$SID" | jq -r '.hits.hits | length')" = 0 ] || fail "GET form"
+[ "$(curl -s -XPOST "$U/_search/scroll/$SID?scroll=1m" | jq -r '._scroll_id')" = "$SID" ] || fail "path form"
+[ "$(curl -s -XDELETE "$U/_search/scroll" -H "$J" -d "{\"scroll_id\":[\"$SID\"]}" | jq -cS .)" = '{"num_freed":1,"succeeded":true}' ] || fail "clear scroll"
+R=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}")
+[ "$(echo "$R" | jq -r '.status')" = 404 ] || fail "cleared scroll is 404: $R"
+[ "$(echo "$R" | jq -r '.error.root_cause[0].type')" = search_context_missing_exception ] || fail "missing-context type"
+R=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d '{"scroll":"1m","scroll_id":"bogus"}')
+[ "$(echo "$R" | jq -r '.status')" = 400 ] && [ "$(echo "$R" | jq -r '.error.reason')" = "Cannot parse scroll id" ] || fail "bogus id: $R"
+[ "$(curl -s -XDELETE "$U/_search/scroll" -H "$J" -d '{"scroll_id":["bogus"]}' | jq -r .status)" = 400 ] || fail "clear bogus"
+[ "$(code -XPOST "$U/people/_search?scroll=1m" -H "$J" -d '{"size":2,"search_after":[1]}')" = 400 ] || fail "scroll + search_after"
+[ "$(code -XPOST "$U/people/_search?scroll=1m" -H "$J" -d '{"size":2,"from":1}')" = 400 ] || fail "scroll + from"
+[ "$(code -XPOST "$U/people/_search?scroll=1x" -H "$J" -d '{}')" = 400 ] || fail "bad keep-alive unit"
+[ "$(code -XPOST "$U/people/_search?scroll=2d" -H "$J" -d '{}')" = 400 ] || fail "keep-alive over the ceiling"
+R=$(curl -s -XPOST "$U/people/_search?scroll=1m" -H "$J" -d '{"size":1,"aggs":{"a":{"terms":{"field":"name"}}}}')
+[ "$(echo "$R" | jq -r '.aggregations.a.buckets | length')" = 3 ] || fail "aggs on first scroll page"
+SID=$(echo "$R" | jq -r '._scroll_id')
+[ "$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}" | jq -r '.aggregations')" = null ] || fail "no aggs on later pages"
+# a field-sorted scroll pages in that order
+R=$(curl -s -XPOST "$U/people/_search?scroll=1m" -H "$J" -d '{"size":1,"sort":[{"name":"asc"}],"_source":false}')
+SID=$(echo "$R" | jq -r '._scroll_id'); s1=$(echo "$R" | jq -r '.hits.hits[0]._id')
+s2=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}" | jq -r '.hits.hits[0]._id')
+s3=$(curl -s -XPOST "$U/_search/scroll" -H "$J" -d "{\"scroll\":\"1m\",\"scroll_id\":\"$SID\"}" | jq -r '.hits.hits[0]._id')
+[ "$s1,$s2,$s3" = "2,1,3" ] || fail "field-sorted scroll: $s1,$s2,$s3"
+[ "$(curl -s -XDELETE "$U/_search/scroll/_all" | jq -r .succeeded)" = true ] || fail "clear _all"
+[ "$(sql "SELECT count(*) FROM scroll_contexts")" = 0 ] || fail "contexts freed"
+
+say "#71 DELETE /{index}"
+[ "$(code -XDELETE "$U/nope")" = 404 ] || fail "delete missing is 404"
+[ "$(code -XDELETE "$U/_all")" = 400 ] || fail "_all refused"
+[ "$(code -XDELETE "$U/*")" = 400 ] || fail "bare * refused"
+[ "$(curl -s -XDELETE "$U/tmp_*")" = '{"acknowledged":true}' ] || fail "glob with no match is acknowledged"
+[ "$(curl -s -XDELETE "$U/people")" = '{"acknowledged":true}' ] || fail "delete people"
+[ "$(code -I "$U/people")" = 404 ] || fail "HEAD after delete"
+[ "$(code "$U/people/_count")" = 404 ] || fail "_count after delete"
+[ "$(curl -s "$U/_cat/indices" | jq -r '[.[].index] | index("people")')" = null ] || fail "gone from _cat/indices"
+say "  drop-and-rebuild under the same name"
+curl -s -XPUT "$U/people" -H "$J" -d '{"settings":{"index":{"mode":"document"}},"mappings":{"properties":{"name":{"type":"keyword"}}}}' | jq -e '.acknowledged' >/dev/null || fail "re-create"
+[ "$(curl -s "$U/people/_count" | jq -r .count)" = 0 ] || fail "re-created index is empty"
+curl -s -XPOST "$U/people/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"1"}}\n{"name":"dave"}\n' | jq -e '.errors == false' >/dev/null || fail "bulk into re-created index"
+[ "$(curl -s "$U/people/_count" | jq -r .count)" = 1 ] || fail "rebuilt index holds only the new doc"
+[ "$(curl -s "$U/people/_mapping" | jq -r '.people.mappings.properties | keys | join(",")')" = "@timestamp,name" ] || fail "old dynamic fields do not leak into the new index"
+say "  storage reclaimed and the retired row purged"
+for i in $(seq 1 30); do
+  [ "$(sql "SELECT count(*) FROM streams WHERE deleted_at IS NOT NULL")" = 0 ] && break; pause 1
+done
+[ "$(sql "SELECT count(*) FROM streams WHERE deleted_at IS NOT NULL")" = 0 ] || fail "retired stream not purged"
+[ "$(sql "SELECT count(*) FROM splits s JOIN streams st ON st.id = s.stream_id WHERE st.name = 'people'")" -ge 1 ] || fail "new stream keeps its split"
+say "  glob and list deletion"
+curl -s -XPUT "$U/tmp_a" >/dev/null; curl -s -XPUT "$U/tmp_b" >/dev/null; curl -s -XPUT "$U/keep" >/dev/null
+[ "$(curl -s -XDELETE "$U/tmp_*,nope_*")" = '{"acknowledged":true}' ] || fail "glob delete"
+# (deletes are audited into rsearch-audit, which appears alongside)
+[ "$(curl -s "$U/_cat/indices" | jq -r '[.[].index | select(. != "rsearch-audit")] | sort | join(",")')" = "keep,people" ] || fail "globbed indices gone: $(curl -s "$U/_cat/indices" | jq -c '[.[].index]')"
+say "  documents in flight at deletion land in the re-created index"
+curl -s -XPOST "$U/inflight/_bulk" -H "$ND" --data-binary $'{"index":{}}\n{"m":"buffered"}\n' | jq -e '.errors == false' >/dev/null || fail "bulk inflight"
+[ "$(curl -s -XDELETE "$U/inflight")" = '{"acknowledged":true}' ] || fail "delete inflight"
+for i in $(seq 1 20); do [ "$(curl -s "$U/inflight/_count" | jq -r '.count // 0')" = 1 ] && break; pause 1; done
+[ "$(curl -s "$U/inflight/_count" | jq -r .count)" = 1 ] || fail "late flush re-created the index with its document"
+say "  scoped keys delete only inside their streams"
+curl -s -XPUT "$U/_rsearch/users/admin" -H "$J" -d '{"password":"adminpassword123","role":"admin"}' | jq -e '.acknowledged' >/dev/null || fail "create admin"
+TOKEN=$(curl -s -XPOST "$U/_rsearch/login" -H "$J" -d '{"username":"admin","password":"adminpassword123"}' | jq -r '.token')
+KEY=$(curl -s -XPOST "$U/_rsearch/api_keys" -H "Authorization: Bearer $TOKEN" -H "$J" -d '{"name":"app","actions":["ingest","search"],"streams":["app-*"]}' | jq -r '.key')
+curl -s -XPUT "$U/app-x" -H "Authorization: Bearer $KEY" >/dev/null
+[ "$(code -XDELETE "$U/app-x" -H "Authorization: Bearer $KEY")" = 200 ] || fail "scoped key deletes its own index"
+[ "$(code -XDELETE "$U/keep" -H "Authorization: Bearer $KEY")" = 403 ] || fail "scoped key denied outside scope"
+curl -s -XPUT "$U/app-y" -H "Authorization: Bearer $KEY" >/dev/null
+[ "$(code -XDELETE "$U/app-*,keep" -H "Authorization: Bearer $KEY")" = 403 ] || fail "list escaping the scope is denied"
+[ "$(code -I "$U/app-y" -H "Authorization: Bearer $KEY")" = 200 ] || fail "denied list deleted nothing"
+[ "$(code "$U/_search/scroll?scroll_id=$(printf '%032d' 0)" -H "Authorization: Bearer $KEY")" = 404 ] || fail "scoped key can reach the scroll API"
+
+say "PASS: OpenSearch compatibility (#71 #72 #73 #74 #76 #77)"

--- a/tests/cluster/run-compat-test.sh
+++ b/tests/cluster/run-compat-test.sh
@@ -112,6 +112,17 @@ say "#77 sort"
 [ "$(order '{"sort":[{"age":{"order":"asc","missing":27}}]}')" = "2,3,1" ] || fail "missing value"
 [ "$(sortvals '{"sort":[{"age":{"order":"asc","missing":27}}]}')" = "[25,27,30]" ] || fail "missing value reported"
 [ "$(order '{"sort":[{"age":{"order":"asc","mode":"min"}}]}')" = "2,1,3" ] || fail "mode min accepted"
+[ "$(order '{"sort":[{"age":"DESC"}]}')" = "1,2,3" ] || fail "order is case-insensitive"
+[ "$(code -XPOST "$U/people/_search" -H "$J" -d '{"sort":[{"age":"desc","name":"asc"}]}')" = 400 ] || fail "multi-key sort object is refused (order cannot be honoured)"
+curl -s -XPOST "$U/people/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"m1"}}\n{"tags":[1,100]}\n{"index":{"_id":"m2"}}\n{"tags":[50,60]}\n' >/dev/null
+# (a field first seen by the split just published becomes sortable once
+# the node's 10s stream cache refreshes its dynamic-field inventory)
+for i in $(seq 1 15); do
+  got=$(curl -s -XPOST "$U/people/_search" -H "$J" -d '{"sort":[{"tags":{"order":"asc","mode":"max"}}],"query":{"exists":{"field":"tags"}}}' | jq -r '[.hits.hits[]?._id] | join(",")')
+  [ "$got" = "m2,m1" ] && break; pause 1
+done
+[ "$got" = "m2,m1" ] || fail "mode max on a multi-valued field: $got"
+curl -s -XPOST "$U/people/_delete_by_query" -H "$J" -d '{"query":{"ids":{"values":["m1","m2"]}}}' >/dev/null; curl -s -XPOST "$U/people/_search?size=0" >/dev/null; pause 1.5
 R=$(curl -s -XPOST "$U/people/_search" -H "$J" -d '{"size":1,"sort":[{"age":"asc"},{"name":"desc"}],"_source":false}')
 [ "$(echo "$R" | jq -r '.hits.hits[0]._id')" = 2 ] || fail "multi sort first"
 SA=$(echo "$R" | jq -c '.hits.hits[0].sort')
@@ -191,11 +202,21 @@ curl -s -XPUT "$U/tmp_a" >/dev/null; curl -s -XPUT "$U/tmp_b" >/dev/null; curl -
 [ "$(curl -s -XDELETE "$U/tmp_*,nope_*")" = '{"acknowledged":true}' ] || fail "glob delete"
 # (deletes are audited into rsearch-audit, which appears alongside)
 [ "$(curl -s "$U/_cat/indices" | jq -r '[.[].index | select(. != "rsearch-audit")] | sort | join(",")')" = "keep,people" ] || fail "globbed indices gone: $(curl -s "$U/_cat/indices" | jq -c '[.[].index]')"
-say "  documents in flight at deletion land in the re-created index"
+say "  documents in flight at deletion die with the index (as in OpenSearch)"
 curl -s -XPOST "$U/inflight/_bulk" -H "$ND" --data-binary $'{"index":{}}\n{"m":"buffered"}\n' | jq -e '.errors == false' >/dev/null || fail "bulk inflight"
 [ "$(curl -s -XDELETE "$U/inflight")" = '{"acknowledged":true}' ] || fail "delete inflight"
-for i in $(seq 1 20); do [ "$(curl -s "$U/inflight/_count" | jq -r '.count // 0')" = 1 ] && break; pause 1; done
-[ "$(curl -s "$U/inflight/_count" | jq -r .count)" = 1 ] || fail "late flush re-created the index with its document"
+pause 6
+[ "$(code -I "$U/inflight")" = 404 ] || fail "a late flush must not resurrect a deleted index"
+grep -q "index deleted; buffered documents dropped" "$LOGDIR/node.log" || fail "drop not logged"
+say "  delete + re-create while a document-mode batch is buffered keeps the new mode"
+curl -s -XPUT "$U/redo" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}' >/dev/null
+curl -s -XPOST "$U/redo/_bulk" -H "$ND" --data-binary $'{"index":{"_id":"old"}}\n{"v":"old"}\n' >/dev/null
+[ "$(curl -s -XDELETE "$U/redo")" = '{"acknowledged":true}' ] || fail "delete redo"
+curl -s -XPUT "$U/redo" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}' | jq -e '.acknowledged' >/dev/null || fail "re-create redo as document mode"
+curl -s -XPOST "$U/redo/_bulk?refresh=wait_for" -H "$ND" --data-binary $'{"index":{"_id":"new"}}\n{"v":"new"}\n' | jq -e '.errors == false' >/dev/null || fail "bulk into re-created redo"
+pause 3
+[ "$(curl -s "$U/redo/_settings" | jq -r '.redo.settings.index.mode')" = document ] || fail "re-created index keeps document mode"
+[ "$(curl -s "$U/redo/_search" -H "$J" -d '{"_source":false}' | jq -r '[.hits.hits[]._id] | sort | join(",")')" = "new" ] || fail "only the post-recreate document survives: $(curl -s "$U/redo/_search" -H "$J" -d '{"_source":false}' | jq -c '[.hits.hits[]._id]')"
 say "  scoped keys delete only inside their streams"
 curl -s -XPUT "$U/_rsearch/users/admin" -H "$J" -d '{"password":"adminpassword123","role":"admin"}' | jq -e '.acknowledged' >/dev/null || fail "create admin"
 TOKEN=$(curl -s -XPOST "$U/_rsearch/login" -H "$J" -d '{"username":"admin","password":"adminpassword123"}' | jq -r '.token')
@@ -207,5 +228,13 @@ curl -s -XPUT "$U/app-y" -H "Authorization: Bearer $KEY" >/dev/null
 [ "$(code -XDELETE "$U/app-*,keep" -H "Authorization: Bearer $KEY")" = 403 ] || fail "list escaping the scope is denied"
 [ "$(code -I "$U/app-y" -H "Authorization: Bearer $KEY")" = 200 ] || fail "denied list deleted nothing"
 [ "$(code "$U/_search/scroll?scroll_id=$(printf '%032d' 0)" -H "Authorization: Bearer $KEY")" = 404 ] || fail "scoped key can reach the scroll API"
+say "  scoped keys clear only their own scroll contexts"
+curl -s -XPUT "$U/app-s" -H "Authorization: Bearer $KEY" >/dev/null
+FOREIGN=$(curl -s -XPOST "$U/keep/_search?scroll=1m" -H "Authorization: Bearer $TOKEN" -H "$J" -d '{}' | jq -r '._scroll_id')
+MINE=$(curl -s -XPOST "$U/app-s/_search?scroll=1m" -H "Authorization: Bearer $KEY" -H "$J" -d '{}' | jq -r '._scroll_id')
+[ "$(code -XDELETE "$U/_search/scroll" -H "Authorization: Bearer $KEY" -H "$J" -d "{\"scroll_id\":\"$FOREIGN\"}")" = 403 ] || fail "scoped key cannot free another tenant's scroll"
+[ "$(curl -s -XDELETE "$U/_search/scroll/_all" -H "Authorization: Bearer $KEY" | jq -r .num_freed)" = 1 ] || fail "scoped _all frees only the key's own contexts"
+[ "$(sql "SELECT count(*) FROM scroll_contexts WHERE id = '$FOREIGN'")" = 1 ] || fail "foreign context survived a scoped _all"
+[ "$(code -XPOST "$U/_search/scroll" -H "Authorization: Bearer $TOKEN" -H "$J" -d "{\"scroll_id\":\"$MINE\"}")" = 404 ] || fail "own context was freed"
 
 say "PASS: OpenSearch compatibility (#71 #72 #73 #74 #76 #77)"


### PR DESCRIPTION
Closes #71, #72, #73, #74, #76, #77. Every response shape and error message below was checked against a real OpenSearch 3.6 (`tests/cluster/run-compat-test.sh` asserts them end to end).

## What changed

**#71 `DELETE /{index}`** — name, comma list, or globs; a named index that is missing is a 404, a glob matching nothing is acknowledged, `_all`/`*` are refused. Deletion is a metastore transaction (`retire_stream`): every split is marked for delete, tombstones dropped, the row renamed to `.deleted-{id}-{name}` and stamped `deleted_at`, so the name is free to re-create immediately (the drop-and-rebuild reindex). The GC job reclaims storage after its grace; a new `stream_purge_job` drops the retired row once no split references it (and marks any split a late flush attached to it). Ingest workers re-resolve the stream before every flush: a deleted-and-recreated stream rebinds the worker to the new id, a deleted one is re-created the way `_bulk` to a missing index always has. Scoped keys may delete only inside their stream scope, whatever the expression expands to.

**#72 scroll** — `?scroll=` on `_search` returns a `_scroll_id`; `POST/GET /_search/scroll[/{id}]` continues, `DELETE /_search/scroll[/{id}|/_all]` frees. Contexts live in a new `scroll_contexts` table (original body minus aggs + last cursor), so a scroll continues on any search node; the control leader sweeps expired rows. OpenSearch's validations (`from`, `search_after` refused; keep-alive units and the 1d ceiling), its 404 for a missing context, its 400 for an unparseable id, stable id across pages, first-page total carried, aggregations on the first page only.

**#73 `PUT /{index}/_mapping`** — adds fields to an existing index; an existing field must keep its (normalized) type (`mapper [age] cannot be changed from type [long] to [keyword]`), missing index is 404.

**#74 `_count`** — GET/POST with a `query` body or `?q=`; any other body key is `request does not support [size]`; exact count (never the 10k lower bound).

**#76 dynamic fields in `_mapping`** — every split now records the unmapped paths it holds and their value types (footer + new `splits.dynamic_fields` JSONB); `GET /{index}/_mapping` and `GET /{index}` union that across published splits and report OpenSearch's dynamic types (`text` + `keyword` sub-field, `long`, `float`, `boolean`, nested `properties`). A control job backfills splits written before the column existed (20 per tick). `dynamic_string_paths` (bare `query_string`) now reads the recorded inventory instead of scanning the term dictionary.

**#77 field sorting** — `sort` on mapped keyword/long/double/boolean/date/ip, `_seq`, dynamic `<path>.keyword`, dynamic numeric/boolean paths, multiple clauses. Text fields (mapped or dynamic string) get OpenSearch's fielddata 400; unknown fields get `No mapping found for [f] in order to sort on` unless `unmapped_type`. `missing: _first/_last/<value>` with OpenSearch's placement (last in both directions) and its reported sentinels; `mode: min|max`. New `FieldSortCollector`: per-segment top-k by term ordinals / raw numbers, cursor applied per document, survivors materialized for the merge. `search_after` accepts the field values alone (an OpenSearch client's cursor) or with the appended `[timestamp, _seq]` tiebreak; arity errors match (`search_after has 1 value(s) but sort has 2.`). The timestamp-only path is unchanged.

## Migrations (3)
`streams.deleted_at`, `splits.dynamic_fields`, `scroll_contexts`. Embedded; applied at node start. Deploy order does not matter for these (all additive), but search nodes should be upgraded before ingest so `_mapping` sees the inventory ingest starts recording.

## Version
Bumped to 0.6.0 (new endpoints + migrations).

## Verified
- `./scripts/ci.sh` (check with `-D warnings`, `cargo test --workspace`, cargo deny)
- `cargo test -p rsearch-metastore -- --include-ignored` against Postgres
- `tests/cluster/run-compat-test.sh` (new; all six issues, single fs-backed node)
- `tests/cluster/run-document-mode-test.sh` (no regression)

## Notes
- `PUT /{index}` on an existing index stays an update (rSearch extension); OpenSearch would 400.
- `_all`/`*` deletion is refused deliberately even though OpenSearch 3.6's default allows it.
- Sorting on `_id` is not supported (not a fast field); `_score`/`_doc` remain no-ops.

## Review follow-up (second commit)

Findings from the code review acted on:

- **Late-flush data loss / resurrection after DELETE.** Every flush attempt re-resolves the stream by name. A deleted index drops its buffered documents (WAL confirmed, logged), as OpenSearch does; a re-created index rebinds the worker to the new row's id, mode and mapping, and every buffered item now carries the stream id it was accepted against so only writes accepted against the new row are published. A publish that fails because the retirement raced it is no longer retried under the retired id.
- **Scroll clear is scoped.** A stream-scoped key frees only contexts on its own streams; `/_all` frees just those; a foreign id is a 403.
- **PUT _mapping is a compare-and-set** against the mapping it read, retried on a concurrent change, so parallel additions never drop fields. `PUT /{index}` with mappings now invalidates the search cache too.
- **Multi-key sort objects are refused** with 400 (their order cannot be honoured after JSON parsing) instead of silently keeping one key.
- **`mode: min|max` is applied** on multi-valued fields; **`order` is case-insensitive**.
- **Backfill leaves NULL on transient errors** and records `{}` only for a malformed split.
- **Wildcard delete and `_msearch` use `stream_glob_matches`** (end-anchored), the same semantics auth scoping uses; the weaker `glob_match` is gone.
- **Dynamic-field inventory is lazy and single-flight**: fetched only when a field sort names something the mapping does not settle, cached for the stream record's lifetime; `dynamic_fields` no longer rides along in every split row read; a partial index backs the backfill scan (fourth migration).
- Dead `sort_desc` binding removed.
