### PR TITLE
Make the dynamic-fields backfill rate configurable and scan in parallel (#82)

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,8 +252,10 @@ way OpenSearch's dynamic mapping would have typed it: strings as `text`
 with the `keyword` sub-field, integers `long`, fractions `float`,
 booleans `boolean`, nested objects as nested `properties`. Each split
 records its unmapped fields when it is built; splits from before this
-existed are inventoried once by the control leader (a bounded number per
-tick) and report nothing until then. `PUT /{index}/_mapping` adds fields
+existed are inventoried once by the control leader
+(`control.dynamic_fields_backfill_splits_per_tick`, default 20, newest
+first, scanned a few at a time in parallel, 0 disables) and report
+nothing until then. `PUT /{index}/_mapping` adds fields
 to an existing index; a field that already exists must keep its type
 (400, as in OpenSearch), and `PUT /{index}` on an existing index is still
 accepted as an update rather than a 400.

--- a/crates/rsearch-common/src/config.rs
+++ b/crates/rsearch-common/src/config.rs
@@ -189,6 +189,14 @@ pub struct ControlConfig {
     /// first), so an upgraded cluster converges on one analyzer and every
     /// split gains the `.keyword` view. 0 disables the pass.
     pub schema_upgrade_splits_per_tick: i64,
+    /// Max published splits registered before the unmapped-field
+    /// inventory was tracked (v0.6) whose inventory is recorded per
+    /// control tick (newest data first). Each costs one split open plus a
+    /// term-dictionary skip-scan — a remote fetch on an object-store
+    /// backend — done a few at a time in parallel. Until a split is
+    /// reached, `_mapping` omits the dynamic fields only it holds. 0
+    /// disables the pass.
+    pub dynamic_fields_backfill_splits_per_tick: i64,
     /// Tombstones are purged from the metastore only once no split can
     /// still hold a version they hide *and* they are at least this old —
     /// the age covers documents still buffered on an ingest node whose
@@ -213,6 +221,7 @@ impl Default for ControlConfig {
             compact_max_age_secs: 3_600.0,
             compact_splits_per_tick: 8,
             schema_upgrade_splits_per_tick: 2,
+            dynamic_fields_backfill_splits_per_tick: 20,
             tombstone_purge_grace_secs: 3_600.0,
         }
     }

--- a/crates/rsearch-server/src/control.rs
+++ b/crates/rsearch-server/src/control.rs
@@ -21,6 +21,10 @@ const REPAIR_DRAIN_CONCURRENCY: usize = 8;
 /// Ceiling on drain batches processed per node per tick — bounds how long
 /// one tick can run while still draining far faster than one batch/tick.
 const DRAIN_BATCHES_PER_TICK: usize = 10;
+/// Dynamic-field backfill scans in flight at once (#82): each opens a
+/// split, a remote fetch on an object-store backend, so a serial batch
+/// was bound by round trips rather than CPU.
+const BACKFILL_SCAN_CONCURRENCY: usize = 4;
 /// How often the full under-replication scan must run even with no
 /// membership change — catches writes that never reached the factor.
 const REPAIR_FULL_SCAN_SECS: u64 = 300;
@@ -1089,25 +1093,40 @@ impl ControlPlane {
 
     /// Record the unmapped-field inventory of splits registered before
     /// it was tracked (#76): each is opened once and its `_dynamic` term
-    /// dictionary skip-scanned, newest data first, a bounded number per
-    /// tick. Until a split is reached, `_mapping` omits the dynamic
-    /// fields only it holds.
+    /// dictionary skip-scanned, newest data first,
+    /// `control.dynamic_fields_backfill_splits_per_tick` per tick (#82).
+    /// The scans are remote fetches on an object-store backend, so a
+    /// batch runs `BACKFILL_SCAN_CONCURRENCY` of them at a time. Until a
+    /// split is reached, `_mapping` omits the dynamic fields only it
+    /// holds.
     async fn dynamic_fields_backfill_job(&self) -> anyhow::Result<()> {
-        const PER_TICK: i64 = 20;
-        let candidates = self.metastore.splits_without_dynamic_fields(PER_TICK).await?;
-        for split in candidates {
-            let scan = async {
-                let reader = SplitReader::open(
-                    self.storage.clone(),
-                    &split.storage_key,
-                    self.cache.clone(),
-                )
-                .await?;
-                tokio::task::spawn_blocking(move || reader.dynamic_field_types())
-                    .await
-                    .map_err(|e| rsearch_index::IndexError::InvalidDocument(e.to_string()))?
-            };
-            let inventory = match scan.await {
+        use futures::stream::{self, StreamExt};
+        let budget = self.config.dynamic_fields_backfill_splits_per_tick;
+        if budget <= 0 {
+            return Ok(());
+        }
+        let candidates = self.metastore.splits_without_dynamic_fields(budget).await?;
+        let scans = stream::iter(candidates)
+            .map(|split| async move {
+                let scanned = async {
+                    let reader = SplitReader::open(
+                        self.storage.clone(),
+                        &split.storage_key,
+                        self.cache.clone(),
+                    )
+                    .await?;
+                    tokio::task::spawn_blocking(move || reader.dynamic_field_types())
+                        .await
+                        .map_err(|e| rsearch_index::IndexError::InvalidDocument(e.to_string()))?
+                }
+                .await;
+                (split, scanned)
+            })
+            .buffer_unordered(BACKFILL_SCAN_CONCURRENCY)
+            .collect::<Vec<_>>()
+            .await;
+        for (split, scanned) in scans {
+            let inventory = match scanned {
                 Ok(fields) => serde_json::to_value(fields)?,
                 // A malformed split will never scan: record an empty
                 // inventory so it does not pin the budget every tick (a


### PR DESCRIPTION
Closes #82

## What changed

- New `control.dynamic_fields_backfill_splits_per_tick` (default 20, 0 disables the pass), mirroring `control.schema_upgrade_splits_per_tick`. Env override: `RSEARCH_CONTROL__DYNAMIC_FIELDS_BACKFILL_SPLITS_PER_TICK`.
- The batch's scans now run four at a time (`BACKFILL_SCAN_CONCURRENCY`) instead of serially. Each scan is a split open plus a term-dictionary skip-scan, a remote fetch on S3/COS, so the serial batch was round-trip bound. Per-split recording and the malformed-vs-transient error handling are unchanged.
- README documents the knob next to the dynamic-field mapping description.

Not changed: the job still runs once per control cycle after merge and compaction. Giving it its own timer is the next step if a larger batch with parallel scans is still too slow on a big archive.

## Verified

- `./scripts/ci.sh`
- `tests/cluster/run-compat-test.sh` (no regression)
- Manually against the test database: nulled `dynamic_fields` on six published splits, ran a control-only node at `0` per tick for 8s (all six stayed NULL, no scans logged), then at `2` per tick with a 1s interval (four recorded by 2s, all six by 4s, six "dynamic fields recorded" lines, no scan failures).

No migrations. Rides in the unpublished 0.7.0.
