### PR TITLE
Bump to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,7 +2334,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-bench"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2348,7 +2348,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-common"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "aws-lc-rs",
  "config",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-index"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "bytes",
  "memmap2",
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-ingest"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "crc32fast",
  "rsearch-common",
@@ -2402,7 +2402,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-metastore"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "rsearch-common",
  "serde",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-search"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "futures",
  "lru 0.18.2",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-server"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "rsearch-storage"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "async-trait",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.1"
 edition = "2024"
 license = "GPL-3.0-or-later"
 rust-version = "1.97"
@@ -23,12 +23,12 @@ keywords = ["search", "logging", "opensearch", "loki", "fips"]
 categories = ["database-implementations", "text-processing"]
 
 [workspace.dependencies]
-rsearch-common = { path = "crates/rsearch-common", version = "0.7.0" }
-rsearch-storage = { path = "crates/rsearch-storage", version = "0.7.0" }
-rsearch-index = { path = "crates/rsearch-index", version = "0.7.0" }
-rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.7.0" }
-rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.7.0" }
-rsearch-search = { path = "crates/rsearch-search", version = "0.7.0" }
+rsearch-common = { path = "crates/rsearch-common", version = "0.8.1" }
+rsearch-storage = { path = "crates/rsearch-storage", version = "0.8.1" }
+rsearch-index = { path = "crates/rsearch-index", version = "0.8.1" }
+rsearch-metastore = { path = "crates/rsearch-metastore", version = "0.8.1" }
+rsearch-ingest = { path = "crates/rsearch-ingest", version = "0.8.1" }
+rsearch-search = { path = "crates/rsearch-search", version = "0.8.1" }
 
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
Version bump only: workspace package version and the six internal rsearch-* dependency versions, Cargo.lock refreshed. No code changes.