### PR TITLE
Add POST|GET /{index}/_refresh and /_refresh (#80)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.6.0" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.6.0" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.6.0" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.6.0" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.6.0" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.6.0" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.7.0" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.7.0" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.7.0" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.7.0" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.7.0" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.7.0" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ and IMDS are never touched.
 | Ingest | `POST /_bulk`, `POST /{index}/_bulk` (`index`, `create`; plus `update`, `delete` on document-mode indices; `?refresh=true\|wait_for`) |
 | Documents | `PUT/POST/GET/HEAD/DELETE /{index}/_doc/{id}`, `POST /{index}/_doc`, `PUT/POST /{index}/_create/{id}`, `POST /{index}/_update/{id}`, `GET /{index}/_source/{id}`, `POST /{index}/_delete_by_query` (document-mode indices) |
 | Search | `POST/GET /{index}/_search` (`?scroll=` opens a scroll), `POST/GET /_search/scroll[/{id}]`, `DELETE /_search/scroll[/{id}\|/_all]`, `GET/POST /{index}/_count` (`?q=` or a `query` body), `POST /_msearch` |
-| Index admin | `PUT /{index}` (settings + mapping), `PUT /{index}/_mapping` (add fields), `GET /{index}/_mapping` (declared + dynamic fields), `DELETE /{index}` (name, list, or glob; `_all` and `*` refused), `GET/HEAD /{index}`, `GET /{index}/_settings`, `GET /_cat/indices` |
+| Index admin | `PUT /{index}` (settings + mapping), `PUT /{index}/_mapping` (add fields), `GET /{index}/_mapping` (declared + dynamic fields), `DELETE /{index}` (name, list, or glob; `_all` and `*` refused), `GET/HEAD /{index}`, `GET /{index}/_settings`, `POST/GET /{index}/_refresh` and `/_refresh` (name, list, glob, or `_all`), `GET /_cat/indices` |
 | Cluster | `GET /`, `GET /_cluster/health`, `GET /_cat/nodes` |
 | Streams | `PUT /_rsearch/streams/{name}/retention`, routing rules under `/_rsearch/routing_rules` |
 | Alerts | `PUT/GET/DELETE /_rsearch/alerts[/{name}]` (scheduled query → webhook) |
@@ -363,7 +363,10 @@ On a document-mode index:
   `ingest.max_batch_secs`, default 30s). `?refresh=true` or
   `?refresh=wait_for` on `_bulk` or any document route cuts the split now
   and returns once it is published, so a save-then-search flow sees its
-  own write. Deletes are visible immediately on the node that took them
+  own write. `POST /{index}/_refresh` (the `indices.refresh` client
+  helper) does the same for an index's buffered writes on every ingest
+  node, for callers that did not make the write; on log indices it is
+  acknowledged without cutting a split. Deletes are visible immediately on the node that took them
   and within ~1s elsewhere. `update`/`create`/GET read published splits
   only, so a read-modify-write chain should set `refresh=wait_for` on
   each step.

--- a/crates/rsearch-server/src/auth.rs
+++ b/crates/rsearch-server/src/auth.rs
@@ -223,6 +223,11 @@ fn classify(method: &str, path: &str) -> Action {
         }
         // Mapping updates are index setup, the same level as PUT /{index}.
         ("PUT", [index, "_mapping"]) => Action::Ingest(Some(index.to_string())),
+        // _refresh (#80) cuts buffered writes: the write side's level, as
+        // `?refresh=` on _bulk is. The handler re-checks what a glob or
+        // list expands to against the identity's scope.
+        (_, ["_refresh"]) => Action::Ingest(None),
+        (_, [index, "_refresh"]) => Action::Ingest(Some(index.to_string())),
         ("POST", ["_msearch"]) => Action::Search(None),
         // Scroll continuation/clear (#72): the stream is in the stored
         // context, not the path — the handler checks it against the
@@ -501,6 +506,11 @@ mod tests {
             Action::Search(Some("app-logs".into()))
         );
         assert_eq!(classify("GET", "/_cat/indices"), Action::Search(None));
+        assert_eq!(classify("POST", "/_refresh"), Action::Ingest(None));
+        assert_eq!(
+            classify("GET", "/app-logs/_refresh"),
+            Action::Ingest(Some("app-logs".into()))
+        );
         // Loki-compatible surface: everything under /loki/api/v1 needs
         // global search access; /ready is health-equivalent and open.
         assert_eq!(classify("GET", "/loki/api/v1/query_range"), Action::Search(None));

--- a/crates/rsearch-server/src/bulk_api.rs
+++ b/crates/rsearch-server/src/bulk_api.rs
@@ -58,7 +58,7 @@ pub struct InternalBulkQuery {
 /// How long a refresh waits for the cut split to publish before the
 /// response goes out anyway (the documents are WAL-durable and will
 /// appear; a storage/metastore outage must not hang the client forever).
-const REFRESH_WAIT_LIMIT: std::time::Duration = std::time::Duration::from_secs(60);
+pub(crate) const REFRESH_WAIT_LIMIT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Receive a batch handed off by a peer (#19). Authenticated by the
 /// cluster token like the internal object API; always indexes locally —

--- a/crates/rsearch-server/src/main.rs
+++ b/crates/rsearch-server/src/main.rs
@@ -14,6 +14,7 @@ mod loki_api;
 mod metrics;
 mod placement;
 mod reconcile;
+mod refresh_api;
 mod routes;
 mod search_api;
 mod state;
@@ -318,6 +319,24 @@ async fn main() -> anyhow::Result<()> {
             config.node_id(),
             rsearch_common::crypto::token_digest(&config.cluster.internal_token),
             config.ingest.balance_bulk,
+        )));
+    }
+    // `_refresh` (#80) must reach every ingest node's buffer from
+    // whichever node took the request, so the fan-out client exists on
+    // every node with a cluster token; without one the node flushes only
+    // its own buffer (a single-node deployment).
+    if !config.cluster.internal_token.is_empty() {
+        state.refresh_peers = Some(std::sync::Arc::new(refresh_api::RefreshPeers::new(
+            state.metastore.clone(),
+            rsearch_storage::PeerClient::new(
+                &config.cluster.internal_token,
+                (!config.cluster.peer_ca_file.is_empty())
+                    .then_some(config.cluster.peer_ca_file.as_str()),
+            )
+            .map_err(|e| anyhow::anyhow!(e))
+            .context("building refresh peer client")?,
+            config.node_id(),
+            rsearch_common::crypto::token_digest(&config.cluster.internal_token),
         )));
     }
     if config.storage.backend == "replicated" {

--- a/crates/rsearch-server/src/refresh_api.rs
+++ b/crates/rsearch-server/src/refresh_api.rs
@@ -1,0 +1,352 @@
+//! `POST|GET /{index}/_refresh` and `/_refresh` (#80): cut the named
+//! document-mode streams' buffered batches on every ingest node and
+//! return once those splits are published, so a search issued after the
+//! response sees every write acknowledged before the call. It is the
+//! flush `?refresh=` performs on a write, reachable through a client's
+//! index-management API (`indices.refresh`) when the caller does not own
+//! the original write. Log streams are acknowledged without a cut, the
+//! same policy `?refresh=` applies: a shipper cannot force a split per
+//! request.
+//!
+//! Buffers are node-local, so the handling node flushes its own pipeline
+//! and asks every live ingest peer to do the same over the internal API
+//! (cluster-token auth), then answers OpenSearch's `_shards` summary with
+//! one shard per index.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+use rsearch_common::crypto;
+use rsearch_metastore::{Metastore, StreamRecord};
+use rsearch_storage::{INTERNAL_TOKEN_HEADER, PeerClient};
+use tracing::warn;
+
+use crate::bulk_api::REFRESH_WAIT_LIMIT;
+use crate::search_api::{es_error, index_not_found};
+use crate::state::AppState;
+
+/// A peer is asked to flush only if it heartbeated this recently; an
+/// older entry is a node that is gone, and waiting on it would only
+/// delay the response.
+const PEER_STALE_SECS: f64 = 30.0;
+
+/// Ingest peers a refresh fans out to. Present on every node with a
+/// cluster token, whatever its roles: a search-only node must still be
+/// able to reach the buffers, which live on the ingest nodes.
+pub struct RefreshPeers {
+    metastore: Metastore,
+    client: PeerClient,
+    node_id: String,
+    /// Digest of the cluster token; inbound flush requests are checked
+    /// against it (digest-to-digest, as the bulk handoff receiver does).
+    pub token_digest: String,
+}
+
+impl RefreshPeers {
+    pub fn new(
+        metastore: Metastore,
+        client: PeerClient,
+        node_id: String,
+        token_digest: String,
+    ) -> Self {
+        Self {
+            metastore,
+            client,
+            node_id,
+            token_digest,
+        }
+    }
+
+    /// Live ingest nodes other than this one, with an advertised address.
+    /// Draining nodes are included: their buffers still hold documents.
+    async fn ingest_peers(&self) -> Vec<(String, String)> {
+        match self.metastore.list_nodes().await {
+            Ok(nodes) => nodes
+                .into_iter()
+                .filter(|n| {
+                    n.id != self.node_id
+                        && n.heartbeat_age_secs < PEER_STALE_SECS
+                        && n.roles.iter().any(|r| r == "ingest")
+                })
+                .filter_map(|n| n.address.map(|addr| (n.id, addr)))
+                .collect(),
+            Err(e) => {
+                warn!(error = %e, "refresh: listing ingest nodes failed");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Ask one peer to flush `streams`; returns the names it could not
+    /// flush (every name when the peer is unreachable or refuses).
+    async fn flush_on(&self, id: &str, addr: &str, streams: &[String]) -> Vec<String> {
+        let all = || streams.to_vec();
+        let mut url = match url::Url::parse(addr) {
+            Ok(url) => url,
+            Err(e) => {
+                warn!(peer = id, addr, error = %e, "refresh: bad peer address");
+                return all();
+            }
+        };
+        url.set_path("/_rsearch/internal/refresh");
+        let body = json!({"streams": streams}).to_string();
+        match self.client.post_raw(url.as_str(), body.into()).await {
+            Ok((200, bytes)) => serde_json::from_slice::<InternalRefreshReply>(&bytes)
+                .map(|r| r.failed)
+                .unwrap_or_else(|_| all()),
+            Ok((status, _)) => {
+                warn!(peer = id, status, "refresh: peer refused flush");
+                all()
+            }
+            Err(e) => {
+                warn!(peer = id, error = %e, "refresh: peer flush failed");
+                all()
+            }
+        }
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct InternalRefreshReply {
+    failed: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct InternalRefreshBody {
+    streams: Vec<String>,
+}
+
+/// `POST /_rsearch/internal/refresh` — flush the named streams' buffers
+/// on this node. Cluster-token authenticated; registered on ingest nodes
+/// only, since only they hold buffers.
+pub async fn refresh_internal(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> Response {
+    let Some(peers) = state.refresh_peers.as_ref() else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let presented = headers
+        .get(INTERNAL_TOKEN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if presented.is_empty() || crypto::token_digest(presented) != peers.token_digest {
+        return (StatusCode::UNAUTHORIZED, "invalid cluster token").into_response();
+    }
+    // Parsed by hand: the peer client sends no content-type, which the
+    // `Json` extractor would reject with 415.
+    let body: InternalRefreshBody = match serde_json::from_slice(&body) {
+        Ok(body) => body,
+        Err(e) => return (StatusCode::BAD_REQUEST, e.to_string()).into_response(),
+    };
+    let failed = match state.pipeline.as_ref() {
+        Some(pipeline) => flush_local(pipeline, &body.streams).await,
+        // Not an ingest node: nothing is buffered here.
+        None => Vec::new(),
+    };
+    Json(InternalRefreshReply { failed }).into_response()
+}
+
+/// `POST|GET /_refresh`.
+pub async fn refresh_all(
+    State(state): State<AppState>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+) -> Response {
+    refresh(state, "_all", identity).await
+}
+
+/// `POST|GET /{index}/_refresh`.
+pub async fn refresh_index(
+    State(state): State<AppState>,
+    Path(index): Path<String>,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+) -> Response {
+    refresh(state, &index, identity).await
+}
+
+async fn refresh(
+    state: AppState,
+    expression: &str,
+    identity: Option<axum::Extension<crate::auth::Identity>>,
+) -> Response {
+    let streams = match state.metastore.list_streams().await {
+        Ok(streams) => streams,
+        Err(e) => {
+            return es_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                &e.to_string(),
+            );
+        }
+    };
+    let targets = match resolve_targets(&streams, expression) {
+        Ok(targets) => targets,
+        Err(missing) => return index_not_found(&missing),
+    };
+    // A glob or list must stay inside the caller's stream scope: the
+    // middleware matched the raw expression, not what it expands to.
+    if let Some(axum::Extension(identity)) = &identity
+        && !identity.is_admin
+        && let Some(outside) = targets.iter().find(|t| !identity.allows_stream(&t.name))
+    {
+        return es_error(
+            StatusCode::FORBIDDEN,
+            "security_exception",
+            &format!(
+                "identity '{}' is not permitted to refresh index [{}]",
+                identity.name, outside.name
+            ),
+        );
+    }
+    let to_flush: Vec<String> = targets
+        .iter()
+        .filter(|s| s.is_document_mode())
+        .map(|s| s.name.clone())
+        .collect();
+    let failed = if to_flush.is_empty() {
+        0
+    } else {
+        match tokio::time::timeout(REFRESH_WAIT_LIMIT, flush_everywhere(&state, &to_flush)).await {
+            Ok(failed) => failed.len(),
+            Err(_) => {
+                warn!(
+                    streams = ?to_flush,
+                    "refresh wait exceeded {}s; reporting the indices as failed",
+                    REFRESH_WAIT_LIMIT.as_secs()
+                );
+                to_flush.len()
+            }
+        }
+    };
+    let total = targets.len();
+    Json(json!({
+        "_shards": {"total": total, "successful": total - failed, "failed": failed}
+    }))
+    .into_response()
+}
+
+/// Expand an index expression (name, comma list, globs, `_all`/`*`/empty
+/// for everything) against the live streams. A named index that does not
+/// exist is the error (OpenSearch's 404); a glob matching nothing is fine.
+fn resolve_targets<'a>(
+    streams: &'a [StreamRecord],
+    expression: &str,
+) -> Result<Vec<&'a StreamRecord>, String> {
+    let expression = expression.trim();
+    let mut targets: Vec<&StreamRecord> = Vec::new();
+    if expression.is_empty() || expression == "_all" || expression == "*" {
+        targets.extend(streams.iter());
+    } else {
+        for part in expression
+            .split(',')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        {
+            if part.contains('*') {
+                targets.extend(
+                    streams
+                        .iter()
+                        .filter(|s| crate::auth::stream_glob_matches(part, &s.name)),
+                );
+            } else if let Some(stream) = streams.iter().find(|s| s.name == part) {
+                targets.push(stream);
+            } else {
+                return Err(part.to_string());
+            }
+        }
+    }
+    targets.sort_by(|a, b| a.name.cmp(&b.name));
+    targets.dedup_by(|a, b| a.name == b.name);
+    Ok(targets)
+}
+
+/// Flush `streams` on this node and on every live ingest peer, in
+/// parallel; returns the names that failed anywhere.
+async fn flush_everywhere(state: &AppState, streams: &[String]) -> HashSet<String> {
+    let local = async {
+        match state.pipeline.as_ref() {
+            Some(pipeline) => flush_local(pipeline, streams).await,
+            None => Vec::new(),
+        }
+    };
+    let remote = async {
+        let Some(peers) = state.refresh_peers.as_ref() else {
+            return Vec::new();
+        };
+        let targets = peers.ingest_peers().await;
+        let peers: Arc<RefreshPeers> = peers.clone();
+        let calls = targets
+            .iter()
+            .map(|(id, addr)| peers.flush_on(id, addr, streams));
+        futures::future::join_all(calls)
+            .await
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>()
+    };
+    let (local, remote) = tokio::join!(local, remote);
+    local.into_iter().chain(remote).collect()
+}
+
+/// Flush each stream's buffer on this node; returns the names whose
+/// flush errored (an unbuffered stream is a successful no-op).
+async fn flush_local(pipeline: &rsearch_ingest::IngestPipeline, streams: &[String]) -> Vec<String> {
+    let mut failed = Vec::new();
+    for stream in streams {
+        if let Err(e) = pipeline.flush_stream(stream).await {
+            warn!(stream, error = %e, "refresh flush failed");
+            failed.push(stream.clone());
+        }
+    }
+    failed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(name: &str) -> StreamRecord {
+        StreamRecord {
+            id: 0,
+            name: name.to_string(),
+            mapping: json!({}),
+            retention_hours: None,
+            mode: "document".to_string(),
+        }
+    }
+
+    fn names(targets: Vec<&StreamRecord>) -> Vec<&str> {
+        targets.into_iter().map(|s| s.name.as_str()).collect()
+    }
+
+    #[test]
+    fn resolves_index_expressions() {
+        let streams = vec![stream("app-a"), stream("app-b"), stream("keep")];
+        assert_eq!(names(resolve_targets(&streams, "keep").unwrap()), ["keep"]);
+        assert_eq!(
+            names(resolve_targets(&streams, "app-*").unwrap()),
+            ["app-a", "app-b"]
+        );
+        assert_eq!(
+            names(resolve_targets(&streams, "keep,app-a,keep").unwrap()),
+            ["app-a", "keep"]
+        );
+        for all in ["_all", "*", "", " "] {
+            assert_eq!(
+                names(resolve_targets(&streams, all).unwrap()),
+                ["app-a", "app-b", "keep"],
+                "{all:?}"
+            );
+        }
+        assert!(resolve_targets(&streams, "nomatch-*").unwrap().is_empty());
+        assert_eq!(resolve_targets(&streams, "nope").unwrap_err(), "nope");
+        assert_eq!(resolve_targets(&streams, "keep,nope").unwrap_err(), "nope");
+    }
+}

--- a/crates/rsearch-server/src/routes.rs
+++ b/crates/rsearch-server/src/routes.rs
@@ -113,6 +113,15 @@ pub fn router(state: AppState) -> Router {
             "/{index}/_count",
             get(search_api::count).post(search_api::count),
         )
+        // _refresh (#80): make buffered writes searchable now.
+        .route(
+            "/_refresh",
+            post(crate::refresh_api::refresh_all).get(crate::refresh_api::refresh_all),
+        )
+        .route(
+            "/{index}/_refresh",
+            post(crate::refresh_api::refresh_index).get(crate::refresh_api::refresh_index),
+        )
         .route("/{index}/_settings", get(search_api::get_settings))
         .route(
             "/{index}",
@@ -190,6 +199,16 @@ pub fn router(state: AppState) -> Router {
         router.route(
             "/_rsearch/internal/bulk",
             post(bulk_api::bulk_internal).layer(DefaultBodyLimit::max(BULK_BODY_LIMIT)),
+        )
+    } else {
+        router
+    };
+    // And the refresh fan-out receiver (#80): only ingest nodes hold
+    // buffers, so only they answer.
+    let router = if state.refresh_peers.is_some() && state.pipeline.is_some() {
+        router.route(
+            "/_rsearch/internal/refresh",
+            post(crate::refresh_api::refresh_internal),
         )
     } else {
         router

--- a/crates/rsearch-server/src/search_api.rs
+++ b/crates/rsearch-server/src/search_api.rs
@@ -1140,7 +1140,7 @@ fn map_search_error(err: SearchError) -> Response {
     }
 }
 
-fn es_error(status: StatusCode, error_type: &str, reason: &str) -> Response {
+pub(crate) fn es_error(status: StatusCode, error_type: &str, reason: &str) -> Response {
     (
         status,
         Json(json!({

--- a/crates/rsearch-server/src/state.rs
+++ b/crates/rsearch-server/src/state.rs
@@ -31,6 +31,9 @@ pub struct AppState {
     /// with a cluster token; whether this node *initiates* handoffs is
     /// its `ingest.balance_bulk` setting.
     pub bulk_forward: Option<Arc<crate::bulk_forward::BulkForwarder>>,
+    /// `_refresh` fan-out to ingest peers (#80). Present on every node
+    /// with a cluster token.
+    pub refresh_peers: Option<Arc<crate::refresh_api::RefreshPeers>>,
     /// Set when the operator drains this node (learned via heartbeat):
     /// bulk ingest is refused so the WAL empties out ahead of shutdown.
     pub draining: Arc<std::sync::atomic::AtomicBool>,
@@ -76,6 +79,7 @@ impl AppState {
             cors_allow_origin: config.http.cors_allow_origin.clone(),
             internal: None,
             bulk_forward: None,
+            refresh_peers: None,
             draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             control: None,
             reconcile: None,

--- a/tests/cluster/run-compat-test.sh
+++ b/tests/cluster/run-compat-test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# OpenSearch-compatibility end-to-end test for issues #71–#77: index
-# deletion, scroll, PUT _mapping, _count, dynamic fields in _mapping and
-# field sorting. One all-roles node on the fs backend + Postgres. Every
+# OpenSearch-compatibility end-to-end test for issues #71–#77 and #80:
+# index deletion, scroll, PUT _mapping, _count, dynamic fields in
+# _mapping, field sorting and _refresh. One all-roles node on the fs backend + Postgres. Every
 # expected shape below was taken from a real OpenSearch 3.6.
 set -euo pipefail
 cd "$(dirname "$0")/../.."
@@ -237,4 +237,28 @@ MINE=$(curl -s -XPOST "$U/app-s/_search?scroll=1m" -H "Authorization: Bearer $KE
 [ "$(sql "SELECT count(*) FROM scroll_contexts WHERE id = '$FOREIGN'")" = 1 ] || fail "foreign context survived a scoped _all"
 [ "$(code -XPOST "$U/_search/scroll" -H "Authorization: Bearer $TOKEN" -H "$J" -d "{\"scroll_id\":\"$MINE\"}")" = 404 ] || fail "own context was freed"
 
-say "PASS: OpenSearch compatibility (#71 #72 #73 #74 #76 #77)"
+say "#80 _refresh"
+A="Authorization: Bearer $TOKEN"
+curl -s -XPUT "$U/rf" -H "$A" -H "$J" -d '{"settings":{"index":{"mode":"document"}}}' | jq -e '.acknowledged' >/dev/null || fail "create rf"
+curl -s -XPOST "$U/rf/_bulk" -H "$A" -H "$ND" --data-binary $'{"index":{"_id":"1"}}\n{"v":1}\n{"index":{"_id":"2"}}\n{"v":2}\n' | jq -e '.errors == false' >/dev/null || fail "bulk rf"
+[ "$(curl -s -XPOST "$U/rf/_refresh" -H "$A" | jq -cS .)" = '{"_shards":{"failed":0,"successful":1,"total":1}}' ] || fail "POST _refresh: $(curl -s -XPOST "$U/rf/_refresh" -H "$A")"
+[ "$(curl -s "$U/rf/_count" -H "$A" | jq -r .count)" = 2 ] || fail "writes visible right after _refresh"
+[ "$(curl -s "$U/rf/_refresh" -H "$A" | jq -cS .)" = '{"_shards":{"failed":0,"successful":1,"total":1}}' ] || fail "GET _refresh"
+[ "$(curl -s -XPOST "$U/rf,people/_refresh" -H "$A" | jq -r '._shards.total')" = 2 ] || fail "list _refresh counts one shard per index"
+[ "$(curl -s -XPOST "$U/re*/_refresh" -H "$A" | jq -r '._shards.total')" = 1 ] || fail "glob _refresh matches redo only"
+[ "$(curl -s -XPOST "$U/nomatch-*/_refresh" -H "$A" | jq -cS .)" = '{"_shards":{"failed":0,"successful":0,"total":0}}' ] || fail "glob matching nothing is acknowledged"
+R=$(curl -s -XPOST "$U/nope/_refresh" -H "$A")
+[ "$(echo "$R" | jq -r .status)" = 404 ] || fail "missing index is 404: $R"
+[ "$(echo "$R" | jq -r '.error.root_cause[0].reason')" = "no such index [nope]" ] || fail "missing index reason: $R"
+[ "$(code -XPOST "$U/rf,nope/_refresh" -H "$A")" = 404 ] || fail "list with a missing index is 404"
+ALL=$(curl -s "$U/_cat/indices?format=json" -H "$A" | jq 'length')
+[ "$(curl -s -XPOST "$U/_refresh" -H "$A" | jq -r '._shards.total')" = "$ALL" ] || fail "/_refresh covers every index"
+[ "$(curl -s -XPOST "$U/_all/_refresh" -H "$A" | jq -r '._shards.total')" = "$ALL" ] || fail "_all/_refresh covers every index"
+[ "$(code -XPUT "$U/rf/_refresh" -H "$A")" = 405 ] || fail "PUT _refresh is 405"
+say "  scoped keys refresh only inside their streams"
+[ "$(code -XPOST "$U/app-y/_refresh" -H "Authorization: Bearer $KEY")" = 200 ] || fail "scoped key refreshes its own index"
+[ "$(code -XPOST "$U/keep/_refresh" -H "Authorization: Bearer $KEY")" = 403 ] || fail "scoped key denied outside scope"
+[ "$(code -XPOST "$U/app-*,keep/_refresh" -H "Authorization: Bearer $KEY")" = 403 ] || fail "list escaping the scope is denied"
+[ "$(code -XPOST "$U/_refresh" -H "Authorization: Bearer $KEY")" = 403 ] || fail "scoped key cannot refresh everything"
+
+say "PASS: OpenSearch compatibility (#71 #72 #73 #74 #76 #77 #80)"

--- a/tests/cluster/run-replicated-test.sh
+++ b/tests/cluster/run-replicated-test.sh
@@ -118,6 +118,23 @@ UNDER=$(under_held rlogs 2 "'node-1','node-2','node-3'")
 [ "$UNDER" = "0" ] || fail "$UNDER published splits below replication factor"
 say "PASS: placement at factor 2"
 
+# ---------- _refresh fans out to every ingest node's buffer (#80) ----------
+say "TEST: _refresh on one node cuts document buffers held on the others"
+curl -s -XPUT "http://127.0.0.1:9311/rdocs" -H 'Content-Type: application/json' \
+  -d '{"settings":{"index":{"mode":"document"}}}' | jq -e '.acknowledged' >/dev/null || fail "create rdocs"
+# Document buffers cut on their own only after document_max_batch_secs
+# (default 5s); the write goes to node-1 and node-2, the refresh to node-3.
+for port in 9311 9312; do
+  printf '{"index":{"_id":"d%s"}}\n{"v":%s}\n' "$port" "$port" \
+    | curl -s -XPOST "http://127.0.0.1:$port/rdocs/_bulk" -H 'Content-Type: application/x-ndjson' --data-binary @- \
+    | jq -e '.errors == false' >/dev/null || fail "bulk rdocs to :$port"
+done
+R=$(curl -s -XPOST "http://127.0.0.1:9313/rdocs/_refresh")
+[ "$(echo "$R" | jq -cS .)" = '{"_shards":{"failed":0,"successful":1,"total":1}}' ] || fail "_refresh via node-3: $R"
+C=$(count_docs 9313 rdocs)
+[ "$C" = "2" ] || fail "node-3 sees $C/2 rdocs right after _refresh"
+say "PASS: _refresh reached both ingest buffers"
+
 # ---------- holder death ----------
 say "TEST: killing node-1; survivors keep answering"
 kill -9 "${PIDS[node-1]}"; unset 'PIDS[node-1]'


### PR DESCRIPTION
Closes #80

`POST|GET /{index}/_refresh` and `/_refresh` cut the named document-mode streams' buffered batches on every ingest node and return once those splits are published. Response shapes and error text were checked against a real OpenSearch 3.6.

## Behaviour

- Index expression: a name, comma list, globs, `_all`/`*`/empty for everything. A named index that does not exist is `index_not_found_exception` (404), also inside a list; a glob matching nothing is `{"_shards":{"total":0,...}}` with 200. PUT/DELETE on the path are 405.
- Response: `{"_shards":{"total":N,"successful":N,"failed":F}}`, one shard per index. An index whose flush errored on any node counts as failed (still 200, as OpenSearch reports shard failures).
- Log streams are acknowledged without a cut, the same policy `?refresh=` already applies so a shipper cannot force a split per request.
- Auth: ingest-level, like `?refresh=` on `_bulk`. The handler re-checks every stream a glob or list expands to against the identity's scope (403 outside it), the way `DELETE /{index}` does. `/_refresh` needs global ingest.

## Cluster fan-out

Buffers are node-local. The handling node flushes its own pipeline and, in parallel, asks every live ingest peer (heartbeat < 30s, draining ones included since their buffers still hold documents) to flush over a new `POST /_rsearch/internal/refresh`, cluster-token authenticated like the bulk handoff receiver. The fan-out client is built on every node with a cluster token regardless of role, so a search-only node can serve `_refresh`. Bounded by the same 60s limit `?refresh=` uses. No migrations, no config.

## Verified

- `./scripts/ci.sh`
- `tests/cluster/run-compat-test.sh`: new `#80 _refresh` section (POST/GET, list, glob, no-match glob, missing index, `_all` and `/_refresh`, 405, scoped-key checks, count visible right after the call)
- `tests/cluster/run-replicated-test.sh`: new section writes to node-1 and node-2 without refresh and calls `_refresh` on node-3, which must see both documents at once. This caught a 415 from the internal endpoint on the first run (axum's `Json` extractor vs. the peer client's bare POST); the body is now parsed by hand.
